### PR TITLE
Allow keeping temporary execution logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project should be documented in this file.
 - A `GuardRemover` mutator as a counterpoint to `GuardInjector`, by @devdanzin.
 - Tests for mutators.py, by @devdanzin.
 - A depth-first way of mutating code samples, by @devdanzin.
+- A `--keep-temp-logs` CLI option to keep temporary log files, by @devdanzin.
 
 
 ### Enhanced
@@ -30,7 +31,7 @@ All notable changes to this project should be documented in this file.
 - Give scores to mutators and reward those most successful, by @devdanzin.
 - Use trace length and number of side exits in corpus scheduling, by @devdanzin.
 - Record JIT state (executing, tracing or optimized) when collecting edges, by @devdanzin.
-- Use `FuzzerSetupNormalizer` make randomness reproducible, by @devdanzin.
+- Use `FuzzerSetupNormalizer` to make randomness reproducible, by @devdanzin.
 - Do not record some known uninteresting crashes, by @devdanzin.
 - Allow disabling tweaks when running `jit_tuner.py`, by @devdanzin.
 

--- a/doc/dev/06_developer_getting_started.md
+++ b/doc/dev/06_developer_getting_started.md
@@ -140,6 +140,13 @@ With the project installed, you can run the fuzzer from any directory on your sy
     lafleur --fusil-path /path/to/fusil/fuzzers/fusil-python-threaded --dynamic-runs
     ```
 
+* **Retaining Logs for Analysis:**
+    To keep temporary log files for offline analysis and debugging, use the `--keep-tmp-logs` flag.
+
+    ```bash
+    lafleur --fusil-path /path/to/fusil/fuzzers/fusil-python-threaded --keep-tmp-logs
+    ```
+
 ### Using the `state_tool.py`
 
 The fuzzer's main state file, `coverage/coverage_state.pkl`, is a binary file that is not human-readable. The `state_tool.py` script is provided to inspect and convert this file. See [05_state_and_data_formats.md](./05_state_and_data_formats.md) for a description of this file's format and interesting fields.


### PR DESCRIPTION
This PR adds a `--keep-temp-logs` CLI flag to optionally save temporary child execution logs to `logs/run_logs/`.

Fixes #76.