### PR TITLE
feat: Add ReentrantSideEffectMutator for "rug pull" attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project should be documented in this file.
 - An `ExceptionGroupMutator` targeting exception group UOPs, by @devdanzin.
 - An `AsyncConstructMutator` targeting async construct UOPs, by @devdanzin.
 - A `SysMonitoringMutator` targeting sys monitoring UOPs, by @devdanzin.
+- A `ReentrantSideEffectMutator` that creates "rug pull" attacks on mutable containers by clearing them during access operations, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -54,6 +54,7 @@ from lafleur.mutators.scenarios_data import (
     IterableMutator,
     MagicMethodMutator,
     NumericMutator,
+    ReentrantSideEffectMutator,
 )
 from lafleur.mutators.scenarios_runtime import (
     FrameManipulator,
@@ -145,6 +146,7 @@ class ASTMutator:
             MagicMethodMutator,
             NumericMutator,
             IterableMutator,
+            ReentrantSideEffectMutator,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary

Implements a new `ReentrantSideEffectMutator` that creates "rug pull" attacks on mutable containers by injecting objects that clear or modify containers during access operations.

This mutator targets re-entrancy bugs and use-after-free vulnerabilities in the JIT compiler.

## Implementation Details

- **Sequence types** (list, bytearray, array, deque): Implements `__index__` that clears the container and returns 0
- **Mapping/Set types** (dict, set): Implements `__hash__` and `__eq__` that clear the container
- **Intelligent targeting**: Scans for existing container variables; falls back to injecting a new list if none found
- **Error handling**: All triggers wrapped in try/except for IndexError, KeyError, RuntimeError, ValueError
- **Trigger mechanisms**: Uses `[]` operator for sequences/dicts, `in` operator for sets
- **Probabilistic application**: 10% chance of mutation

## Test Coverage

Added comprehensive test suite with 5 test cases covering:
- List attack (sequence type with `__index__`)
- Set attack (mapping type with `__hash__`/`__eq__` and `in` operator)
- Dict attack (mapping type with `[]` operator)
- Variable injection fallback
- Probability threshold handling

All 347 mutator tests pass.

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)