### PR TITLE
docs: Update developer documentation for Tier 2 Aware Fuzzing

### DIFF
--- a/doc/dev/01_architecture_overview.md
+++ b/doc/dev/01_architecture_overview.md
@@ -17,6 +17,19 @@ The core of `lafleur` is an evolutionary, hill-climbing search algorithm that co
 
 This cycle allows the fuzzer to iteratively build upon its successes, exploring deeper and more complex areas of the JIT's state space over time.
 
+### Session Fuzzing Architecture
+
+To find deep, state-dependent bugs that only appear after prolonged execution or specific memory patterns, `lafleur` supports a **Session Fuzzing** mode (`--session-fuzz`).
+
+In this mode, the fuzzer moves beyond executing isolated scripts. Instead, it constructs a **Session Bundle**—a sequence of scripts executed in a single, shared process. This preserves the JIT's internal state (traces, global watchers, memory layout) across script boundaries.
+
+A typical session follows this "Mixer" strategy:
+1.  **Polluters (The Mixer):** The session optionally begins by executing 1-3 random scripts from the corpus. These serve to "pollute" the JIT's cache, fill Bloom filters, and fragment the memory allocator, creating a hostile environment for the test case.
+2.  **Warmup (The Parent):** The original parent script is executed to establish a known, "warm" JIT state.
+3.  **Attack (The Child):** Finally, the mutated child script is executed. Because the JIT is already warm (and potentially unstable from the polluters), the child can trigger edge cases like "Zombie Traces" (Use-After-Free) or optimization invalidation bugs that isolated execution would miss.
+
+If a crash occurs, `lafleur` saves the entire bundle (polluters, parent, and child) into a directory, ensuring exact reproducibility of the JIT state.
+
 ### High-Level System Diagram
 
 The diagram below illustrates the main components of the `lafleur` fuzzer and the flow of data through the system.
@@ -25,7 +38,7 @@ The diagram below illustrates the main components of the `lafleur` fuzzer and th
 flowchart TD
     subgraph LafleurOrchestrator
         A[1.Select Parent] --> B(2.Mutate);
-        B --> C{3.Execute Child};
+        B --> C{3.Execute Session};
         C --> D[4.Analyze Log];
         D --> E{Interesting?};
     end
@@ -49,8 +62,8 @@ flowchart TD
     F -- Parent File --> A;
     B -- AST --> G;
     G -- Mutated AST --> B;
-    C -- Executable --> I(Subprocess);
-    I -- JIT Log --> H;
+    C -- Bundle --> I(Subprocess / Driver);
+    I -- JIT Log & Vitals --> H;
     H -- Coverage Profile --> D;
     
     E -- Yes --> F;
@@ -68,10 +81,11 @@ flowchart TD
 
 The `lafleur` project is organized into several distinct Python modules, each with a clear responsibility.
 
