### PR TITLE
Compress large timeout logs using zstd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project should be documented in this file.
 - A `bump_version.py` script to automate version update, by @smiyashaji.
 - A `--timeout` CLI option for configurable script running timeouts, by @ShrayJP.
 
+### Enhanced
+
+- Timeout log files will be compressed with zstd if larger than 1MB, by @devdanzin.
 
 ## [0.0.1] - 2024-11-20
 


### PR DESCRIPTION
Add compression of large (>1MB) log files using zstd from the stdlib. While this restricts us to running lafleur with Python 3.14 or newer, our current fuzzing only happens in main tip, so I don't expect a negative impact.

Fixes #10.