### PR TITLE
Improve interestingness analysis based on scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project should be documented in this file.
 - Do not record some known uninteresting crashes, by @devdanzin.
 - Allow disabling tweaks when running `jit_tuner.py`, by @devdanzin.
 - Store int ids for UOPs, edges, and rare events instead of strings in the coverage file, by @devdanzin.
-
+- Make interestingness more strict based on scores calculated by `InterestingnessScorer`, by @devdanzin.
 
 ### Fixed
 

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -236,6 +236,8 @@ class CorpusManager:
                     parent_id=None,
                     mutation_info={"strategy": "seed"},
                     mutation_seed=0,
+                    parent_file_size=0,
+                    parent_lineage_edge_count=0,
                 )
                 if analysis_data["status"] == "NEW_COVERAGE":
                     self.add_new_file(
@@ -434,6 +436,8 @@ class CorpusManager:
             parent_id=None,
             mutation_info={"strategy": "generative_seed"},
             mutation_seed=0,
+            parent_file_size=0,
+            parent_lineage_edge_count=0,
         )
         if analysis_data["status"] == "NEW_COVERAGE":
             self.add_new_file(


### PR DESCRIPTION
This PR adds the `InterestingnessScorer` and makes interestingness analysis more strict, rewarding children that better cover the JIT state. We reward increased number of edges, global coverage over relative coverage, percentage increase in total coverage, and smaller file sizes.

Fixes #81.