### PR TITLE
Add a `GuardRemover` mutator as a counterpoint to `GuardInjector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project should be documented in this file.
 - A `TraceBreaker` mutator to attack the JIT's ability to form superblocks using trace-unfriendly code, by @devdanzin.
 - An `ExitStresser` mutator to attack the JIT's side-exit mechanism with loops containing many frequently taken branches, by @devdanzin.
 - A `DeepCallMutator` to attack the JIT's trace stack limit by adding a chain of nested function calls, by @devdanzin.
+- A a `GuardRemover` mutator as a counterpoint to `GuardInjector`, by @devdanzin.
 
 
 ### Enhanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project should be documented in this file.
 - A `TraceBreaker` mutator to attack the JIT's ability to form superblocks using trace-unfriendly code, by @devdanzin.
 - An `ExitStresser` mutator to attack the JIT's side-exit mechanism with loops containing many frequently taken branches, by @devdanzin.
 - A `DeepCallMutator` to attack the JIT's trace stack limit by adding a chain of nested function calls, by @devdanzin.
-- A a `GuardRemover` mutator as a counterpoint to `GuardInjector`, by @devdanzin.
+- A `GuardRemover` mutator as a counterpoint to `GuardInjector`, by @devdanzin.
 
 
 ### Enhanced


### PR DESCRIPTION
This PR adds a new  `GuardRemover` mutator to avoid or delay too deep nesting of code caused by `GuardInjector`, which leads to valueless crashes.

Fixes #25.