### PR TITLE
Add BuiltinNamespaceCorruptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project should be documented in this file.
 - A `CoroutineStateCorruptor` to create a coroutine where a local variable is corrupted, by @devdanzin.
 - A `WeakRefCallbackChaos` to use a weakref callback that violates a variable's type assumption, by @devdanzin.
 - An `ExceptionHandlerMaze` to add an exception with a metaclass to make except blocks stateful, by @devdanzin.
+- A `BuiltinNamespaceCorruptor` to replace built-in functions with malicious versions, by @devdanzin.
 
 
 ### Enhanced


### PR DESCRIPTION
This PR adds the `BuiltinNamespaceCorruptor` to temporarily replace built-in functions with malicious versions.

Fixes #127.