### PR TITLE
Pass reason when saving a divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to this project should be documented in this file.
 - UOP are validated against the set of known UOPs to avoid recording cut names, by @devdanzin.
 - Wrong concatenation in `_execute_child` using escaped `"\\n"`, by @devdanzin.
 - Wrong environment values in `_run_timed_trial` making JIT run mistakenly verbose, by @devdanzin.
+- Not passing `reason` when detecting a divergence and then terminating, by @devdanzin.
 
 
 ## [0.0.1] - 2024-11-20

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -98,8 +98,9 @@ class ExecutionResult:
     source_path: Path
     execution_time_ms: int
     is_divergence: bool = False
-    jit_stdout: str | None = None
-    nojit_stdout: str | None = None
+    divergence_reason: str | None = None
+    jit_output: str | None = None
+    nojit_output: str | None = None
     jit_avg_time_ms: float | None = None
     nojit_avg_time_ms: float | None = None
     nojit_cv: float | None = None


### PR DESCRIPTION
This PR fixes a crash when trying to save a divergence in differential mode. It happened because we weren't passing the required `reason` argument to `_save_divergence`.

Fixes #147.