### PR TITLE
New mutators from docs analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project should be documented in this file.
 - A way to prepend code lowering the GC thresholds to the test case, by @devdanzin.
 - A `DictPolluter` mutator to attack global or local dict caches (dk_version), by @devdanzin.
 - A `FunctionPatcher` mutator to attack function versioning and inlining caches, by @devdanzin.
-- A `TraceBreaker` mutator to attack the JIT's ability to form superblocks using trace-unfriendly code, by @devdanzin. 
+- A `TraceBreaker` mutator to attack the JIT's ability to form superblocks using trace-unfriendly code, by @devdanzin.
+- An `ExitStresser` mutator to attack the JIT's side-exit mechanism with loops containing many frequently taken branches, by @devdanzin.
 
 
 ### Enhanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project should be documented in this file.
 - A way to prepend code lowering the GC thresholds to the test case, by @devdanzin.
 - A `DictPolluter` mutator to attack global or local dict caches (dk_version), by @devdanzin.
 - A `FunctionPatcher` mutator to attack function versioning and inlining caches, by @devdanzin.
+- A `TraceBreaker` mutator to attack the JIT's ability to form superblocks using trace-unfriendly code, by @devdanzin. 
 
 
 ### Enhanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project should be documented in this file.
 - A `--dynamic-runs` CLI option to calculate number of runs based on parent score, by @devdanzin.
 - A `GCInjector` mutator to lower GC thresholds inside the harness function, by @devdanzin.
 - A way to prepend code lowering the GC thresholds to the test case, by @devdanzin.
+- A `DictPolluter` mutator to attack global or local dict caches (dk_version), by @devdanzin.
+
 
 ### Enhanced
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project should be documented in this file.
 - A `FunctionPatcher` mutator to attack function versioning and inlining caches, by @devdanzin.
 - A `TraceBreaker` mutator to attack the JIT's ability to form superblocks using trace-unfriendly code, by @devdanzin.
 - An `ExitStresser` mutator to attack the JIT's side-exit mechanism with loops containing many frequently taken branches, by @devdanzin.
+- A `DeepCallMutator` to attack the JIT's trace stack limit by adding a chain of nested function calls, by @devdanzin.
 
 
 ### Enhanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project should be documented in this file.
 - A `GCInjector` mutator to lower GC thresholds inside the harness function, by @devdanzin.
 - A way to prepend code lowering the GC thresholds to the test case, by @devdanzin.
 - A `DictPolluter` mutator to attack global or local dict caches (dk_version), by @devdanzin.
+- A `FunctionPatcher` mutator to attack function versioning and inlining caches, by @devdanzin.
 
 
 ### Enhanced


### PR DESCRIPTION
This PR adds 5 new mutators that came up from analysis of JIT docs and code:
- A `DictPolluter` mutator to attack global or local dict caches (dk_version).
- A `FunctionPatcher` mutator to attack function versioning and inlining caches.
- A `TraceBreaker` mutator to attack the JIT's ability to form superblocks using trace-unfriendly code.
- An `ExitStresser` mutator to attack the JIT's side-exit mechanism with loops containing many frequently taken branches.
- A `DeepCallMutator` to attack the JIT's trace stack limit by adding a chain of nested function calls.

Fixes #20.