### PR TITLE
Save regressions to their directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ All notable changes to this project should be documented in this file.
 - Wrong concatenation in `_execute_child` using escaped `"\\n"`, by @devdanzin.
 - Wrong environment values in `_run_timed_trial` making JIT run mistakenly verbose, by @devdanzin.
 - Not passing `reason` when detecting a divergence and then terminating, by @devdanzin.
+- Not saving regressions to their separate directory, by @devdanzin.
 
 
 ## [0.0.1] - 2024-11-20


### PR DESCRIPTION
This PR fixes saving regressions to their directory by making `analyze_run` return the necessary values for usage in `_handle_analysis_data`.

Fixes #148.