### PR TITLE
Add `BoundaryValuesMutator` replacing numbers with boundary values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project should be documented in this file.
 - A `--keep-temp-logs` CLI option to keep temporary log files, by @devdanzin.
 - A `SlicingMutator` to only visit part of the AST of very big files, by @devdanzin.
 - Pruning (`--prune-corpus -f`) of the corpus by removing files that are subsumed by others, by @devdanzin.
+- A `BoundaryValuesMutator` that replaces numeric constants with interesting/boundary values, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutator.py
+++ b/lafleur/mutator.py
@@ -15,7 +15,6 @@ import builtins
 import random
 import copy
 import sys
-from math import log10
 from textwrap import dedent, indent
 
 

--- a/lafleur/mutator.py
+++ b/lafleur/mutator.py
@@ -15,6 +15,7 @@ import builtins
 import random
 import copy
 import sys
+from math import log10
 from textwrap import dedent, indent
 
 
@@ -78,6 +79,78 @@ class ConstantPerturbator(ast.NodeTransformer):
             char_val = ord(node.value[pos])
             new_char = chr(char_val + random.choice([-1, 1]))
             node.value = node.value[:pos] + new_char + node.value[pos + 1 :]
+        return node
+
+
+class BoundaryValuesMutator(ast.NodeTransformer):
+    """
+    Replaces numeric constants with interesting boundary values to stress
+    JIT specializations for numbers.
+    """
+
+    BOUNDARY_VALUES = [
+        # Integers
+        "0",
+        "-1",
+        "2**31 - 1",  # Max signed 32-bit int
+        "2**31",  # Signed 32-bit int overflow
+        "-2**31",  # Min signed 32-bit int
+        "-2**31 - 1",  # Signed 32-bit int underflow
+        "2**63 - 1",  # Max signed 64-bit int
+        "2**63",  # Signed 64-bit int overflow
+        "-2**63",  # Min signed 64-bit int
+        "-2**63 - 1",  # Signed 64-bit int underflow
+        "2 ** 1024",  # Large positive int
+        "-2 ** 1024",  # Large negative int
+        "sys.maxsize",
+        "sys.maxsize - 1",
+        "sys.maxsize + 1",
+        "-sys.maxsize",
+        "-sys.maxsize + 1",
+        "-sys.maxsize - 1",
+        # Floats
+        "0.0",
+        "-0.0",
+        "float('inf')",
+        "float('-inf')",
+        "float('nan')",
+        "sys.float_info.max",
+        "sys.float_info.min",
+        "sys.float_info.epsilon",
+        "float(10**15000)",
+        "-float(10**15000)",
+        "-sys.float_info.max",
+        "-sys.float_info.epsilon",
+        "sys.float_info.min / 2",
+        "-sys.float_info.min / 2",
+        "float('0.0000001')",
+        "-float('0.0000001')",
+        # Complex numbers
+        "complex(sys.maxsize, sys.maxsize)",
+        "complex(float('inf'), float('nan'))",
+        "complex(sys.float_info.max, sys.float_info.epsilon)",
+        "1j",
+        "-1j",
+    ]
+
+    def visit_Constant(self, node: ast.Constant) -> ast.AST:
+        # We only want to mutate existing numbers, not None, strings, etc.
+        if not isinstance(node.value, (int, float, complex)):
+            return node
+
+        if random.random() < 0.2:
+            new_value_str = random.choice(self.BOUNDARY_VALUES)
+            print(
+                f"    -> Mutating constant '{ast.unparse(node)}' to boundary value '{new_value_str}'",
+                file=sys.stderr,
+            )
+            try:
+                # We want the expression itself, not the module wrapper.
+                new_node = ast.parse(new_value_str, mode="eval").body
+                return new_node
+            except (SyntaxError, ValueError):
+                # Fallback to the original node if parsing fails for any reason
+                return node
         return node
 
 
@@ -1959,6 +2032,7 @@ class ASTMutator:
             OperatorSwapper,
             ComparisonSwapper,
             ConstantPerturbator,
+            BoundaryValuesMutator,
             GuardInjector,
             ContainerChanger,
             VariableSwapper,


### PR DESCRIPTION
This PR adds the `BoundaryValuesMutator`, which replaces numeric values with interesting/boundary values. 

Fixes #90.