### PR TITLE
Add timings fuzzing mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project should be documented in this file.
 - An `ExceptionHandlerMaze` to add an exception with a metaclass to make except blocks stateful, by @devdanzin.
 - A `BuiltinNamespaceCorruptor` to replace built-in functions with malicious versions, by @devdanzin.
 - A `CodeObjectSwapper` to swap the code object of a function with that of another, by @devdanzin.
+- A timing fuzzing mode to search for code samples where the JIT is slower than no JIT, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -100,3 +100,5 @@ class ExecutionResult:
     is_divergence: bool = False
     jit_stdout: str | None = None
     nojit_stdout: str | None = None
+    jit_avg_time_ms: float | None = None
+    nojit_avg_time_ms: float | None = None


### PR DESCRIPTION
This PR adds a timings fuzzing mode to compare the execution times with and without the JIT, flagging cases where the JIT is slower and saving them to the corpus to try to find even slower cases.

Fixes #136.