### PR TITLE
fix: Handle non-string keys and RuntimeError in get_jit_stats

### DIFF
--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -68,6 +68,10 @@ def get_jit_stats(namespace: dict) -> dict:
         }
 
     for name, obj in namespace.items():
+        # FIX: The fuzzer might inject bytes keys into globals
+        if not isinstance(name, str):
+            continue
+
         # Skip dunder names and imports
         if name.startswith("_"):
             continue
@@ -88,7 +92,7 @@ def get_jit_stats(namespace: dict) -> dict:
                             if executor is not None:
                                 executor_count += 1
                                 break  # Only count once per function
-                    except (ValueError, TypeError):
+                    except (ValueError, TypeError, RuntimeError):
                         pass
                     functions_scanned += 1
             continue
@@ -102,7 +106,7 @@ def get_jit_stats(namespace: dict) -> dict:
                     if executor is not None:
                         executor_count += 1
                         break  # Only count once per function
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, RuntimeError):
                 pass
 
     return {


### PR DESCRIPTION
## Summary
Fixes two issues in the session fuzzing driver (`lafleur/driver.py`):

### Issue 1: TypeError when fuzzer injects bytes keys into globals
- Added `isinstance(name, str)` check before calling `name.startswith()`
- Prevents "startswith first arg must be bytes" error
- Allows fuzzer to inject any type of key into globals without crashing the driver

### Issue 2: RuntimeError when JIT executors aren't available
- Added `RuntimeError` to exception handling in `get_executor()` calls
- Prevents crashes on Python builds without JIT support
- Gracefully handles "Executors are not available in this build" error

## Test plan
- [x] All 12 tests in tests/test_driver.py pass
- [x] Tested on build without JIT support - no crashes

Fixes #243 

🤖 Generated with [Claude Code](https://claude.com/claude-code)