### PR TITLE
Record JIT state when gathering edges

### DIFF
--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -41,15 +41,18 @@ class CorpusScheduler:
         self.global_coverage = coverage_state.get("global_coverage", {})
 
     def _calculate_rarity_score(self, file_metadata: dict[str, Any]) -> float:
-        """Calculate a score based on the rarity of the file's coverage."""
+        """
+        Calculate a score based on the rarity of the file's coverage.
+        Rarer edges (lower global hit count) contribute more to the score.
+        """
         rarity_score = 0.0
         baseline_coverage = file_metadata.get("baseline_coverage", {})
 
         for harness_data in baseline_coverage.values():
-            for edge in harness_data.get("edges", []):
+            for edge_tuple in harness_data.get("edges", []):
                 # The score for an edge is the inverse of its global hit count.
                 # We add 1 to the denominator to avoid division by zero.
-                global_hits = self.global_coverage.get("edges", {}).get(edge, 0)
+                global_hits = self.global_coverage.get("edges", {}).get(edge_tuple, 0)
                 rarity_score += 1.0 / (global_hits + 1)
         return rarity_score
 

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -874,7 +874,7 @@ except Exception:
         for harness_id in sorted(coverage_profile.keys()):
             edges = sorted(coverage_profile[harness_id].get("edges", {}).keys())
             if edges:
-                all_edges.append(f"{harness_id}:{','.join(edges)}")
+                all_edges.append(f"{harness_id}:{','.join(": ".join(edge) for edge in edges)}")
 
         canonical_string = ";".join(all_edges)
         return hashlib.sha256(canonical_string.encode('utf-8')).hexdigest()
@@ -965,11 +965,10 @@ except Exception:
             lineage_harness = lineage.setdefault(
                 harness_id, {"uops": set(), "edges": set(), "rare_events": set()}
             )
-            for key in ["uops", "edges", "rare_events"]:
-                # Get the set of items from the parent's lineage.
-                lineage_set = lineage_harness.setdefault(key, set())
-                # Add all the keys from the child's new coverage to the set.
-                lineage_set.update(child_data.get(key, {}).keys())
+            lineage_harness["uops"].update(child_data.get("uops", {}).keys())
+            lineage_harness["rare_events"].update(child_data.get("rare_events", {}).keys())
+            lineage_harness["edges"].update(child_data.get("edges", {}).keys())
+
         return lineage
 
     def _get_differential_test_boilerplate(self) -> str:


### PR DESCRIPTION
This PR introduces recording of the JIT state (executing, tracing or optimized) when gathering edges, which are now stored as tuples: `(state, uop->uop)`.

Fixes #44.