### PR TITLE
feat: Add ContextManagerInjector for context manager stress testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project should be documented in this file.
 - A `SysMonitoringMutator` targeting sys monitoring UOPs, by @devdanzin.
 - A `ReentrantSideEffectMutator` that creates "rug pull" attacks on mutable containers by clearing them during access operations, by @devdanzin.
 - A `ComparisonChainerMutator` that extends simple comparisons into chained comparisons to stress JIT stack management, by @devdanzin.
+- A `ContextManagerInjector` that wraps code blocks in context managers to stress-test SETUP_WITH and exception propagation, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -40,6 +40,7 @@ from lafleur.mutators.generic import (
     VariableSwapper,
 )
 from lafleur.mutators.scenarios_control import (
+    ContextManagerInjector,
     CoroutineStateCorruptor,
     DeepCallMutator,
     ExceptionHandlerMaze,
@@ -161,6 +162,7 @@ class ASTMutator:
             NewUnpackingMutator,
             DecoratorMutator,
             RecursionWrappingMutator,
+            ContextManagerInjector,
             DescriptorChaosGenerator,
             MROShuffler,
             FrameManipulator,


### PR DESCRIPTION
## Summary

Implements a new `ContextManagerInjector` mutator that wraps blocks of code in context managers to stress-test the JIT's handling of SETUP_WITH bytecode and exception propagation.

## Implementation Details

The mutator uses **three strategies** to maximize code coverage:

### 1. Simple Strategy (`contextlib.nullcontext()`)
- Tests basic context manager protocol
- Clean entry/exit with no exceptions or side effects
- Targets basic SETUP_WITH bytecode handling

### 2. Resource Strategy (`open(os.devnull, 'w')`)
- Tests real resource management
- Exercises file handle cleanup
- Tests context manager cleanup on exception paths

### 3. Evil Strategy (Custom `EvilContext` class)
- **`__enter__`**: Randomly raises `RuntimeError` (30% chance)
- **`__exit__`**: Randomly raises `RuntimeError` (30% chance) OR returns `True` to swallow exceptions (50% chance)
- Wrapped in try/except to handle chaotic behavior
- Stresses exception propagation through context managers

## Key Features

- **Targeting**: Only mutates `uop_harness` functions with 2+ statements
- **Wrapping**: Selects contiguous slices of 2-5 statements
- **Probability**: Applies with 15% chance
- **Import handling**: Automatically adds required imports (`contextlib`, `os`)
- **AST safety**: Properly calls `ast.fix_missing_locations()`

## Bytecode Targets

This mutator specifically targets:
- `SETUP_WITH` - Context manager setup
- `WITH_EXCEPT_START` - Exception handling in context managers
- `POP_BLOCK` - Stack cleanup on exit

## Test Coverage

Added comprehensive test suite with 10 test cases covering:
- All three strategies (simple, resource, evil)
- Exception behavior (`__enter__` and `__exit__` raising)
- Contiguous slice wrapping
- Edge cases (non-harness functions, too few statements)
- Probability thresholds
- Valid code generation

All 358 mutator tests pass.

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)