### PR TITLE
Add FuzzerSetupNormalizer to remove old RNG seeding and GC tuning code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project should be documented in this file.
 ### Fixed
 
 - Correctly delete all temporary files created by multiple runs, by @devdanzin.
+- Avoid adding RNG seeding and GC tuning multiple times, by @devdanzin.
 
 
 ## [0.0.1] - 2024-11-20

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -31,7 +31,7 @@ from typing import Any
 
 from lafleur.corpus_manager import CorpusManager
 from lafleur.coverage import parse_log_for_edge_coverage, load_coverage_state
-from lafleur.mutator import ASTMutator, VariableRenamer
+from lafleur.mutator import ASTMutator, FuzzerSetupNormalizer, VariableRenamer
 from lafleur.utils import ExecutionResult, TeeLogger, load_run_stats, save_run_stats
 
 RANDOM = random.Random()
@@ -413,6 +413,10 @@ class LafleurOrchestrator:
         weights = [0.85, 0.10, 0.05]
 
         tree_copy = copy.deepcopy(base_ast)
+        # Clean the AST of any previous fuzzer setup before applying new mutations.
+        normalizer = FuzzerSetupNormalizer()
+        tree_copy = normalizer.visit(tree_copy)
+
         chosen_strategy = RANDOM.choices(strategies, weights=weights, k=1)[0]
 
         # The `seed` argument is used by the deterministic stage for its own


### PR DESCRIPTION
This PR adds a `FuzzerSetupNormalizer` mutator that is always run in `apply_mutation_strategy` in order to remove old RNG seeding and GC tuning code, so we don't end up with multiple copies of such code.

Fixes #21.