### PR TITLE
Add SysMonitoringMutator targeting sys monitoring UOPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project should be documented in this file.
 - A `StringInterpolationMutator` targeting string interpolation UOPs, by @devdanzin.
 - An `ExceptionGroupMutator` targeting exception group UOPs, by @devdanzin.
 - An `AsyncConstructMutator` targeting async construct UOPs, by @devdanzin.
+- A `SysMonitoringMutator` targeting sys monitoring UOPs, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -34,6 +34,7 @@ from lafleur.mutators.generic import (
     SliceMutator,
     # StatementDuplicator,
     StringInterpolationMutator,
+    SysMonitoringMutator,
     UnpackingMutator,
     VariableSwapper,
 )
@@ -172,6 +173,7 @@ class ASTMutator:
             StringInterpolationMutator,
             ExceptionGroupMutator,
             AsyncConstructMutator,
+            SysMonitoringMutator,
         ]
 
     def mutate_ast(


### PR DESCRIPTION
This PR adds the `SysMonitoringMutator` in an attempt to elicit monitoring and instrumentation UOPs, like `_INSTRUMENTED_FOR_ITER`, `_INSTRUMENTED_LINE`, and `_MONITOR_CALL`.

The mutator fails to generate the targeted UOPs, but still adds some coverage.

Fixes #187.