### PR TITLE
Make differential mode use two processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ All notable changes to this project should be documented in this file.
 - Store int ids for UOPs, edges, and rare events instead of strings in the coverage file, by @devdanzin.
 - Make interestingness more strict based on scores calculated by `InterestingnessScorer`, by @devdanzin.
 - Update calling of `fusil` to use `--only-generate` instead of `sudo`.
-- Many mutators based on Claude suggestions.
+- Many mutators based on Claude suggestions, by @devdanzin.
+- Differential testing mode to use different processes, by @devdanzin.
 
 
 ### Fixed

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -97,3 +97,6 @@ class ExecutionResult:
     log_path: Path
     source_path: Path
     execution_time_ms: int
+    is_divergence: bool = False
+    jit_stdout: str | None = None
+    nojit_stdout: str | None = None


### PR DESCRIPTION
This PR changes differential (divergence, correctness) mode to use two processes with JIT on or OFF. It also changes the comparison method between runs, now relying on comparing `stdout`, which features a normalized view of class instances and functions.

Fixes #134.