### PR TITLE
Increase timing robustness using statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project should be documented in this file.
 - Many mutators based on Claude suggestions, by @devdanzin.
 - Differential testing mode to use different processes, by @devdanzin.
 - Deeper analysis of differences in differential testing mode, by @devdanzin.
+- Implemented statistical comparisons in timing fuzzing mode, by @devdanzin.
 
 
 ### Fixed

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -102,3 +102,4 @@ class ExecutionResult:
     nojit_stdout: str | None = None
     jit_avg_time_ms: float | None = None
     nojit_avg_time_ms: float | None = None
+    nojit_cv: float | None = None


### PR DESCRIPTION
This PR improves timing fuzzing robustness by calculating Coefficient of Variation and dynamically calculating minimum slowdown based on it.

Fixes #143.