### PR TITLE
Add UnpackingMutator to transform assignments into unpacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project should be documented in this file.
 - Pruning (`--prune-corpus -f`) of the corpus by removing files that are subsumed by others, by @devdanzin.
 - A `BoundaryValuesMutator` that replaces numeric constants with interesting/boundary values, by @devdanzin.
 - A `BlockTransposerMutator` that moves code blocks within a function body, by @devdanzin.
+- A `UnpackingMutator` that transforms simple assignments into complex unpacking ones, by @devdanzin.
 
 
 ### Enhanced


### PR DESCRIPTION
This PR adds the `UnpackingMutator`, which replaces simple assignments with complex tuple unpacking assignments.

Fixes #95.