### PR TITLE
Add WeakRefCallbackChaos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project should be documented in this file.
 - A `ComprehensionBomb` that runs a list comprehension over a stateful iterator, by @devdanzin.
 - A `SuperResolutionAttacker` to stress the caches that the JIT uses for super() calls, by @devdanzin.
 - A `CoroutineStateCorruptor` to create a coroutine where a local variable is corrupted, by @devdanzin.
+- A `WeakRefCallbackChaos` to use a weakref callback that violates a variable's type assumption, by @devdanzin.
 
 
 ### Enhanced


### PR DESCRIPTION
This PR adds the `WeakRefCallbackChaos`, which adds a scenario in which the type of a variable is established in a hot loop, then a weakref callback is set up so that it will violate that assumption when garbage collection occurs.

Fixes #123.