### PR TITLE
feat: Add ComparisonChainerMutator for chained comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project should be documented in this file.
 - An `AsyncConstructMutator` targeting async construct UOPs, by @devdanzin.
 - A `SysMonitoringMutator` targeting sys monitoring UOPs, by @devdanzin.
 - A `ReentrantSideEffectMutator` that creates "rug pull" attacks on mutable containers by clearing them during access operations, by @devdanzin.
+- A `ComparisonChainerMutator` that extends simple comparisons into chained comparisons to stress JIT stack management, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -20,6 +20,7 @@ from lafleur.mutators.generic import (
     AsyncConstructMutator,
     BlockTransposerMutator,
     BoundaryValuesMutator,
+    ComparisonChainerMutator,
     ComparisonSwapper,
     ConstantPerturbator,
     ContainerChanger,
@@ -127,6 +128,7 @@ class ASTMutator:
         self.transformers = [
             OperatorSwapper,
             ComparisonSwapper,
+            ComparisonChainerMutator,
             ConstantPerturbator,
             BoundaryValuesMutator,
             GuardInjector,


### PR DESCRIPTION
## Summary

Implements a new `ComparisonChainerMutator` that extends simple comparisons into chained comparisons to stress the JIT's stack management.

Python's chained comparison syntax (e.g., `a < b < c`) generates complex bytecode including `ROT_THREE` and `DUP_TOP` operations, which can expose bugs in the JIT's stack handling.

## Implementation Details

The mutator takes existing `ast.Compare` nodes and extends them by:

- **Adding random comparison operators**: `Eq`, `Lt`, `Gt`, `LtE`, `GtE`, `NotEq`, `Is`, `IsNot`, `In`, `NotIn`
- **Appending appropriate comparators** chosen from three categories:
  - **Constants**: `0`, `1`, `None`, `True`, `""`
  - **Recycled values**: Reuses `node.left` if it's a `Name` or `Constant` (creates patterns like `x < 10 > x`)
  - **Collections**: `[]` or `{}` (useful for `In`/`NotIn` operators)

- **Probabilistic application**: 50% chance of mutation
- **Proper AST handling**: Ensures `ast.fix_missing_locations` is called

## Example Transformations

- `x < 10` → `x < 10 == True`
- `a > b` → `a > b in []`
- `y == 5` → `y == 5 is None`

## Test Coverage

Added comprehensive test in `test_generic.py` that verifies:
- Chain extension with correct operator and comparator counts
- Valid syntax generation (can be unparsed)
- Proper AST node structure

All 348 mutator tests pass.

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)