### PR TITLE
Add YieldFromInjector to target generator suspension and yield from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project should be documented in this file.
 - A `ContextManagerInjector` that wraps code blocks in context managers to stress-test SETUP_WITH and exception propagation, by @devdanzin.
 - An `ImportChaosMutator` that injects random standard library imports to alter memory layout and global state, by @devdanzin.
 - A `LiteralTypeSwapMutator` that swaps literal constants with different-typed values to stress JIT type specialization and guards, by @devdanzin.
+- A `YieldFromInjector` that targets generator suspension, `yield from` delegation, and stack unwinding during cleanup with try/finally blocks, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -50,6 +50,7 @@ from lafleur.mutators.scenarios_control import (
     GuardExhaustionGenerator,
     RecursionWrappingMutator,
     TraceBreaker,
+    YieldFromInjector,
 )
 from lafleur.mutators.scenarios_data import (
     BuiltinNamespaceCorruptor,
@@ -167,6 +168,7 @@ class ASTMutator:
             DecoratorMutator,
             RecursionWrappingMutator,
             ContextManagerInjector,
+            YieldFromInjector,
             DescriptorChaosGenerator,
             MROShuffler,
             FrameManipulator,


### PR DESCRIPTION
## Summary

Implements `YieldFromInjector`, a new mutator that targets the JIT's handling of generator suspension, `yield from` delegation, and stack unwinding during cleanup (`try/finally` blocks).

## Changes

- Added `YieldFromInjector` class in `lafleur/mutators/scenarios_control.py`
- Registered mutator in `lafleur/mutators/engine.py`
- Added 8 comprehensive tests in `tests/mutators/test_scenarios_control.py`
- Updated `CHANGELOG.md`

## Features

- Creates nested generator functions with `yield from range(10)`
- Wraps `yield from` in try/finally blocks for cleanup testing
- 20% probability of recursive generator pattern (depth-limited to 5)
- Unique naming with random suffixes
- Consumes generators with `list()` to force execution

## Testing

All 8 new tests pass:
- ✅ test_injects_simple_yield_from_generator
- ✅ test_injects_recursive_yield_from_generator
- ✅ test_prepends_generator_and_appends_driver
- ✅ test_respects_probability
- ✅ test_only_mutates_uop_harness_functions
- ✅ test_produces_valid_code_simple
- ✅ test_produces_valid_code_recursive
- ✅ test_unique_naming

All 385 mutator tests pass with no regressions.

## How It Works

The mutator stress-tests the JIT by:
- Generator suspension/resumption mechanics
- Stack unwinding during cleanup (finally blocks)
- Delegation chains (yield from)
- Recursive generator patterns with depth limits

### Simple Generator Example:
```python
def _yield_from_gen_5000():
    try:
        yield from range(10)
    finally:
        pass

list(_yield_from_gen_5000())
```

### Recursive Generator Example:
```python
def _yield_from_gen_6000(depth=0):
    if depth > 5:
        return
    try:
        yield from _yield_from_gen_6000(depth + 1)
    finally:
        pass

list(_yield_from_gen_6000(0))
```

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)