### PR TITLE
Add ExceptionGroupMutator targeting exception groups UOPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this project should be documented in this file.
 - An `ArithmeticSpamMutator` that injects tight loops with arithmetic operations to target related UOPs, by @devdanzin.
 - A `NewUnpackingMutator` targeting unpacking dicts and single element lists, by @devdanzin.
 - A `StringInterpolationMutator` targeting string interpolation UOPs, by @devdanzin.
+- An `ExceptionGroupMutator` targeting exception group UOPs, by @devdanzin.
+
 
 ### Enhanced
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -23,6 +23,7 @@ from lafleur.mutators.generic import (
     ConstantPerturbator,
     ContainerChanger,
     DecoratorMutator,
+    ExceptionGroupMutator,
     ForLoopInjector,
     GuardInjector,
     GuardRemover,
@@ -168,6 +169,7 @@ class ASTMutator:
             PatternMatchingMutator,
             ArithmeticSpamMutator,
             StringInterpolationMutator,
+            ExceptionGroupMutator,
         ]
 
     def mutate_ast(


### PR DESCRIPTION
This PR add `ExceptionGroupMutator` in an attempt to uncover exception group related UOPs such as `_CHECK_EG_MATCH`, `_PUSH_EXC_INFO`, and `_CHECK_EXC_MATCH.`

While it seems that the targeted UOPs aren't being found, this mutator still finds interesting new coverage.

Fixes #183.