### PR TITLE
Allow disabling tweaks when running `jit_tuner.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project should be documented in this file.
 - Record JIT state (executing, tracing or optimized) when collecting edges, by @devdanzin.
 - Use `FuzzerSetupNormalizer` make randomness reproducible, by @devdanzin.
 - Do not record some known uninteresting crashes, by @devdanzin.
+- Allow disabling tweaks when running `jit_tuner.py`, by @devdanzin.
 
 
 ### Fixed


### PR DESCRIPTION
This PR adds support for disabling tweaks (either specific tweaks or all tweaks in a file) from the command line.

Fixes #74.