### PR TITLE
Add RedundantStatementSanitizer to control file size bloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project should be documented in this file.
 - An `ImportChaosMutator` that injects random standard library imports to alter memory layout and global state, by @devdanzin.
 - A `LiteralTypeSwapMutator` that swaps literal constants with different-typed values to stress JIT type specialization and guards, by @devdanzin.
 - A `YieldFromInjector` that targets generator suspension, `yield from` delegation, and stack unwinding during cleanup with try/finally blocks, by @devdanzin.
+- A `RedundantStatementSanitizer` that removes consecutive identical statements probabilistically to control file size bloat from mutators like StatementDuplicator, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/__init__.py
+++ b/lafleur/mutators/__init__.py
@@ -12,6 +12,7 @@ from lafleur.mutators.utils import (
     FuzzerSetupNormalizer,
     EmptyBodySanitizer,
     HarnessInstrumentor,
+    RedundantStatementSanitizer,
 )
 from lafleur.mutators.generic import VariableRenamer
 
@@ -21,5 +22,6 @@ __all__ = [
     "FuzzerSetupNormalizer",
     "EmptyBodySanitizer",
     "HarnessInstrumentor",
+    "RedundantStatementSanitizer",
     "VariableRenamer",
 ]

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -81,6 +81,7 @@ from lafleur.mutators.scenarios_types import (
     TypeInstabilityInjector,
     TypeIntrospectionMutator,
 )
+from lafleur.mutators.utils import RedundantStatementSanitizer
 
 
 class SlicingMutator(ast.NodeTransformer):
@@ -186,6 +187,7 @@ class ASTMutator:
             ExceptionGroupMutator,
             AsyncConstructMutator,
             SysMonitoringMutator,
+            RedundantStatementSanitizer,
         ]
 
     def mutate_ast(


### PR DESCRIPTION
## Summary

Implements `RedundantStatementSanitizer`, a new sanitizer that removes consecutive identical statements probabilistically to control file size bloat caused by mutators like `StatementDuplicator`.

## Changes

- Added `RedundantStatementSanitizer` class in `lafleur/mutators/utils.py`
- Registered sanitizer in `lafleur/mutators/engine.py` transformers list
- Exported sanitizer in `lafleur/mutators/__init__.py`
- Added 10 comprehensive tests in `tests/mutators/test_utils.py`
- Updated `CHANGELOG.md`

## Features

- Configurable removal probability (default 90%)
- Processes all major container nodes:
  - Module, FunctionDef, AsyncFunctionDef
  - For, AsyncFor, While, If
  - With, AsyncWith
  - Try (body, orelse, finalbody)
- Removes consecutive duplicates while always preserving non-identical statements
- Uses `ast.dump()` for precise node comparison

## Testing

All 10 new tests pass:
- ✅ test_removes_consecutive_identical_statements
- ✅ test_keeps_some_duplicates_probabilistically
- ✅ test_preserves_non_identical_statements
- ✅ test_handles_mixed_statements
- ✅ test_processes_if_body
- ✅ test_processes_for_body
- ✅ test_processes_while_body
- ✅ test_processes_try_body
- ✅ test_custom_removal_probability
- ✅ test_produces_valid_code

All 395 mutator tests pass with no regressions.

## How It Works

The sanitizer:
1. Iterates through statement lists in AST nodes
2. Compares each statement with the previous one using `ast.dump()`
3. If identical and `random.random() < removal_probability`, skips the duplicate
4. If different or kept by RNG, adds to the deduplicated list
5. Preserves "warming loop" behavior (useful for JIT) while preventing infinite growth

### Example:

**Before:**
```python
def test():
    x = 1
    x = 1  # duplicate
    x = 1  # duplicate
    x = 1  # duplicate
    y = 2
```

**After (with 90% removal probability):**
```python
def test():
    x = 1
    # ~90% of duplicates removed, ~10% kept
    y = 2
```

Fixes #215 

🤖 Generated with [Claude Code](https://claude.com/claude-code)