### PR TITLE
 Add StringInterpolationMutator to target string formating UOPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ All notable changes to this project should be documented in this file.
 - A `PatternMatchingMutator` that injects match/case statements to target pattern matching UOPs, by @devdanzin.
 - An `ArithmeticSpamMutator` that injects tight loops with arithmetic operations to target related UOPs, by @devdanzin.
 - A `NewUnpackingMutator` targeting unpacking dicts and single element lists, by @devdanzin.
-
+- A `StringInterpolationMutator` targeting string interpolation UOPs, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -31,6 +31,7 @@ from lafleur.mutators.generic import (
     PatternMatchingMutator,
     SliceMutator,
     # StatementDuplicator,
+    StringInterpolationMutator,
     UnpackingMutator,
     VariableSwapper,
 )
@@ -166,6 +167,7 @@ class ASTMutator:
             SliceMutator,
             PatternMatchingMutator,
             ArithmeticSpamMutator,
+            StringInterpolationMutator,
         ]
 
     def mutate_ast(


### PR DESCRIPTION
This PR adds `StringInterpolationMutator`, which injects complex f-strings (targeting `_FORMAT_WITH_SPEC`) and Python 3.14+ t-strings (targeting `_BUILD_TEMPLATE`, `_BUILD_INTERPOLATION`).

Fixes #181.