### PR TITLE
Allow timing and differential modes to run together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project should be documented in this file.
 - Differential testing mode to use different processes, by @devdanzin.
 - Deeper analysis of differences in differential testing mode, by @devdanzin.
 - Implemented statistical comparisons in timing fuzzing mode, by @devdanzin.
+- Allow timing and differential modes to run together, by @devdanzin.
 
 
 ### Fixed


### PR DESCRIPTION
This PR enables running differential and timing modes to run together, sequentially: first we check for divergences, then for performance regressions, and lastly we gather UOP and edge coverage.

Fixes #144.