### PR TITLE
Make `GuardRemover` more robust so it doesn't return empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project should be documented in this file.
 
 - Correctly delete all temporary files created by multiple runs, by @devdanzin.
 - Avoid adding RNG seeding and GC tuning multiple times, by @devdanzin.
+- Avoid double counting crashes, by @devdanzin.
+- Avoid IndentationErrors after mutation with `GuardRemover`, by @devdanzin.
 
 
 ## [0.0.1] - 2024-11-20

--- a/lafleur/mutator.py
+++ b/lafleur/mutator.py
@@ -1882,12 +1882,13 @@ class GuardRemover(ast.NodeTransformer):
         if (isinstance(node.test, ast.Compare) and
                 self.is_rng_check(node.test.left)):
 
-            # With a certain probability, remove this guard.
             if random.random() < 0.25:
                 print("    -> Removing fuzzer-injected guard.", file=sys.stderr)
-                # The transformer automatically handles replacing one statement
-                # with a list of them.
-                return node.body
+
+                # If the body is not empty, unwrap it.
+                # If the body IS empty (because a child visitor removed its contents),
+                # replace the entire 'if' with a 'pass' to maintain valid syntax.
+                return node.body if node.body else ast.Pass()
 
         return node
 


### PR DESCRIPTION
This PR fixes a rare issue where we would get valueless crashes due to our mutations generating empty `if` blocks like below:
```python
    for i in range(500):
        obj = shapes_la_8634[i % len(shapes_la_8634)]
        try:
            payload_val = obj.payload
            if callable(payload_val):
                payload_val()
        except Exception:
            pass
    if fuzzer_rng.random() >= 0.1:
    if fuzzer_rng.random() >= 0.1:
    if fuzzer_rng.random() >= 0.1:
        print('[uop_harness_f1_6025] Running all()/any() attack scenario...', file=sys.stderr)
```

The fix is to update `GuardRemover` to return `ast.Pass()` if the `if` body would be empty.