### PR TITLE
feat: Add ZombieTraceMutator to stress executor lifecycle management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to this project should be documented in this file.
 - A `GlobalOptimizationInvalidator` that exploits the JIT's "Global-to-Constant Promotion" by training the JIT to trust a global variable (`range`), then swapping it for an `_EvilGlobal` callable class mid-loop (at iteration 1000 of 2000) to force complex deoptimization, by @devdanzin.
 - A `CodeObjectHotSwapper` that targets `_RETURN_GENERATOR` opcode by training the JIT on `_gen_A()` generators (1000 warmup iterations), then swapping `_gen_A.__code__ = _gen_B.__code__` to force deoptimization when the JIT's cached metadata becomes stale, by @devdanzin.
 - A `TypeShadowingMutator` that attacks `_GUARD_TYPE_VERSION` by training the JIT on a float variable, then using `sys._getframe().f_locals` to change its type to a string mid-loop (bypassing standard bytecodes), and triggering the type-specialized operation again, by @devdanzin.
+- A `ZombieTraceMutator` that stresses the JIT's executor lifecycle management (`pycore_optimizer.h`) by rapidly creating and destroying JIT traces in a loop (50 iterations), defining hot functions that trigger Tier 2 compilation, then letting them go out of scope to test the `pending_deletion` linked list logic for `_PyExecutorObject` cleanup, by @devdanzin.
 
 
 ### Enhanced

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -69,6 +69,7 @@ from lafleur.mutators.scenarios_data import (
     ReentrantSideEffectMutator,
     StackCacheThrasher,
     TypeShadowingMutator,
+    ZombieTraceMutator,
 )
 from lafleur.mutators.scenarios_runtime import (
     FrameManipulator,
@@ -173,6 +174,7 @@ class ASTMutator:
             GlobalOptimizationInvalidator,
             CodeObjectHotSwapper,
             TypeShadowingMutator,
+            ZombieTraceMutator,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary
- Adds `ZombieTraceMutator` that stresses the JIT's executor lifecycle management
- Defines `_zombie_churn()` helper function that loops 50 times
- Each iteration creates a `_zombie_victim()` function with a hot loop (1000 iterations)
- Calls the victim to trigger Tier 2 compilation
- Lets the victim go out of scope to mark its Executor for `pending_deletion`
- Tests the `pending_deletion` linked list logic for `_PyExecutorObject` cleanup in `pycore_optimizer.h`

## Test plan
- [x] Added 9 tests covering function injection, loop creation, victim function, hot loop, and calls
- [x] All 110 tests in test_scenarios_data.py pass
- [x] Updated CHANGELOG.md

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)