-  * `lafleur/orchestrator.py`: The "brain" of the fuzzer. Contains the `LafleurOrchestrator` class, which manages the main evolutionary loop and coordinates all other components.
-  * `lafleur/corpus_manager.py`: Handles all interactions with the on-disk corpus and the persistent state file (`coverage_state.pkl`). It is responsible for selecting parents, adding new files, and generating initial seeds.
-  * `lafleur/coverage.py`: The "eyes" of the fuzzer. Contains the logic for parsing verbose JIT trace logs to extract the coverage feedback signal (uop edges and rare events).
-  * `lafleur/mutators/`: The "hands" of the fuzzer. This package contains the `ASTMutator` engine (in `engine.py`) and a rich library of `NodeTransformer` subclasses (in modules like `generic.py`, `scenarios_control.py`, etc.) that perform both generic and highly-specialized, JIT-aware code mutations.
-  * `lafleur/learning.py`: Houses the `MutatorScoreTracker`, the adaptive learning engine that scores mutation strategies based on their historical success, allowing the fuzzer to dynamically focus on the most effective techniques.
-  * `lafleur/utils.py`: A collection of generic, reusable helper components, such as the `TeeLogger` for simultaneous console and file logging, and functions for managing run statistics.
-  * `lafleur/state_tool.py`: A standalone command-line utility for managing the binary state file.
+* `lafleur/orchestrator.py`: The "brain" of the fuzzer. Contains the `LafleurOrchestrator` class, which manages the main evolutionary loop. It now supports **Session Fuzzing**, coordinating the assembly of script bundles and implementing the **Differential Scoring** logic that rewards JIT instability (like high exit density).
+* `lafleur/corpus_manager.py`: Handles all interactions with the on-disk corpus and the persistent state file (`coverage_state.pkl`). It is responsible for selecting parents, adding new files, and generating initial seeds.
+* `lafleur/driver.py`: The execution engine. This standalone script runs the fuzzing sessions. It includes the **JIT Introspection (EKG)** system, which uses `ctypes` to inspect internal C structs (`_PyExecutorObject`) in real-time, extracting vital metrics like exit density and zombie trace counts.
+* `lafleur/coverage.py`: The "eyes" of the fuzzer. Contains the logic for parsing verbose JIT trace logs to extract the coverage feedback signal (uop edges and rare events).
+* `lafleur/mutators/`: The "hands" of the fuzzer. This package contains the `ASTMutator` engine (in `engine.py`) and a rich library of `NodeTransformer` subclasses. It includes advanced **Tier 2 Aware** mutators (e.g., `ZombieTraceMutator`, `GlobalOptimizationInvalidator`) designed to attack specific JIT optimizations.
+* `lafleur/learning.py`: Houses the `MutatorScoreTracker`, the adaptive learning engine that scores mutation strategies based on their historical success, allowing the fuzzer to dynamically focus on the most effective techniques.
+* `lafleur/utils.py`: A collection of generic, reusable helper components, such as the `TeeLogger` for simultaneous console and file logging, and functions for managing run statistics.
+* `lafleur/state_tool.py`: A standalone command-line utility for managing the binary state file.

--- a/doc/dev/02_the_evolutionary_loop.md
+++ b/doc/dev/02_the_evolutionary_loop.md
@@ -4,11 +4,11 @@
 
 The core of `lafleur` is its evolutionary loop, managed by the `LafleurOrchestrator` class in `orchestrator.py`. This document provides a detailed walkthrough of a single fuzzing "session".
 
-The loop is now a highly adaptive process. For each session, it makes a probabilistic choice between a **breadth-first** strategy (exploring a wide variety of parents from the corpus) and a **depth-first** "deepening" strategy (aggressively mutating a single promising lineage). Furthermore, the selection of mutation strategies is no longer static; it is guided by a learning engine that tracks the historical success of each mutator. Finally, to handle non-deterministic bugs, each mutated child can be executed multiple times.
+The loop is now a highly adaptive process. For each session, it makes a probabilistic choice between a **breadth-first** strategy (exploring a wide variety of parents from the corpus) and a **depth-first** "deepening" strategy (aggressively mutating a single promising lineage). Furthermore, the selection of mutation strategies is guided by a learning engine, and the execution phase can now run complex **multi-script sessions** to stress the JIT's state persistence.
 
 ### Flowchart of a Fuzzing Session
 
-The following diagram illustrates the complete logical flow, including the deepening and multi-run execution loops.
+The following diagram illustrates the complete logical flow, including the new session construction and differential scoring steps.
 
 ```mermaid
 graph TD
@@ -19,15 +19,16 @@ graph TD
     subgraph "Mutation Cycle (execute_mutation_and_analysis_cycle)"
         B --> C[Calculate Mutations & Runs for Parent];
         C --> D{Mutate Parent -> C1};
-        D --> E[Start Multi-Run Loop for C1];
+        D --> D1{Assemble Session Bundle};
+        D1 --> E[Start Multi-Run Loop];
         subgraph " "
-        E --> F{Execute C1 - Run #1};
-        F --> G{Analyze Result};
+        E --> F{Execute Session (Mixer + Parent + C1)};
+        F --> G{Analyze Result & JIT Vitals};
         G --> H{Interesting?};
         H -- No --> I{More Runs Left?};
         H -- Yes --> L[Update Mutator Scores];
-        I -- Yes --> F2[Execute C1 - Run #2];
-        F2 --> G2{Analyze Result};
+        I -- Yes --> F2[Execute Session - Run #2];
+        F2 --> G2{Analyze Result...};
         G2 --> H2{Interesting?};
         H2 -- No --> I2[...];
         I -- No --> J{More Mutations Left?};
@@ -47,11 +48,13 @@ graph TD
 
     style A fill:#d4edda,stroke:#333,stroke-width:2px
     style B2 fill:#cce5ff,stroke:#333,stroke-width:2px
+    style D1 fill:#fff3cd,stroke:#333,stroke-width:2px
+
 ```
 
 ### **Step-by-Step Analysis of a Fuzzing Session**
 
