### PR TITLE
feat: Add BloomFilterSaturator to attack JIT's global variable tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project should be documented in this file.
 - A `YieldFromInjector` that targets generator suspension, `yield from` delegation, and stack unwinding during cleanup with try/finally blocks, by @devdanzin.
 - A `RedundantStatementSanitizer` that removes consecutive identical statements probabilistically to control file size bloat from mutators like StatementDuplicator, by @devdanzin.
 - A `LatticeSurfingMutator` that attacks the JIT's Abstract Interpretation Lattice by injecting objects that dynamically flip their `__class__` to stress-test `_GUARD_TYPE_VERSION` guards, by @devdanzin.
+- A `BloomFilterSaturator` that exploits the JIT's global variable tracking by saturating the bloom filter (reaching the ~4096 mutation limit) and then modifying watched globals to trigger stale-cache bugs, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -53,6 +53,7 @@ from lafleur.mutators.scenarios_control import (
     YieldFromInjector,
 )
 from lafleur.mutators.scenarios_data import (
+    BloomFilterSaturator,
     BuiltinNamespaceCorruptor,
     ComprehensionBomb,
     DictPolluter,
@@ -158,6 +159,7 @@ class ASTMutator:
             IterableMutator,
             ReentrantSideEffectMutator,
             LatticeSurfingMutator,
+            BloomFilterSaturator,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary

Fixes #223

This PR implements the `BloomFilterSaturator` to exploit CPython JIT's global variable tracking bloom filter by saturating it and then modifying watched globals to trigger stale-cache bugs.

## How It Works

The mutator implements a three-stage "Saturate-and-Switch" attack:

### 1. Module-Level Setup
Injects tracking variables at module scope:
```python
_bloom_target = 0
_bloom_noise_idx = 0
```

### 2. Function-Level Attack (Bait → Noise → Switch)

```python
def uop_harness_test():
    global _bloom_target, _bloom_noise_idx
    
    # BAIT: Train JIT to expect _bloom_target == 0
    if _bloom_target % 2 == 0: 
        pass
    
    # NOISE: Thrash globals dict (150 writes per call)
    for _ in range(150):
        _bloom_noise_idx += 1
        globals()[f'_bloom_noise_{_bloom_noise_idx}'] = _bloom_noise_idx
    
    # SWITCH: Invalidate JIT's assumption
    _bloom_target += 1
```

### 3. Saturation Strategy

The JIT uses `_GUARD_GLOBALS_VERSION` to track global modifications but stops watching after approximately **4,096 mutations**. Our attack:

- Each function call writes 150 values to `globals()`
- After ~27 function calls: **150 × 27 = 4,050 mutations** (near limit)
- The JIT stops tracking globals (bloom filter saturated)
- We then modify `_bloom_target`, which the JIT believes is still `0`
- **Result**: Stale cache bugs when JIT-compiled code uses the outdated value

## What It Stress-Tests

- **`_GUARD_GLOBALS_VERSION`**: JIT global variable tracking
- **Bloom filter saturation**: Behavior when mutation limit is exceeded
- **Stale cache detection**: JIT response when globals change after saturation

## Key Implementation Details

### Safety Guard
Uses `module_vars_added` instance attribute to ensure function-level code only references globals that were actually injected at module scope (prevents `NameError`).

### Visitor Order
Calls `generic_visit()` **after** setting `module_vars_added` flag so child FunctionDef visitors see the correct state.

### Saturation Tuning
Uses `range(150)` iterations (not 50) to more effectively reach the ~4096 mutation limit with repeated calls.

## Testing

- ✓ Added 7 comprehensive tests in `tests/mutators/test_scenarios_data.py`
- ✓ All 55 tests in test_scenarios_data.py pass
- ✓ Verifies module variables injection, saturation logic, and safety guards
- ✓ Validates code remains parseable and executable

## Files Changed

- **lafleur/mutators/scenarios_data.py**: BloomFilterSaturator class (76 lines)
- **lafleur/mutators/engine.py**: Registration
- **tests/mutators/test_scenarios_data.py**: 7 tests (145 lines)
- **CHANGELOG.md**: Added entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)