### PR TITLE
Use trace length and number of side exits in corpus scheduling

### DIFF
--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -84,6 +84,19 @@ class CorpusScheduler:
             # Slightly reward deeper mutation chains to encourage depth exploration.
             score += metadata.get("lineage_depth", 1) * 5.0
 
+            total_trace_length = 0
+            total_side_exits = 0
+            baseline_coverage = metadata.get("baseline_coverage", {})
+            for harness_data in baseline_coverage.values():
+                total_trace_length += harness_data.get("trace_length", 0)
+                total_side_exits += harness_data.get("side_exits", 0)
+
+            # Reward files that produce long, optimized traces.
+            score += total_trace_length * 0.2
+
+            # Strongly reward files that explore many different side exits.
+            score += total_side_exits * 5.0
+
             # Ensure score is non-negative
             scores[filename] = max(1.0, score)
 

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -697,7 +697,7 @@ except Exception:
         if self.use_dynamic_runs:
             # Use a logarithmic scale to model diminishing returns.
             # A score of ~60 results in 3 runs, ~120 in 4 runs, etc.
-            num_runs = 2 + int(math.floor(math.log(max(1.0, parent_score / 15))))
+            num_runs = 2 + int(math.floor(math.log(max(1.0, parent_score / 25))))
             num_runs = min(num_runs, 10)  # Cap at 10 runs to avoid excessive execution
             print(f"    -> Dynamically set run count to {num_runs} for this parent.")
         else:
@@ -962,12 +962,22 @@ except Exception:
         lineage = copy.deepcopy(parent_lineage_profile)
         for harness_id, child_data in child_baseline_profile.items():
             # Ensure the harness entry exists in the new lineage profile.
-            lineage_harness = lineage.setdefault(
-                harness_id, {"uops": set(), "edges": set(), "rare_events": set()}
-            )
+            lineage_harness = lineage.setdefault(harness_id, {
+                "uops": set(), "edges": set(), "rare_events": set(),
+                "max_trace_length": 0, "max_side_exits": 0
+            })
             lineage_harness["uops"].update(child_data.get("uops", {}).keys())
             lineage_harness["rare_events"].update(child_data.get("rare_events", {}).keys())
             lineage_harness["edges"].update(child_data.get("edges", {}).keys())
+
+            lineage_harness["max_trace_length"] = max(
+                lineage_harness.get("max_trace_length", 0),
+                child_data.get("trace_length", 0)
+            )
+            lineage_harness["max_side_exits"] = max(
+                lineage_harness.get("max_side_exits", 0),
+                child_data.get("side_exits", 0)
+            )
 
         return lineage
 


### PR DESCRIPTION
This PR adds code to track trace length and number of side exits and use these values to improve corpus scheduling.

Fixes #46.