-The modern lafleur session is a dynamic, multi-stage process. The following steps detail the complete lifecycle, combining the foundational evolutionary model with the newer adaptive and non-deterministic strategies.
+The modern lafleur session is a dynamic, multi-stage process. The following steps detail the complete lifecycle, combining the foundational evolutionary model with advanced state-fuzzing strategies.
 
 ### Step 1: Parent and Strategy Selection
 
@@ -62,43 +65,52 @@ The fuzzing session begins in the `run_evolutionary_loop` method. The first step
       * **Rarity:** Files that contain coverage features (specifically, stateful uop edges) that are globally rare receive a significant score bonus.
       * **Fertility:** Files that have historically produced many "interesting" children are considered more "fertile" and are rewarded. Conversely, files that have been mutated many times without producing new discoveries are marked as "sterile" and are heavily penalized.
       * **Depth:** Files that are the result of a long, successful chain of mutations (a deep lineage) receive a small score bonus to encourage exploration of deep states.
-      * **Structural Feedback:** Files that produce longer JIT traces and a higher number of side-exits are rewarded, as this indicates they are exercising the optimizer more thoroughly.
-  * **Selection:** The orchestrator performs a weighted random selection on the corpus, where the weight for each file is the score calculated by the scheduler. This ensures that while high-scoring parents are heavily favored, lower-scoring ones still have a chance to be chosen, preventing stagnation.
-  * **Strategy Choice:** Once a parent is selected, the orchestrator makes a probabilistic choice. With a 20% chance, the session is designated a **depth-first "deepening" session**; otherwise, it's a standard **breadth-first session**.
+      * **JIT Instability:** Files that have previously demonstrated high JIT "Tachycardia" (high exit density) are rewarded to encourage further stress testing of that instability.
+  * **Selection:** The orchestrator performs a weighted random selection on the corpus, where the weight for each file is the score calculated by the scheduler.
+  * **Strategy Choice:** Once a parent is selected, the orchestrator makes a probabilistic choice (default 20%) to enter a **depth-first "deepening" session**, where the loop will immediately switch to mutating any interesting child found, creating deep lineages rapidly.
 
 ### Step 2: Adaptive Mutation
 
 With a parent and a strategy selected, the orchestrator reads the parent's source code and parses its "core" part into an Abstract Syntax Tree (AST). The `base_harness_node` (e.g., `uop_harness_f1`) is identified and passed to the `apply_mutation_strategy` method.
 
-  * **Adaptive Strategy Selection:** This method no longer uses hardcoded weights. It consults the `MutatorScoreTracker` from `lafleur/learning.py` to get dynamic weights for each high-level strategy based on their recent success in finding new coverage. It then probabilistically chooses one of the following:
-      * **Deterministic:** Applies a small (1-3) number of seeded transformations.
-      * **Havoc:** Applies a large number (15-50) of different, randomly chosen transformations.
-      * **Spam:** Applies the same transformation 20-50 times to aggressively exercise a single mutator.
-  * **Code Normalization & Sanitization:** Before applying the chosen strategy, a `FuzzerSetupNormalizer` is run on the parent's AST to remove any fuzzer-injected code from previous generations. After the mutation is applied, a final `EmptyBodySanitizer` pass ensures no control flow statements have empty bodies, preventing `IndentationError` crashes.
+* **Adaptive Strategy Selection:** This method consults the `MutatorScoreTracker` to get dynamic weights for each high-level strategy (Deterministic, Havoc, Spam) based on their recent success.
+* **Code Normalization & Sanitization:** A `FuzzerSetupNormalizer` removes old setup code, and an `EmptyBodySanitizer` ensures no control flow statements have empty bodies, preventing syntax errors.
+* **Tier 2 Aware Mutation:** The engine applies specific JIT-breaking patterns, such as `ZombieTraceMutator` (stressing executor lifecycles) or `GlobalOptimizationInvalidator` (breaking global assumptions mid-loop).
 
 The result of this phase is a new, mutated AST for the harness function.
 
