### PR TITLE
feat: Implement session crash bundles for reproducibility

### DIFF
--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -104,3 +104,4 @@ class ExecutionResult:
     jit_avg_time_ms: float | None = None
     nojit_avg_time_ms: float | None = None
     nojit_cv: float | None = None
+    parent_path: Path | None = None


### PR DESCRIPTION
## Summary
Implements crash bundle saving for session fuzzing mode to enable full reproduction of crashes that depend on JIT state built by earlier scripts.

### Problem
In `--session-fuzz` mode, crashes often depend on JIT state built by the parent (warmup) script. Previously, only the child (attack) script was saved, making reproduction impossible.

### Solution
Added session crash bundle functionality that saves the entire script sequence plus a reproduction script.

## Changes

### 1. New `_save_session_crash()` method in `LafleurOrchestrator`
- Creates unique crash directory: `crashes/session_crash_{timestamp}_{random}/`
- Copies all scripts with sequential prefixes:
  - `00_warmup.py` - Parent/warmup script
  - `01_attack.py` - Child/attack script  
  - `0N_script.py` - Additional scripts (if >2)
- Generates executable `reproduce.sh`:
  ```bash
  #!/bin/bash
  # Session crash reproducer
  # Exit code: <code>
  # Generated: <timestamp>
  
  python3 -m lafleur.driver 00_warmup.py 01_attack.py
  ```

### 2. Modified `_check_for_crash()` to branch on session mode
- **Session mode** (`self.session_fuzz and parent_path is not None`):
  - Calls `_save_session_crash()` with script list
  - Saves crash log to bundle directory
  - Prints bundle location
- **Standard mode** (existing behavior):
  - Saves single child file to crashes/
  - Preserves existing filename format

### 3. Added `parent_path` field to `ExecutionResult` dataclass
- Tracks parent script path for crash bundle creation
- Updated all 5 `ExecutionResult` instantiations in `_execute_child()`
- Updated crash detection call to pass `exec_result.parent_path`

### 4. Safety improvements
- Used `getattr(self, 'session_fuzz', False)` for backwards compatibility with tests
- All crash artifacts use `shutil.copy2()` to preserve metadata

## Test plan
- [x] All 33 tests in `tests/orchestrator/test_crash_detection.py` pass
- [x] Backwards compatibility: tests without `session_fuzz` attribute work correctly
- [x] Code compiles without syntax errors

## Example crash bundle structure
```
crashes/session_crash_20260103_174530_1234/
├── 00_warmup.py
├── 01_attack.py
├── session_signal_SIGSEGV.log
└── reproduce.sh
```

Fixes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)