### PR TITLE
Add NewUnpackingMutator targeting unpacking UOPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project should be documented in this file.
 - A check that the target Python interpreter outputs the necessary JIT debug messages, by @devdanzin.
 - A `PatternMatchingMutator` that injects match/case statements to target pattern matching UOPs, by @devdanzin.
 - An `ArithmeticSpamMutator` that injects tight loops with arithmetic operations to target related UOPs, by @devdanzin.
+- A `NewUnpackingMutator` targeting unpacking dicts and single element lists, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -26,6 +26,7 @@ from lafleur.mutators.generic import (
     ForLoopInjector,
     GuardInjector,
     GuardRemover,
+    NewUnpackingMutator,
     OperatorSwapper,
     PatternMatchingMutator,
     SliceMutator,
@@ -91,7 +92,7 @@ class SlicingMutator(ast.NodeTransformer):
 
         print(f"    -> Slicing large function body of {body_len} statements.", file=sys.stderr)
 
-        start = 0 # random.randint(0, body_len - self.SLICE_SIZE)
+        start = random.randint(0, body_len - self.SLICE_SIZE)
         end = start + self.SLICE_SIZE
         body_slice = node.body[start:end]
 
@@ -149,6 +150,7 @@ class ASTMutator:
             GuardRemover,
             BlockTransposerMutator,
             UnpackingMutator,
+            NewUnpackingMutator,
             DecoratorMutator,
             RecursionWrappingMutator,
             DescriptorChaosGenerator,


### PR DESCRIPTION
This PR adds the `NewUnpackingMutator`, which  targets unpacking dicts and single element lists to get coverage of more unpacking UOPs.

Fixes #179.