### PR TITLE
feat: Add StackCacheThrasher to stress JIT's Stack Cache and Register Allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project should be documented in this file.
 - A `RedundantStatementSanitizer` that removes consecutive identical statements probabilistically to control file size bloat from mutators like StatementDuplicator, by @devdanzin.
 - A `LatticeSurfingMutator` that attacks the JIT's Abstract Interpretation Lattice by injecting objects that dynamically flip their `__class__` to stress-test `_GUARD_TYPE_VERSION` guards, by @devdanzin.
 - A `BloomFilterSaturator` that exploits the JIT's global variable tracking by saturating the bloom filter (reaching the ~4096 mutation limit) and then modifying watched globals to trigger stale-cache bugs, by @devdanzin.
+- A `StackCacheThrasher` that stresses the JIT's Stack Cache and Register Allocator by creating deeply nested right-associative expressions (8 levels) that force stack depth beyond the 3-item cache limit, triggering _SPILL and _RELOAD instructions, by @devdanzin.
 - A `MaxOperandMutator` that stresses the JIT's Copy-and-Patch encoding by forcing EXTENDED_ARG bytecodes (300 local variables for LOAD_FAST > 255, or 200-statement blocks for jump offsets > 255), by @devdanzin.
 
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -63,6 +63,7 @@ from lafleur.mutators.scenarios_data import (
     MagicMethodMutator,
     NumericMutator,
     ReentrantSideEffectMutator,
+    StackCacheThrasher,
 )
 from lafleur.mutators.scenarios_runtime import (
     FrameManipulator,
@@ -161,6 +162,7 @@ class ASTMutator:
             ReentrantSideEffectMutator,
             LatticeSurfingMutator,
             BloomFilterSaturator,
+            StackCacheThrasher,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary
- Implements `StackCacheThrasher` mutator to stress the JIT's Stack Cache and Register Allocator
- Creates deeply nested right-associative expressions (8 levels) that force stack depth beyond the 3-item cache limit
- Triggers `_SPILL` and `_RELOAD` instructions to test stack pointer consistency

## Implementation Details
The JIT caches the top 3 stack items in registers. By creating right-associative expressions with depth > 3, we force the JIT to emit `_SPILL` and `_RELOAD` instructions.

The mutator:
1. Injects 8 local variables (`_st_0` through `_st_7`)
2. Creates a right-associative expression: `_ = _st_0 + (_st_1 - (_st_2 * (_st_3 | (_st_4 & (_st_5 ^ (_st_6 + _st_7))))))`
3. Places initialization at the beginning and the thrashing expression in the middle of the function body

## Test Coverage
Added 7 comprehensive tests:
- Variable injection verification
- Right-associative structure validation
- Stack depth verification
- Edge case handling

All tests pass with the CPython JIT build.

## Related Issue
Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)