### PR TITLE
Run test cases multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project should be documented in this file.
 
 - A `bump_version.py` script to automate version update, by @smiyashaji.
 - A `--timeout` CLI option for configurable script running timeouts, by @ShrayJP.
+- A `--runs` CLI option to determine how many times each test case is run, by @devdanzin.
+- A `--dynamic-runs` CLI option to calculate number of runs based on parent score, by @devdanzin.
 
 ### Enhanced
 


### PR DESCRIPTION
This PR makes it possible to select the number of time each test case will be run by using the new `--runs` CLI flag. It also allows dynamic calculation of the number of runs based on parent score by using the `--dynamic-runs` CLI flag. 

Dynamic calculation currently follows this curve (so most test cases will run 3 or 4 times):
```
Score: num_runs
1: 2
30: 2
60: 3
90: 3
120: 4
150: 4
180: 4
210: 4
240: 4
270: 4
300: 4
400: 5
500: 5
600: 5
700: 5
1000: 6
2000: 6
5000: 7
10000: 8
```

Fixes #16.