### PR TITLE
feat: Add TypeShadowingMutator to attack _GUARD_TYPE_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to this project should be documented in this file.
 - A `SessionFuzzingDriver` (`lafleur/driver.py`) and `--session-fuzz` CLI flag that enables "warm JIT" fuzzing. In this mode, scripts run sequentially in the same process via `exec()`, allowing JIT state (traces, caches, global watchers) to persist. The driver runs a parent script (warmup) followed by the child (attack), by @devdanzin.
 - A `GlobalOptimizationInvalidator` that exploits the JIT's "Global-to-Constant Promotion" by training the JIT to trust a global variable (`range`), then swapping it for an `_EvilGlobal` callable class mid-loop (at iteration 1000 of 2000) to force complex deoptimization, by @devdanzin.
 - A `CodeObjectHotSwapper` that targets `_RETURN_GENERATOR` opcode by training the JIT on `_gen_A()` generators (1000 warmup iterations), then swapping `_gen_A.__code__ = _gen_B.__code__` to force deoptimization when the JIT's cached metadata becomes stale, by @devdanzin.
+- A `TypeShadowingMutator` that attacks `_GUARD_TYPE_VERSION` by training the JIT on a float variable, then using `sys._getframe().f_locals` to change its type to a string mid-loop (bypassing standard bytecodes), and triggering the type-specialized operation again, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -68,6 +68,7 @@ from lafleur.mutators.scenarios_data import (
     NumericMutator,
     ReentrantSideEffectMutator,
     StackCacheThrasher,
+    TypeShadowingMutator,
 )
 from lafleur.mutators.scenarios_runtime import (
     FrameManipulator,
@@ -171,6 +172,7 @@ class ASTMutator:
             AbstractInterpreterConfusionMutator,
             GlobalOptimizationInvalidator,
             CodeObjectHotSwapper,
+            TypeShadowingMutator,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary
- Adds `TypeShadowingMutator` that attacks `_GUARD_TYPE_VERSION` optimization
- Trains the JIT on a float variable for 1500 iterations
- Uses `sys._getframe().f_locals` to change variable type to string mid-loop (bypassing standard bytecodes)
- Triggers the type-specialized `float_add` operation again to test if JIT correctly guards against f_locals writes
- Catches `TypeError` to allow script to continue if deopt occurs correctly

## Test plan
- [x] Added 9 tests covering sys._getframe injection, float setup, warmup loop, type swap, exception handling
- [x] All 101 tests in test_scenarios_data.py pass
- [x] Updated CHANGELOG.md

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)