### PR TITLE
Record signal, retcode or keyword that caused a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this project should be documented in this file.
 - Allow timing and differential modes to run together, by @devdanzin.
 - Truncate timeout log files if they're too large, by @devdanzin.
 - Truncate or compress timeout log files if they're too large, by @devdanzin.
+- Record the reason for a crash (return code, signal, or keyword) in the filename, by @devdanzin. 
 
 
 ### Fixed


### PR DESCRIPTION
This PRs makes lafleur add the signal name, return code, or keyword that was recorded as the cause of a crash to the filename.

Fixes #165.