-### Step 3: Multi-Run Child Execution
+### Step 3: Session Assembly and Execution
 
-The orchestrator takes the mutated harness AST and reassembles the full script for the child test case. It creates a complete copy of the parent's AST and replaces the old harness function with the newly mutated one. The final tree is then **unparsed** back into a string of Python code.
+Unlike simpler fuzzers that execute the child script in isolation, `lafleur` assembles a **Session Bundle** to test state persistence and JIT cache coherency.
 
-  * **Multi-Run Loop:** To handle non-deterministic bugs, the orchestrator enters an inner loop to execute the child multiple times. The number of runs can be a static value from the `--runs` flag or a dynamic value calculated from the parent's score if `--dynamic-runs` is used.
-  * **Reproducible Non-determinism:** For each run, a unique but deterministic **`runtime_seed`** is generated. This seed is injected into the child's script to initialize an internal `fuzzer_rng` object. This allows any `if fuzzer_rng.random() < ...:` branches to behave differently on each run, while ensuring the entire process can be reproduced.
-  * **Subprocess Execution:** The code is written to a temporary file and executed in an isolated `subprocess`. Critically, the subprocess is launched with the necessary environment variables (`PYTHON_JIT=1`, `PYTHON_LLTRACE=2`, etc.) to enable the JIT and capture its verbose debug logs. The orchestrator waits for the process to complete (or time out) and captures its results.
+1. **The Mixer (Pollution):** With a configurable probability (default 30%), the orchestrator selects 1-3 random "polluter" scripts from the corpus. These are prepended to the session to fill Bloom filters, fragment memory, and stress the JIT's global watchers before the test even begins.
+2. **The Warmup:** The original **Parent** script is added to the bundle. Running it first ensures the JIT has "warmed up" traces relevant to the lineage.
+3. **The Attack:** The mutated **Child** script is added last. It attacks the JIT state established by the previous scripts.
 
-### Step 4: Analysis, Corpus Update, and Loop Control
+The orchestrator then executes this bundle using the `lafleur.driver` module. The driver runs all scripts sequentially in a **single shared process**. This ensures that JIT traces, type feedback, and memory layouts persist from the polluters/parent to the child.
 
-The result of each run is passed to the `analyze_run` method, which performs the final, critical steps. This process has been significantly enhanced to move beyond a simple "new or not new" check and now uses a multi-factor scoring system to evaluate the quality of a discovery.
+* **JIT Introspection (The EKG):** During execution, the driver uses `ctypes` to inspect the internal `_PyExecutorObject` structs of the JIT. It records vital signs like **Exit Density** (bailouts per instruction) and **Zombie Traces** (`pending_deletion` flags).
 
