### PR TITLE
Use int ids to record UOPs, edges and rare events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project should be documented in this file.
 - Use `FuzzerSetupNormalizer` to make randomness reproducible, by @devdanzin.
 - Do not record some known uninteresting crashes, by @devdanzin.
 - Allow disabling tweaks when running `jit_tuner.py`, by @devdanzin.
+- Store int ids for UOPs, edges, and rare events instead of strings in the coverage file, by @devdanzin.
 
 
 ### Fixed

--- a/doc/dev/06_developer_getting_started.md
+++ b/doc/dev/06_developer_getting_started.md
@@ -149,18 +149,26 @@ With the project installed, you can run the fuzzer from any directory on your sy
 
 ### Using the `state_tool.py`
 
-The fuzzer's main state file, `coverage/coverage_state.pkl`, is a binary file that is not human-readable. The `state_tool.py` script is provided to inspect and convert this file. See [05_state_and_data_formats.md](./05_state_and_data_formats.md) for a description of this file's format and interesting fields.
+The fuzzer's main state file, `coverage/coverage_state.pkl`, is a binary file that is not human-readable. The `state_tool.py` script is provided to inspect, convert, and migrate this file.
 
-  * **To view the state file as JSON:**
+* **To view the state file as JSON:**
+    This command will automatically handle both old (string-based) and new (integer-based) formats, printing a human-readable JSON representation to your console.
 
     ```bash
     python lafleur/state_tool.py coverage/coverage_state.pkl
     ```
 
-  * **To convert the state file to a human-readable JSON file:**
+* **To convert the state file to a JSON file:**
 
     ```bash
     python lafleur/state_tool.py coverage/coverage_state.pkl coverage/pretty_state.json
+    ```
+
+* **To manually migrate an old state file:**
+    If you need to manually convert an old, string-based state file to the new integer-based format, you can specify a `.pkl` output file.
+
+    ```bash
+    python lafleur/state_tool.py /path/to/old_state.pkl /path/to/new_state.pkl
     ```
 
 ### Interpreting the results

--- a/lafleur/state_tool.py
+++ b/lafleur/state_tool.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+A standalone command-line utility for inspecting and migrating lafleur's
+binary state file (`coverage_state.pkl`).
+"""
+
+import argparse
+import json
+import pickle
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def migrate_state_to_integers(old_state: dict[str, Any]) -> dict[str, Any]:
+    """
+    Convert a string-based coverage state file to the new integer-based format.
+    """
+    print("[*] Starting migration of coverage state to integer-based format...")
+    new_state = {
+        "uop_map": {},
+        "edge_map": {},
+        "rare_event_map": {},
+        "next_id_map": {"uop": 0, "edge": 0, "rare_event": 0},
+        "global_coverage": {"uops": {}, "edges": {}, "rare_events": {}},
+        "per_file_coverage": {},
+    }
+
+    # Helper to create mappings and get IDs
+    def get_or_create_id(item_type: str, item_string: str) -> int:
+        map_name = f"{item_type}_map"
+        if item_string in new_state[map_name]:
+            return new_state[map_name][item_string]
+
+        new_id = new_state["next_id_map"][item_type]
+        new_state[map_name][item_string] = new_id
+        new_state["next_id_map"][item_type] += 1
+        return new_id
+
+    # 1. Migrate global_coverage
+    for cov_type in ["uops", "edges", "rare_events"]:
+        id_type = cov_type.rstrip("s")
+        for item_str, count in old_state.get("global_coverage", {}).get(cov_type, {}).items():
+            item_id = get_or_create_id(id_type, str(item_str))
+            new_state["global_coverage"][cov_type][item_id] = count
+
+    # 2. Migrate per_file_coverage
+    for filename, metadata in old_state.get("per_file_coverage", {}).items():
+        new_metadata = metadata.copy()
+
+        # a. Migrate baseline_coverage
+        new_baseline = {}
+        for harness, harness_data in metadata.get("baseline_coverage", {}).items():
+            new_harness_data = harness_data.copy()
+            for cov_type in ["uops", "edges", "rare_events"]:
+                id_type = cov_type.rstrip("s")
+                new_harness_data[cov_type] = {
+                    get_or_create_id(id_type, str(item_str)): count
+                    for item_str, count in harness_data.get(cov_type, {}).items()
+                }
+            new_baseline[harness] = new_harness_data
+        new_metadata["baseline_coverage"] = new_baseline
+
+        # b. Migrate lineage_coverage_profile
+        new_lineage = {}
+        for harness, harness_data in metadata.get("lineage_coverage_profile", {}).items():
+            new_harness_data = harness_data.copy()
+            for cov_type in ["uops", "edges", "rare_events"]:
+                id_type = cov_type.rstrip("s")
+                new_harness_data[cov_type] = {
+                    get_or_create_id(id_type, str(item_str))
+                    for item_str in harness_data.get(cov_type, set())
+                }
+            new_lineage[harness] = new_harness_data
+        new_metadata["lineage_coverage_profile"] = new_lineage
+
+        new_state["per_file_coverage"][filename] = new_metadata
+
+    print("[+] Migration complete.")
+    return new_state
+
+
+def main() -> None:
+    """Parse args to inspect, convert, or migrate the state file."""
+    parser = argparse.ArgumentParser(description="Inspect or migrate lafleur's coverage state.")
+    parser.add_argument("input_file", type=Path, help="Path to the coverage_state.pkl file.")
+    parser.add_argument(
+        "output_file",
+        type=Path,
+        nargs="?",
+        help="Optional path to save output. If ends in .json, saves as JSON. If ends in .pkl, saves as a migrated pickle file.",
+    )
+
+    args = parser.parse_args()
+
+    if not args.input_file.is_file():
+        print(f"Error: Input file not found at {args.input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(args.input_file, "rb") as f:
+            state = pickle.load(f)
+    except (pickle.UnpicklingError, IOError) as e:
+        print(f"Error: Could not read pickle file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # --- Main Logic ---
+    migrated_state = state
+    if "uop_map" not in state:
+        migrated_state = migrate_state_to_integers(state)
+
+    # Convert sets to lists for JSON serialization
+    def set_to_list(obj):
+        if isinstance(obj, set):
+            return sorted(list(obj))
+        raise TypeError
+
+    if not args.output_file:
+        # Default action: print as JSON to stdout
+        print(json.dumps(migrated_state, indent=2, default=set_to_list))
+
+    elif args.output_file.suffix == ".json":
+        with open(args.output_file, "w") as f:
+            json.dump(migrated_state, f, indent=2, default=set_to_list)
+        print(f"State saved as JSON to {args.output_file}")
+
+    elif args.output_file.suffix == ".pkl":
+        with open(args.output_file, "wb") as f:
+            pickle.dump(migrated_state, f)
+        print(f"Migrated state saved as pickle to {args.output_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR changes the format of the `coverage.pkl` file so it  uses integer ids instead of strings to record UOPs, edges and rare events. It also provides a tool to migrate files from the old format to the new one.

Fixes #79.