### PR TITLE
Add PatternMatchingMutator to target pattern matching UOPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project should be documented in this file.
 - A `SliceMutator` to add slices and slicing operations, by @devdanzin.
 - The `--target-python` CLI option to run the fuzzing scripts on a different Python interpreter, by @devdanzin.
 - A check that the target Python interpreter outputs the necessary JIT debug messages, by @devdanzin.
+- A `PatternMatchingMutator` that injects match/case statements to target pattern matching UOPs, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -26,6 +26,7 @@ from lafleur.mutators.generic import (
     GuardInjector,
     GuardRemover,
     OperatorSwapper,
+    PatternMatchingMutator,
     SliceMutator,
     # StatementDuplicator,
     UnpackingMutator,
@@ -160,6 +161,7 @@ class ASTMutator:
             BuiltinNamespaceCorruptor,
             CodeObjectSwapper,
             SliceMutator,
+            PatternMatchingMutator,
         ]
 
     def mutate_ast(


### PR DESCRIPTION
This PR adds the `PatternMatchingMutator`, which targets pattern matching UOPs like `_MATCH_SEQUENCE`, `_MATCH_MAPPING`, `_MATCH_KEYS`, and `_GET_LEN`.

Fixes #175.