### PR TITLE
Truncate or compress crash log files if they're too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to this project should be documented in this file.
 - Implemented statistical comparisons in timing fuzzing mode, by @devdanzin.
 - Allow timing and differential modes to run together, by @devdanzin.
 - Truncate timeout log files if they're too large, by @devdanzin.
+- Truncate or compress timeout log files if they're too large, by @devdanzin.
 
 
 ### Fixed


### PR DESCRIPTION
This PR adds compression or truncation of crash logs if their size is too big. Just like with timeouts, there's a minimum size above which the file is compressed, then a ceiling above which the file is truncated. Also changes `--max-log-size` to `--max-timeout-log-size` and creates `--max-crash-log-size`.

Fixes #167.