-1.  **Error Checking:** The method first checks for crashes or correctness divergences. If an error is found, the test case is saved to the appropriate directory (`crashes/` or `divergences/`), and the analysis for that run concludes.
-2.  **Coverage Parsing:** If no crash occurred, the log file is parsed to extract the child's complete coverage profile.
-3.  **Interestingness Scoring:** The orchestrator no longer uses a simple boolean check. Instead, it uses a dedicated `InterestingnessScorer` to calculate a score based on several heuristics that measure the value of the mutation:
-    * **Global Discoveries**: The score is heavily weighted towards finding **new global coverage**—edges, uops, or rare events never before seen in the campaign. This is the most valuable outcome.
-    * **Relative Discoveries**: A smaller number of points are awarded for finding **new relative coverage**—items that are new to the parent's specific lineage but have been seen elsewhere.
-    * **Richness**: The scorer compares the child's total number of unique edges to its parent's lineage. Children that are significantly "richer" (i.e., have a higher percentage of total coverage) receive a score bonus.
-    * **Coverage Density**: The scorer penalizes mutations that result in a large file size increase for a minimal gain in new coverage. This helps keep the corpus small and efficient.
-4.  **Threshold Check:** A child is only considered "interesting" if its final score exceeds a predefined threshold. This ensures that only high-value mutations are added to the corpus.
-5.  **Duplicate Check:** An interesting child is still checked for duplication. It is considered a duplicate only if it has both the same **`content_hash`** and the same **`coverage_hash`** as a previously seen test case.
-6.  **Corpus Commit & Loop Control:** If a child is both interesting (its score is high enough) and unique, it is saved to the corpus, and the fuzzer's state is updated.
-    * **If in a Breadth-first Session:** The discovery of an interesting child causes the entire mutation cycle for the current parent to end, and the fuzzer moves on to select a new parent.
-    * **If in a Depth-first Session:** The new interesting child immediately becomes the **new parent**, and the loop continues by mutating this new file.
+### Step 4: Analysis, Scoring, and Feedback
+
+The result of the session is passed to the `analyze_run` method. This process has been enhanced with **Differential Vital Scoring** to reward JIT instability.
+
+1. **Error Checking & Crash Bundles:**
+* If a crash occurs, the orchestrator saves the **entire session bundle** (polluters, parent, child) into a directory (e.g., `crashes/session_crash_123/`).
+* It also generates a `reproduce.sh` script, ensuring the crash can be deterministically reproduced with the exact same JIT state.
+
+2. **Coverage & Vitals Parsing:**
+* The log file is parsed to extract the coverage profile (edges, rare events).
+* The JIT Vitals are parsed: `max_exit_density`, `zombie_traces`, `chain_depth`.
+
+3. **Interestingness Scoring:**
+The `InterestingnessScorer` evaluates the child using a multi-factor system:
+* **New Coverage:** Heavy weight for new global edges or rare events.
+* **Zombie Bonus:** Massive reward (+50) if any `zombie_traces` were detected (potential Use-After-Free).
+* **Differential Tachycardia:** The scorer compares the child's `max_exit_density` to its parent's. It only awards a bonus if the child is **significantly more unstable** (e.g., > 25% higher density) than the parent. This prevents lineages from coasting on inherited instability.
+
+4. **Dynamic Density Clamping:**
+If a child produces an extremely high density (e.g., 9,000,000), the value saved to the corpus metadata is **clamped** using a trailing limit (e.g., `min(parent * 5, child)`). This ensures future generations have a reachable target to beat, preventing "fitness cliffs" where a lineage dies out because it became too successful too quickly.
+
+5. **Corpus Commit:**
+If the child is interesting and unique, it is saved to the corpus. Its metadata includes the new JIT vitals, which will be used as the baseline for the next generation of mutations.

--- a/doc/dev/03_coverage_and_feedback.md
+++ b/doc/dev/03_coverage_and_feedback.md
@@ -31,10 +31,41 @@ The `lafleur/coverage.py` module is responsible for transforming the raw, unstru
 
 The main function, `parse_log_for_edge_coverage`, uses a series of regular expressions to process the log file line by line. It is implemented as a **state machine** that tracks the JIT's current operational state and identifies several key pieces of information:
 
