### PR TITLE
Add a coverage hash to handle non-deterministic duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project should be documented in this file.
 
 - A `bump_version.py` script to automate version update, by @smiyashaji.
 - A `--timeout` CLI option for configurable script running timeouts, by @ShrayJP.
+- A coverage hash to handle duplicated files with non-deterministic results, by @devdanzin.
 
 ### Enhanced
 


### PR DESCRIPTION
With non-deterministic code in our test cases, execution will result in different edges and uops. This PR adds a "coverage hash" (consisting of a hash of the string representation of all sorted edges) so that we record when the same file content results in different coverage. 

Fixes #14.