### PR TITLE
Delete compressed temporary log files

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -803,6 +803,8 @@ except Exception:
                             print(f"Error deleting {child_source_path}, file doesn't exist!")
                         if child_log_path.exists():
                             child_log_path.unlink()
+                        elif child_log_path.with_suffix(".log.zst").exists():
+                            child_log_path.with_suffix(".log.zst").unlink()
                         else:
                             print(f"Error deleting {child_log_path}, file doesn't exist!")
                     except OSError as e:


### PR DESCRIPTION
This PR is another attempt at deleting the temporary children log files that are being left in `tmp_fuzz_run`.

Fixes #55.