-1.  **Harness Markers (`[f1]`)**: These markers allow the parser to attribute all subsequent coverage to a specific harness function within the test case.
-2.  **JIT State Transitions**: The parser looks for keywords like `Created a proto-trace` and `Optimized trace` to determine if the JIT is currently in the `TRACING` or `OPTIMIZED` state.
-3.  **Micro-operations (uops)**: It looks for lines indicating a uop was added to a trace or executed (e.g., `ADD_TO_TRACE: _LOAD_ATTR`).
-4.  **Rare Events**: It scans for a curated list of strings that signal a JIT bailout, failure, or other interesting non-standard behavior (e.g., `Bailing on recursive call`).
+1. **Harness Markers (`[f1]`)**: These markers allow the parser to attribute all subsequent coverage to a specific harness function within the test case.
+2. **JIT State Transitions**: The parser looks for keywords like `Created a proto-trace` and `Optimized trace` to determine if the JIT is currently in the `TRACING` or `OPTIMIZED` state.
+3. **Micro-operations (uops)**: It looks for lines indicating a uop was added to a trace or executed (e.g., `ADD_TO_TRACE: _LOAD_ATTR`).
+4. **Rare Events**: It scans for a curated list of strings that signal a JIT bailout, failure, or other interesting non-standard behavior (e.g., `Bailing on recursive call`).
+
+-----
+
+### JIT Introspection (The EKG)
+
+Beyond text log parsing, `lafleur` employs a powerful runtime introspection system nicknamed "The JIT EKG" (Electrocardiogram). Located in `lafleur/driver.py`, this system uses Python's `ctypes` library to bridge the gap between Python and C, allowing the fuzzer to inspect the internal state of the JIT compiler's data structures directly.
+
+Specifically, it maps the opaque `_PyExecutorObject` C struct (defined in `pycore_optimizer.h`) to a Python `ctypes.Structure`. This gives the fuzzer X-ray vision into the `vm_data` fields that are normally hidden from the Python runtime.
+
+#### Monitored Vitals
+
+The EKG monitors several "vital signs" of the JIT's health. Abnormal values in these metrics are often precursors to crashes or state corruption bugs.
+
+* **Exit Density (`exit_count / code_size`)**: This is the most critical metric for detecting "JIT Tachycardia" (thrashing).
+* **What it measures**: The ratio of how often a trace "bails out" (deoptimizes) relative to its length.
+* **Why it matters**: A high density (e.g., > 10.0) means the JIT compiled a trace that is failing to run to completion almost every time. This usually indicates a deoptimization loop or a guard that is constantly failing, stressing the bailout machinery.
+
+
+* **Zombie Traces (`pending_deletion`)**:
+* **What it measures**: The number of JIT traces that have been marked for deletion but have not yet been freed.
+* **Why it matters**: This is the "Holy Grail" state for finding Use-After-Free bugs. If the fuzzer can trigger execution while `pending_deletion` is non-zero, it is hitting a race condition in the executor lifecycle management.
+
+
+* **Chain Depth**:
+* **What it measures**: The length of the linked list of optimized traces chained together.
+* **Why it matters**: Extremely deep chains can violate stack depth assumptions or abstract interpretation limits, leading to potential overflows or logic errors.
+
+
+* **Code Size (Hypoplasia)**:
+* **What it measures**: The number of micro-ops in the generated trace.
+* **Why it matters**: Extremely short traces (1-5 uops) often indicate "optimization stubs"—attempts to compile that were aborted early. Detecting these helps identify code patterns that confuse the optimizer.
 
 -----
 
@@ -60,8 +91,6 @@ The output of the parser is a "coverage profile," which is a dictionary containi
 
 The `analyze_run` method within the `LafleurOrchestrator` is the final step in the feedback loop. It takes the coverage profile from the parser and decides if the child test case is "interesting" enough to be saved. To ensure state consistency, it uses a robust **two-pass system**.
 
-1.  **Pass 1: Read-Only Check**: The method first performs a read-only check. It compares the child's coverage against the `global_coverage` map (all coverage ever seen) and the parent's `lineage_coverage_profile` (all coverage seen in its ancestry). If a stateful edge or rare event is found that is not in the global map, it's a **new global discovery**. If it's not new globally but is new to its lineage, it's a **new relative discovery**. In either case, an `is_interesting` flag is set to `True`. The main `global_coverage` state is **not** modified during this pass.
-
-2.  **Duplicate Check**: If the child is deemed interesting, its `content_hash` (from its source code) and a new **`coverage_hash`** (from its specific execution behavior) are calculated. A child is now considered a duplicate only if the tuple `(content_hash, coverage_hash)` has been seen before. This allows the fuzzer to save multiple copies of the same source file if they produce different, non-deterministic behaviors.
-
-3.  **Pass 2: Commit**: Only if the child is interesting AND not a duplicate does the orchestrator proceed to the commit phase. In this pass, the `_update_global_coverage` method is called to add the new coverage to the main `global_coverage` map, and the `CorpusManager` is called to save the new file to the corpus and persist the updated state to disk.
+1. **Pass 1: Read-Only Check**: The method first performs a read-only check. It compares the child's coverage against the `global_coverage` map (all coverage ever seen) and the parent's `lineage_coverage_profile` (all coverage seen in its ancestry). If a stateful edge or rare event is found that is not in the global map, it's a **new global discovery**. If it's not new globally but is new to its lineage, it's a **new relative discovery**. In either case, an `is_interesting` flag is set to `True`. The main `global_coverage` state is **not** modified during this pass.
+2. **Duplicate Check**: If the child is deemed interesting, its `content_hash` (from its source code) and a new **`coverage_hash`** (from its specific execution behavior) are calculated. A child is now considered a duplicate only if the tuple `(content_hash, coverage_hash)` has been seen before. This allows the fuzzer to save multiple copies of the same source file if they produce different, non-deterministic behaviors.
+3. **Pass 2: Commit**: Only if the child is interesting AND not a duplicate does the orchestrator proceed to the commit phase. In this pass, the `_update_global_coverage` method is called to add the new coverage to the main `global_coverage` map, and the `CorpusManager` is called to save the new file to the corpus and persist the updated state to disk.

