### PR TITLE
Lower GC thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this project should be documented in this file.
 
 - A `bump_version.py` script to automate version update, by @smiyashaji.
 - A `--timeout` CLI option for configurable script running timeouts, by @ShrayJP.
-- A coverage hash to handle duplicated files with non-deterministic results, by @devdanzin. 
+- A coverage hash to handle duplicated files with non-deterministic results, by @devdanzin.
 - A `--runs` CLI option to determine how many times each test case is run, by @devdanzin.
 - A `--dynamic-runs` CLI option to calculate number of runs based on parent score, by @devdanzin.
+- A `GCInjector` mutator to lower GC thresholds inside the harness function, by @devdanzin.
+- A way to prepend code lowering the GC thresholds to the test case, by @devdanzin.
 
 ### Enhanced
 


### PR DESCRIPTION
This PR adds two ways to lower GC thresholds, a technique that may increase the likelihood or triggering JIT bugs. Both ways target setting the threshold to numbers between 1 and 150, with higher weights for 1, a bit lower for 10 and 100, and much lower for all other numbers.

First way, it's now possible to prepend such code to the test case, making the threshold lower during test case imports and setup code.

Second way, the call to `gc.set_threshold()` can happen inside the harness via a new `GCInjector` mutator.

Fixes #18.