### PR TITLE
Call fusil using --only-generate instead of sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project should be documented in this file.
 - Allow disabling tweaks when running `jit_tuner.py`, by @devdanzin.
 - Store int ids for UOPs, edges, and rare events instead of strings in the coverage file, by @devdanzin.
 - Make interestingness more strict based on scores calculated by `InterestingnessScorer`, by @devdanzin.
+- Update calling of `fusil` to use `--only-generate` instead of `sudo`.
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ With the venv created, you can now install `lafleur` and use its JIT-tuning tool
     cd fusil
     pip install .
     ```
-2.  **Configure `sudoers`:** The `fusil` seeder requires root privileges. To allow `lafleur` to call it without a password, run `sudo visudo` and add the following line, replacing the placeholders with your absolute paths:
-    ```bash
-    # Allow your_username to run the fusil seed generator without a password
-    your_username ALL=(ALL) NOPASSWD: /path/to/fusil_venv/bin/python3 /path/to/fusil/fuzzers/fusil-python-threaded *
-    ```
 
   * **Alternative: Manual Seeding:** If you prefer not to install `fusil`, you can create a directory named `corpus/jit_interesting_tests/` in your working directory and place your own hand-crafted Python seed files inside it.
 

--- a/doc/dev/06_developer_getting_started.md
+++ b/doc/dev/06_developer_getting_started.md
@@ -41,27 +41,6 @@ To make fuzzing easier and more effective, `lafleur` includes a script for adjus
     ./python -m venv ~/venvs/lafleur_venv
     ```
 
-#### 2. `sudoers` Configuration for the `fusil` Seeder
-
-`lafleur` uses the classic `fusil` fuzzer as a subprocess to generate initial seed files for the corpus. The `fusil` tool requires `root` privileges to operate correctly. To allow `lafleur` (running as a normal user) to call `fusil` with `sudo` without requiring a password prompt, you must add a specific rule to your system's `sudoers` configuration.
-
-**Warning:** Always use the `visudo` command to edit this file. It performs a syntax check before saving to prevent you from being locked out of your system.
-
-1.  Open the `sudoers` file for editing:
-
-    ```bash
-    sudo visudo
-    ```
-
-2.  Add the following line to the end of the file, replacing `your_username` and the paths with your actual system paths. **The paths must be absolute.**
-
-    ```bash
-    # Allow 'your_username' to run the fusil seed generator without a password
-    your_username ALL=(ALL) NOPASSWD: /path/to/fusil/fuzzers/fusil-python-threaded
-    ```
-
-(This step will become unnecessary once fusil supports running in seeder mode without requiring root)
-
 -----
 
 ### Installation and JIT tuning

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -383,7 +383,6 @@ class CorpusManager:
         python_executable = sys.executable
         # Use fusil to generate a new file
         command = [
-            "sudo",
             python_executable,
             self.fusil_path,
             "--jit-fuzz",
@@ -401,6 +400,7 @@ class CorpusManager:
             "--jit-loop-iterations=300",
             "--no-numpy",
             "--modules=encodings.ascii",
+            "--only-generate",
             # "--keep-sessions",
         ]
         print(f"[*] Generating new seed with command: {' '.join(command)}")


### PR DESCRIPTION
This PR makes lafleur call fusil without sudo, using the `--only-generate` CLI option instead.

Fixes #100.