### PR TITLE
Add support for fuzzing ASAN-enabled builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project should be documented in this file.
 - An `UnpackingMutator` that transforms simple assignments into complex unpacking ones, by @devdanzin.
 - A `DecoratorMutator` that wraps functions inside our harness with simple decorators, by @devdanzin.
 - A `RecursionWrappingMutator` that wraps blocks of code in self-recursive functions, by @devdanzin.
+- Support to fuzzing Python builds with `ASAN` enabled, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -28,6 +28,7 @@ ENV.update(
         "PYTHON_LLTRACE": "4",
         "PYTHON_OPT_DEBUG": "4",
         "PYTHON_JIT": "1",
+        "ASAN_OPTIONS": "detect_leaks=0",
     }
 )
 
@@ -404,7 +405,7 @@ class CorpusManager:
             # "--keep-sessions",
         ]
         print(f"[*] Generating new seed with command: {' '.join(command)}")
-        subprocess.run(command, capture_output=True)
+        subprocess.run(command, capture_output=True, env=ENV)
 
         # Execute it to get a log (also using the configurable timeout)
         try:

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -73,6 +73,7 @@ ENV.update(
         "PYTHON_LLTRACE": "4",
         "PYTHON_OPT_DEBUG": "4",
         "PYTHON_JIT": "1",
+        "ASAN_OPTIONS": "detect_leaks=0"
     }
 )
 


### PR DESCRIPTION
This PR avoids false positives from detection of memory leaks by setting `ASAN_OPTIONS` to `detect_leaks=0`.

Fixes #104.