### PR TITLE
feat: Score JIT vitals to reward interesting states

### DIFF
--- a/tests/orchestrator/test_jit_parsing.py
+++ b/tests/orchestrator/test_jit_parsing.py
@@ -1,0 +1,83 @@
+import unittest
+import json
+from unittest.mock import patch
+from lafleur.orchestrator import LafleurOrchestrator
+
+
+class TestJITParsing(unittest.TestCase):
+    def setUp(self):
+        # We need to mock the orchestrator's init to avoid FS operations
+        with (
+            patch("lafleur.orchestrator.load_coverage_state"),
+            patch("lafleur.orchestrator.load_run_stats"),
+            patch("lafleur.orchestrator.CoverageManager"),
+            patch("lafleur.orchestrator.CorpusManager"),
+            patch("lafleur.orchestrator.MutatorScoreTracker"),
+            patch("pathlib.Path.mkdir"),
+        ):
+            self.orch = LafleurOrchestrator(fusil_path="dummy")
+
+    def test_parse_jit_stats_single_entry(self):
+        """Test parsing a single stats entry."""
+        stats = {
+            "max_exit_count": 10,
+            "max_chain_depth": 2,
+            "zombie_traces": 0,
+            "min_code_size": 100,
+        }
+        log_content = f"Some log\n[DRIVER:STATS] {json.dumps(stats)}\nEnd log"
+
+        parsed = self.orch._parse_jit_stats(log_content)
+
+        self.assertEqual(parsed["max_exit_count"], 10)
+        self.assertEqual(parsed["max_chain_depth"], 2)
+        self.assertEqual(parsed["zombie_traces"], 0)
+        self.assertEqual(parsed["min_code_size"], 100)
+
+    def test_parse_jit_stats_aggregation(self):
+        """Test aggregation of multiple stats entries (session mode)."""
+        stats1 = {
+            "max_exit_count": 10,
+            "max_chain_depth": 5,
+            "zombie_traces": 0,
+            "min_code_size": 100,
+        }
+        stats2 = {
+            "max_exit_count": 50,  # Higher
+            "max_chain_depth": 2,
+            "zombie_traces": 1,  # Higher
+            "min_code_size": 20,  # Lower (better)
+        }
+
+        log_content = (
+            f"[DRIVER:STATS] {json.dumps(stats1)}\n"
+            f"Debug info...\n"
+            f"[DRIVER:STATS] {json.dumps(stats2)}"
+        )
+
+        parsed = self.orch._parse_jit_stats(log_content)
+
+        self.assertEqual(parsed["max_exit_count"], 50)  # Max
+        self.assertEqual(parsed["max_chain_depth"], 5)  # Max
+        self.assertEqual(parsed["zombie_traces"], 1)  # Max
+        self.assertEqual(parsed["min_code_size"], 20)  # Min
+
+    def test_parse_jit_stats_empty(self):
+        """Test parsing logs with no stats."""
+        log_content = "Just some debug info\nNo stats here"
+        parsed = self.orch._parse_jit_stats(log_content)
+
+        self.assertEqual(parsed["max_exit_count"], 0)
+        self.assertEqual(parsed["min_code_size"], 0)
+
+    def test_parse_jit_stats_malformed(self):
+        """Test graceful handling of malformed JSON."""
+        log_content = "[DRIVER:STATS] {invalid_json"
+        parsed = self.orch._parse_jit_stats(log_content)
+
+        # Should return defaults, not crash
+        self.assertEqual(parsed["max_exit_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/orchestrator/test_jit_scoring.py
+++ b/tests/orchestrator/test_jit_scoring.py
@@ -1,0 +1,88 @@
+import unittest
+from lafleur.orchestrator import InterestingnessScorer, NewCoverageInfo
+
+
+class TestJITScoring(unittest.TestCase):
+    def setUp(self):
+        # Base coverage info with no new coverage
+        self.base_coverage = NewCoverageInfo()
+
+        # Standard scorer args
+        self.scorer_args = {
+            "coverage_info": self.base_coverage,
+            "parent_file_size": 100,
+            "parent_lineage_edge_count": 50,
+            "child_file_size": 110,
+            "is_timing_mode": False,
+            "jit_avg_time_ms": None,
+            "nojit_avg_time_ms": None,
+            "nojit_cv": None,
+        }
+
+    def test_zombie_bonus(self):
+        """Test that zombie traces trigger a large bonus."""
+        jit_stats = {"zombie_traces": 1}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 50.0)
+
+    def test_tachycardia_bonus(self):
+        """Test that high exit counts trigger a bonus."""
+        jit_stats = {"max_exit_count": 51}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
+
+        # Check boundary
+        jit_stats = {"max_exit_count": 50}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 0.0)
+
+    def test_chain_bonus(self):
+        """Test that deep chains trigger a bonus."""
+        jit_stats = {"max_chain_depth": 4}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 10.0)
+
+        # Check boundary
+        jit_stats = {"max_chain_depth": 3}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 0.0)
+
+    def test_stub_bonus(self):
+        """Test that small code sizes trigger a bonus."""
+        jit_stats = {"min_code_size": 4}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 5.0)
+
+        # Check boundary
+        jit_stats = {"min_code_size": 5}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 0.0)
+
+        # Zero code size (invalid/none) should be ignored
+        jit_stats = {"min_code_size": 0}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 0.0)
+
+    def test_stacked_bonuses(self):
+        """Test that multiple bonuses stack correctly."""
+        jit_stats = {
+            "zombie_traces": 1,  # +50
+            "max_exit_count": 100,  # +20
+            "max_chain_depth": 5,  # +10
+            "min_code_size": 3,  # +5
+        }
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 85.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
This PR completes the 'JIT EKG' feature loop (Issue #254) by updating the `LafleurOrchestrator` to actively use the JIT vitals exposed by the driver (in PR #253).

## Key Features
- **Feedback-Driven Scoring**: The `InterestingnessScorer` now awards points for specific JIT behaviors:
  - **Zombie Trace Bonus (+50)**: Heavily rewards any mutation that creates a JIT executor marked for deletion (`pending_deletion`). This is a critical state for finding use-after-free bugs.
  - **Tachycardia Bonus (+20)**: Rewards high side-exit counts (`> 50`), indicating fragile optimization guards.
  - **Hyper-Extension Bonus (+10)**: Rewards deep executor chains (`> 3`), probing complex optimization limits.
  - **Stub Bonus (+5)**: Rewards tiny compiled code blocks, often associated with tight loops or degenerate cases.

- **Session Aggregation**: The orchestrator now correctly parses multiple `[DRIVER:STATS]` lines from a single session log (e.g., [Warmup, Attack]) and aggregates them to find the **peak stress** values (max exit count, max depth, etc.) seen anywhere in the session.

- **Data Persistence**: The `jit_stats` are now included in the analysis result, allowing future tooling to track these metrics over time.

## Testing
- Added `tests/orchestrator/test_jit_scoring.py` to verify that bonuses are applied correctly and stack.
- Added `tests/orchestrator/test_jit_parsing.py` to verify that stats are correctly extracted and aggregated from complex session logs.

Closes #254