--- a/doc/dev/04_mutation_engine.md
+++ b/doc/dev/04_mutation_engine.md
@@ -80,6 +80,10 @@ This is a library of advanced mutators specifically designed to generate pattern
 * **`CodeObjectSwapper`**: Attacks function execution by hot-swapping the `__code__` object of a function with that of another, incompatible function.
 * **`SysMonitoringMutator`**: Attacks the `sys.monitoring` interactions by registering and unregistering tool IDs during execution.
 * **`AsyncConstructMutator`**: Attacks async-specific UOPs by generating complex `async for` and `async with` patterns.
+* **`GlobalOptimizationInvalidator`**: Attacks **"Global-to-Constant Promotion"**. It targets the JIT's optimization that treats globals (like `range`) as constants. It injects a hot loop that uses a global, then swaps that global for an incompatible object (e.g., a dummy callable) mid-execution, forcing a complex deoptimization or a crash if the guard fails.
+* **`CodeObjectHotSwapper`**: Attacks the **`_RETURN_GENERATOR`** opcode. It compiles a generator function, then hot-swaps the function's `__code__` object with one from a different generator, and calls it again. This tests if the JIT holds onto stale `CodeObject` pointers or cached creation paths.
+* **`TypeShadowingMutator`**: Attacks **`_GUARD_TYPE_VERSION`**. It tricks the JIT into optimizing a variable as one type (e.g., `float`), then uses `sys._getframe().f_locals` to overwrite that variable with an incompatible type (e.g., `str`) behind the JIT's back, immediately followed by an operation that requires the original type.
+* **`ZombieTraceMutator`**: Attacks the **Executor Lifecycle** and memory management (`pending_deletion`). It rapidly creates and destroys closures (and their associated JIT traces) in a loop to stress the garbage collector and the JIT's linked list of executors, aiming to trigger Use-After-Free bugs or race conditions.
 
 ---
 

--- a/doc/dev/05_state_and_data_formats.md
+++ b/doc/dev/05_state_and_data_formats.md
@@ -28,6 +28,7 @@ It contains a single dictionary with the following top-level keys:
     * `is_sterile`: A boolean flag that is set to `True` if the parent has been mutated many times without producing any new discoveries.
     * `baseline_coverage`: A dictionary representing the coverage this specific file generated when it was discovered. It includes `uops`, `edges`, `rare_events`, and structural metrics like `trace_length` and `side_exits`.
     * `lineage_coverage_profile`: A set-based representation of the union of all coverage found in this file's entire ancestry.
+    * **`mutation_info`**: A dictionary containing extra data about the mutation process that created this file. Crucially, it now stores **JIT Vitals** (e.g., `max_exit_density`, `zombie_traces`) used for differential scoring in future generations. Note that metrics like `max_exit_density` may be "clamped" here to ensure reachable targets for offspring.
 
 ---
 
@@ -85,5 +86,10 @@ The fuzzer saves its findings—the valuable test cases that reveal bugs—into 
 
 * **`corpus/`**: Contains the main collection of "interesting" test cases that have discovered new JIT coverage.
 * **`crashes/`**: Stores test cases that caused the Python interpreter to crash or that contained a keyword indicating a fatal error.
