### PR TITLE
Add `ComprehensionBomb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project should be documented in this file.
 - A `DescriptorChaosGenerator` that injects a class with a stateful descriptor, by @devdanzin.
 - A `MROShuffler`that injects a scenario which changes MRO after a while, by @devdanzin.
 - A `FrameManipulator` that injects a function that modifies a local variable up the call stack, by @devdanzin.
+- A `ComprehensionBomb` that runs a list comprehension over a stateful iterator, by @devdanzin.
 
 
 ### Enhanced


### PR DESCRIPTION
This PR adds a mutator that injects a self-contained scenario where we define a stateful iterator with side effects, then use it in a list comprehension.

Fixes #112.