### PR TITLE
feat: Add AbstractInterpreterConfusionMutator to stress-test JIT's specialized micro-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to this project should be documented in this file.
 - A `BloomFilterSaturator` that exploits the JIT's global variable tracking by saturating the bloom filter (reaching the ~4096 mutation limit) and then modifying watched globals to trigger stale-cache bugs, by @devdanzin.
 - A `StackCacheThrasher` that stresses the JIT's Stack Cache and Register Allocator by creating deeply nested right-associative expressions (8 levels) that force stack depth beyond the 3-item cache limit, triggering _SPILL and _RELOAD instructions, by @devdanzin.
 - A `BoundaryComparisonMutator` that stresses the JIT's platform-specific assembly optimizers (Tools/jit/_optimizers.py) by generating edge-case comparisons (NaN vs NaN, NaN vs Inf, 0.0 vs -0.0) that force CPU flags into unusual states (like Parity Flag set) to expose incorrect branch inversion logic, by @devdanzin.
+- An `AbstractInterpreterConfusionMutator` that stress-tests the JIT's specialized micro-ops (like _BINARY_OP_SUBSCR_LIST_INT) by wrapping subscript indices with _ChameleonInt (an int subclass that can raise exceptions during __index__() or __hash__()), verifying that the JIT correctly handles exceptions from within index conversion and unwinds properly, by @devdanzin.
 - A `MaxOperandMutator` that stresses the JIT's Copy-and-Patch encoding by forcing EXTENDED_ARG bytecodes (300 local variables for LOAD_FAST > 255, or 200-statement blocks for jump offsets > 255), by @devdanzin.
 
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -54,6 +54,7 @@ from lafleur.mutators.scenarios_control import (
     YieldFromInjector,
 )
 from lafleur.mutators.scenarios_data import (
+    AbstractInterpreterConfusionMutator,
     BloomFilterSaturator,
     BoundaryComparisonMutator,
     BuiltinNamespaceCorruptor,
@@ -165,6 +166,7 @@ class ASTMutator:
             BloomFilterSaturator,
             StackCacheThrasher,
             BoundaryComparisonMutator,
+            AbstractInterpreterConfusionMutator,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary
- Implements `AbstractInterpreterConfusionMutator` to stress-test the JIT's specialized micro-ops
- Wraps subscript indices with `_ChameleonInt`, an int subclass that can raise exceptions
- Verifies that the JIT correctly handles exceptions from within index conversion and unwinds properly

## Implementation Details
The JIT has specialized micro-ops like `_BINARY_OP_SUBSCR_LIST_INT` that expect simple index operations. By wrapping indices with `_ChameleonInt`, we verify exception handling in specialized operations.

The mutator:
1. Injects a `_ChameleonInt` class that inherits from `int`
2. `_ChameleonInt.__index__()` raises `ValueError` 10% of the time (when `self % 10 == 7`)
3. `_ChameleonInt.__hash__()` raises `TypeError` 10% of the time (when `self % 10 == 8`)
4. Wraps simple subscript indices (`Constant`, `Name`) with `_ChameleonInt()` calls
5. Applies to ~30% of subscripts

**Example transformation:**
```python
# Before:
l[0]

# After:
l[_ChameleonInt(0)]
```

## Test Coverage
Added 7 comprehensive tests:
- _ChameleonInt class injection verification
- Constant index wrapping
- Name index wrapping
- Random probability handling
- Class structure verification
- Simple indices only (no complex slicing)
- Valid code generation

All tests pass with the CPython JIT build.

## Related Issue
Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)