### PR TITLE
Allow pruning the corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project should be documented in this file.
 - Tests for mutators.py, by @devdanzin.
 - A depth-first way of mutating code samples, by @devdanzin.
 - A `--keep-temp-logs` CLI option to keep temporary log files, by @devdanzin.
-- A `SlicingMutator` to only visit part of the AST of very big files, by @devdanzin.]
+- A `SlicingMutator` to only visit part of the AST of very big files, by @devdanzin.
+- Pruning (`--prune-corpus -f`) of the corpus by removing files that are subsumed by others, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -483,11 +483,11 @@ class CorpusManager:
         # 3. Check for Efficiency.
         # File B must be better than file A in at least one metric (size or speed),
         # without being worse in the other.
-        size_a = file_a_meta.get("file_size_bytes", float('inf'))
-        size_b = file_b_meta.get("file_size_bytes", float('inf'))
+        size_a = file_a_meta.get("file_size_bytes", float("inf"))
+        size_b = file_b_meta.get("file_size_bytes", float("inf"))
 
-        time_a = file_a_meta.get("execution_time_ms", float('inf'))
-        time_b = file_b_meta.get("execution_time_ms", float('inf'))
+        time_a = file_a_meta.get("execution_time_ms", float("inf"))
+        time_b = file_b_meta.get("execution_time_ms", float("inf"))
 
         if size_b <= size_a and time_b <= time_a:
             # If B is smaller/faster in both, it's definitely better.

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -1524,7 +1524,8 @@ def main():
         help="Run the corpus pruning tool to find and report redundant test cases, then exit.",
     )
     parser.add_argument(
-        "-f", "--force",
+        "-f",
+        "--force",
         action="store_true",
         help="Used with --prune-corpus to actually delete the files. (Default: dry run)",
     )

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -167,6 +167,8 @@ class LafleurOrchestrator:
         num_runs: int = 1,
         use_dynamic_runs: bool = False,
         keep_tmp_logs: bool = False,
+        prune_corpus_flag: bool = False,
+        force_prune: bool = False,
     ):
         """Initialize the orchestrator and the corpus manager."""
         self.differential_testing = differential_testing
@@ -192,6 +194,11 @@ class LafleurOrchestrator:
         )
         # Synchronize the corpus and state at startup.
         self.corpus_manager.synchronize(self.analyze_run, self._build_lineage_profile)
+
+        if prune_corpus_flag:
+            self.corpus_manager.prune_corpus(dry_run=not force_prune)
+            print("[*] Pruning complete. Exiting.")
+            sys.exit(0)
 
         self.mutations_since_last_find = 0
         self.global_seed_counter = self.run_stats.get("global_seed_counter", 0)
@@ -1511,6 +1518,16 @@ def main():
         action="store_true",
         help="Retain temporary log files for all runs in the logs/run_logs/ directory for offline analysis.",
     )
+    parser.add_argument(
+        "--prune-corpus",
+        action="store_true",
+        help="Run the corpus pruning tool to find and report redundant test cases, then exit.",
+    )
+    parser.add_argument(
+        "-f", "--force",
+        action="store_true",
+        help="Used with --prune-corpus to actually delete the files. (Default: dry run)",
+    )
     args = parser.parse_args()
 
     LOGS_DIR.mkdir(exist_ok=True)
@@ -1565,6 +1582,8 @@ Initial Stats:
             num_runs=args.runs,
             use_dynamic_runs=args.dynamic_runs,
             keep_tmp_logs=args.keep_tmp_logs,
+            prune_corpus_flag=args.prune_corpus,
+            force_prune=args.force,
         )
         orchestrator.run_evolutionary_loop()
     except KeyboardInterrupt:


### PR DESCRIPTION
This PR adds the `--prune-corpus` and `--force` CLI options to prune the corpus from files that are subsumed by others.

A file `A` is subsumed by file `B` if all of the following are true:
- The set of coverage edges from file `A` is a proper subset of the edges from file `B` (`edges(A) ⊂ edges(B)`).
- File `B` is more "efficient" than file `A`, where efficiency is a combination of smaller file size and faster execution time.

Fixes #85.