### PR TITLE
feat: Add BoundaryComparisonMutator to stress JIT's assembly optimizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project should be documented in this file.
 - A `LatticeSurfingMutator` that attacks the JIT's Abstract Interpretation Lattice by injecting objects that dynamically flip their `__class__` to stress-test `_GUARD_TYPE_VERSION` guards, by @devdanzin.
 - A `BloomFilterSaturator` that exploits the JIT's global variable tracking by saturating the bloom filter (reaching the ~4096 mutation limit) and then modifying watched globals to trigger stale-cache bugs, by @devdanzin.
 - A `StackCacheThrasher` that stresses the JIT's Stack Cache and Register Allocator by creating deeply nested right-associative expressions (8 levels) that force stack depth beyond the 3-item cache limit, triggering _SPILL and _RELOAD instructions, by @devdanzin.
+- A `BoundaryComparisonMutator` that stresses the JIT's platform-specific assembly optimizers (Tools/jit/_optimizers.py) by generating edge-case comparisons (NaN vs NaN, NaN vs Inf, 0.0 vs -0.0) that force CPU flags into unusual states (like Parity Flag set) to expose incorrect branch inversion logic, by @devdanzin.
 - A `MaxOperandMutator` that stresses the JIT's Copy-and-Patch encoding by forcing EXTENDED_ARG bytecodes (300 local variables for LOAD_FAST > 255, or 200-statement blocks for jump offsets > 255), by @devdanzin.
 
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -55,6 +55,7 @@ from lafleur.mutators.scenarios_control import (
 )
 from lafleur.mutators.scenarios_data import (
     BloomFilterSaturator,
+    BoundaryComparisonMutator,
     BuiltinNamespaceCorruptor,
     ComprehensionBomb,
     DictPolluter,
@@ -163,6 +164,7 @@ class ASTMutator:
             LatticeSurfingMutator,
             BloomFilterSaturator,
             StackCacheThrasher,
+            BoundaryComparisonMutator,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary
- Implements `BoundaryComparisonMutator` to stress the JIT's platform-specific assembly optimizers
- Generates edge-case comparisons (NaN vs NaN, NaN vs Inf, 0.0 vs -0.0) to expose incorrect branch inversion logic
- Forces CPU flags into unusual states (like Parity Flag set) that might be mishandled

## Implementation Details
The JIT's assembly optimizers (Tools/jit/_optimizers.py) rewrite branch instructions. By comparing edge-case floats, we force CPU flags into states that might reveal bugs in branch inversion logic.

The mutator:
1. Injects 5 variables: `_bnd_nan`, `_bnd_inf`, `_bnd_nzero`, `_bnd_zero`, `_bnd_dummy`
2. Creates If statements for each operator (==, !=, <, >) testing:
   - NaN vs NaN
   - NaN vs Inf
   - 0.0 vs -0.0
3. Each comparison has a side effect (`_bnd_dummy += 1`) to prevent dead code elimination

## Test Coverage
Added 7 comprehensive tests:
- Edge-case float injection verification
- Comparison block creation verification
- All operators usage verification
- Side effects verification
- All combinations verification
- Edge case handling

All tests pass with the CPython JIT build.

## Related Issue
Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)