### PR TITLE
Proceed to a coverage run if a crash happens in a timed run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable changes to this project should be documented in this file.
 - Not passing `reason` when detecting a divergence and then terminating, by @devdanzin.
 - Not saving regressions to their separate directory, by @devdanzin.
 - Errors trying to serialize objects JSON doesn't know how to encode, by @devdanzin.
+- When a crash happens in a timed run, continue to the coverage run to try to record it, by @devdanzin.
 
 
 ## [0.0.1] - 2024-11-20

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -1008,16 +1008,12 @@ class LafleurOrchestrator:
             )
             if timed_out:
                 return self._handle_timeout(child_source_path, child_log_path, parent_path)
-            if nojit_avg_ms is None:
-                return None
 
             jit_avg_ms, timed_out, _ = self._run_timed_trial(
                 child_source_path, num_timing_runs, jit_enabled=True
             )
             if timed_out:
                 self._save_regression_timeout(child_source_path, parent_path)
-                return None
-            if jit_avg_ms is None:
                 return None
 
         # --- Stage 3: Normal Coverage-Gathering Run ---


### PR DESCRIPTION
This PR avoids returning `None` from `_execute_child`, allowing a coverage run to happen after a crash happens in a timed run. This makes it possible to reproduce and record the crash in the coverage run.

Fixes #157.