### PR TITLE
Only mutate a slice of large test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project should be documented in this file.
 - Tests for mutators.py, by @devdanzin.
 - A depth-first way of mutating code samples, by @devdanzin.
 - A `--keep-temp-logs` CLI option to keep temporary log files, by @devdanzin.
+- A `SlicingMutator` to only visit part of the AST of very big files, by @devdanzin.]
 
 
 ### Enhanced
@@ -36,6 +37,7 @@ All notable changes to this project should be documented in this file.
 - Allow disabling tweaks when running `jit_tuner.py`, by @devdanzin.
 - Store int ids for UOPs, edges, and rare events instead of strings in the coverage file, by @devdanzin.
 - Make interestingness more strict based on scores calculated by `InterestingnessScorer`, by @devdanzin.
+
 
 ### Fixed
 

--- a/lafleur/mutator.py
+++ b/lafleur/mutator.py
@@ -1915,8 +1915,8 @@ class SlicingMutator(ast.NodeTransformer):
     slice of a very large function body.
     """
 
-    MIN_STATEMENTS_FOR_SLICE = 30
-    SLICE_SIZE = 15
+    MIN_STATEMENTS_FOR_SLICE = 100
+    SLICE_SIZE = 25
 
     def __init__(self, transformer_instances: list[ast.NodeTransformer]):
         self.pipeline = transformer_instances

--- a/lafleur/mutator.py
+++ b/lafleur/mutator.py
@@ -1909,6 +1909,41 @@ class GuardRemover(ast.NodeTransformer):
         return node
 
 
+class SlicingMutator(ast.NodeTransformer):
+    """
+    A meta-mutator that applies a given mutation pipeline to only a small
+    slice of a very large function body.
+    """
+
+    MIN_STATEMENTS_FOR_SLICE = 30
+    SLICE_SIZE = 15
+
+    def __init__(self, transformer_instances: list[ast.NodeTransformer]):
+        self.pipeline = transformer_instances
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        body_len = len(node.body)
+        if body_len < self.MIN_STATEMENTS_FOR_SLICE:
+            return node
+
+        print(f"    -> Slicing large function body of {body_len} statements.", file=sys.stderr)
+
+        start = random.randint(0, body_len - self.SLICE_SIZE)
+        end = start + self.SLICE_SIZE
+        body_slice = node.body[start:end]
+
+        temp_module = ast.Module(body=body_slice, type_ignores=[])
+
+        for transformer in self.pipeline:
+            temp_module = transformer.visit(temp_module)
+
+        mutated_slice = temp_module.body
+        node.body = node.body[:start] + mutated_slice + node.body[end:]
+
+        ast.fix_missing_locations(node)
+        return node
+
+
 class ASTMutator:
     """
     An engine for structurally modifying Python code at the AST level.

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -396,10 +396,12 @@ class LafleurOrchestrator:
         self, base_ast: ast.AST, seed: int, **kwargs
     ) -> tuple[ast.AST, dict[str, Any]]:
         """Apply a single, seeded, deterministic mutation."""
-        harness_node = next((n for n in base_ast.body if isinstance(n, ast.FunctionDef)), None)
-        if harness_node and len(harness_node.body) > SlicingMutator.MIN_STATEMENTS_FOR_SLICE:
-            return self._run_slicing(base_ast, "deterministic", len(harness_node.body), seed=seed)
+        harness_node = base_ast
+        len_harness = len(harness_node.body) if harness_node else 0
+        if harness_node and len_harness > SlicingMutator.MIN_STATEMENTS_FOR_SLICE:
+            return self._run_slicing(base_ast, "deterministic", len_harness, seed=seed)
 
+        print(f"  [~] Running DETERMINISTIC stage ({len_harness} statements)...", file=sys.stderr)
         mutated_ast, transformers_used = self.ast_mutator.mutate_ast(base_ast, seed=seed)
         mutation_info = {
             "strategy": "deterministic",
@@ -409,11 +411,12 @@ class LafleurOrchestrator:
 
     def _run_havoc_stage(self, base_ast: ast.AST, **kwargs) -> tuple[ast.AST, dict[str, Any]]:
         """Apply a random stack of many different mutations to the AST."""
-        harness_node = next((n for n in base_ast.body if isinstance(n, ast.FunctionDef)), None)
-        if harness_node and len(harness_node.body) > SlicingMutator.MIN_STATEMENTS_FOR_SLICE:
-            return self._run_slicing(base_ast, "havoc", len(harness_node.body))
+        harness_node = base_ast
+        len_harness = len(harness_node.body) if harness_node else 0
+        if harness_node and len_harness > SlicingMutator.MIN_STATEMENTS_FOR_SLICE:
+            return self._run_slicing(base_ast, "havoc", len_harness)
 
-        print("  [~] Running HAVOC stage...", file=sys.stderr)
+        print(f"  [~] Running HAVOC stage ({len_harness} statements)...", file=sys.stderr)
         tree = base_ast  # Start with the copied tree from the dispatcher
         num_havoc_mutations = RANDOM.randint(15, 50)
         transformers_applied = []
@@ -437,11 +440,12 @@ class LafleurOrchestrator:
 
     def _run_spam_stage(self, base_ast: ast.AST, **kwargs) -> tuple[ast.AST, dict[str, Any]]:
         """Repeatedly apply the same type of mutation to the AST."""
-        harness_node = next((n for n in base_ast.body if isinstance(n, ast.FunctionDef)), None)
-        if harness_node and len(harness_node.body) > SlicingMutator.MIN_STATEMENTS_FOR_SLICE:
-            return self._run_slicing(base_ast, "spam", len(harness_node.body))
+        harness_node = base_ast
+        len_harness = len(harness_node.body) if harness_node else 0
+        if harness_node and len_harness > SlicingMutator.MIN_STATEMENTS_FOR_SLICE:
+            return self._run_slicing(base_ast, "spam", len_harness)
 
-        print("  [~] Running SPAM stage...", file=sys.stderr)
+        print(f"  [~] Running SPAM stage ({len_harness} statements)...", file=sys.stderr)
         tree = base_ast
         num_spam_mutations = RANDOM.randint(20, 50)
 


### PR DESCRIPTION
This PR adds the `SlicingMutator` meta-mutator and uses it to only mutate a slice of large test cases. This improves the run time of AST mutation because there's less work to do. Also seems to make test case size growth slower, because, instead of adding a lot of code, mutations add a bounded amount of code.

Fixes #83.