### PR TITLE
Re-enable GuardInjector and make it reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project should be documented in this file.
 ### Enhanced
 
 - Timeout log files will be compressed with zstd if larger than 1MB, by @devdanzin.
+- Mutations (`GuardInjector`) will add non-determinism again in a reproducible way, by @devdanzin.
 
 ## [0.0.1] - 2024-11-20
 


### PR DESCRIPTION
This PR re-enables the `GuardInjector` mutation, which adds non-deterministic `if` guards that compare `random()` from our seeded RNG to `0.1`. Seeding the RNG makes the non-deterministic behavior reproducible.

Fixes #12.