+    * **Standard Mode:** Contains individual files like `crash_123.py`.
+    * **Session Mode:** Contains **Session Bundles**—directories (e.g., `session_crash_123/`) that preserve the full context needed to reproduce the bug. These include:
+        * `00_polluter.py`, `01_warmup.py`: The context scripts that set up the JIT state.
+        * `02_attack.py`: The mutated child script that triggered the crash.
+        * `reproduce.sh`: A generated script to run the bundle in the correct order.
 * **`timeouts/`**: Stores test cases that caused the child process to hang. Large log files in this directory are automatically compressed with `zstd`.
 * **`divergences/`**: When running in differential testing mode, this directory stores test cases that revealed a correctness bug.

--- a/doc/dev/06_developer_getting_started.md
+++ b/doc/dev/06_developer_getting_started.md
@@ -17,7 +17,7 @@ To make fuzzing easier and more effective, `lafleur` includes a script for adjus
 1.  **Clone the CPython Repository:** First, clone the CPython source code from the official repository. It is recommended to check out the specific commit or branch that `lafleur` is currently targeting to ensure compatibility.
 
     ```bash
-    git clone https://github.com/python/cpython.git
+    git clone [https://github.com/python/cpython.git](https://github.com/python/cpython.git)
     cd cpython
     ```
 
@@ -56,7 +56,7 @@ Once the prerequisites are met, installing `lafleur` is straightforward.
 2.  **Clone the `lafleur` Repository:**
 
     ```bash
-    git clone https://github.com/devdanzin/lafleur.git
+    git clone [https://github.com/devdanzin/lafleur.git](https://github.com/devdanzin/lafleur.git)
     cd lafleur
     ```
 
@@ -101,6 +101,13 @@ With the project installed, you can run the fuzzer from any directory on your sy
     lafleur --fusil-path /path/to/fusil/fuzzers/fusil-python-threaded
     ```
 
+  * **Running in Session Mode (JIT State Fuzzing):**
+    To enable stateful fuzzing, use the `--session-fuzz` flag. This executes scripts in a shared process (Parent -> Child) and injects random "polluter" scripts to stress the JIT's cache and memory management. This is highly effective for finding "Zombie Traces" (Use-After-Free) and optimization invalidation bugs.
+
+    ```bash
+    lafleur --fusil-path /path/to/fusil/fuzzers/fusil-python-threaded --session-fuzz
+    ```
+
   * **Running in Differential Testing Mode:**
     To enable the "Paired Harness" mode for finding correctness bugs, add the `--differential-testing` flag.
 
@@ -119,7 +126,7 @@ With the project installed, you can run the fuzzer from any directory on your sy
     lafleur --fusil-path /path/to/fusil/fuzzers/fusil-python-threaded --dynamic-runs
     ```
 
-* **Retaining Logs for Analysis:**
+  * **Retaining Logs for Analysis:**
     To keep temporary log files for offline analysis and debugging, use the `--keep-tmp-logs` flag.
 
     ```bash


### PR DESCRIPTION
## Description
This PR updates the developer documentation to reflect the significant architectural changes and new features introduced in the 'Tier 2 Aware Fuzzing' milestone.

## Changes
- **01_architecture_overview.md**: Added 'Session Fuzzing Architecture' section and updated the module breakdown to include `driver.py` and JIT introspection.
- **02_the_evolutionary_loop.md**: Documented 'The Mixer' strategy (polluters) and the new 'Differential Vital Scoring' logic in the analysis phase.
- **03_coverage_and_feedback.md**: Added a major section 'JIT Introspection (The EKG)' detailing the new metrics: `exit_density`, `zombie_traces`, `chain_depth`, and `code_size`.
- **04_mutation_engine.md**: Added descriptions for the 4 new Tier 2 mutators: `GlobalOptimizationInvalidator`, `CodeObjectHotSwapper`, `TypeShadowingMutator`, and `ZombieTraceMutator`.
- **05_state_and_data_formats.md**: Updated output directories to describe 'Session Crash Bundles' and the `reproduce.sh` artifact.
- **06_developer_getting_started.md**: Added CLI examples and explanation for the `--session-fuzz` flag.

Fixes #264