### PR TITLE
feat: Add hyperlinks to issue numbers in HTML reports

### DIFF
--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -561,12 +561,14 @@ def generate_html_report(aggregator: CampaignAggregator) -> str:
             badge = '<span class="badge new">NEW</span>'
 
         # Format issue link
-        if info.issue_number and info.issue_url:
-            issue_html = (
-                f'<a href="{html.escape(info.issue_url)}" target="_blank">#{info.issue_number}</a>'
+        if info.issue_number:
+            # Use provided URL or default to CPython issues tracker
+            issue_url = (
+                info.issue_url or f"https://github.com/python/cpython/issues/{info.issue_number}"
             )
-        elif info.issue_number:
-            issue_html = f"#{info.issue_number}"
+            issue_html = (
+                f'<a href="{html.escape(issue_url)}" target="_blank">#{info.issue_number}</a>'
+            )
         else:
             issue_html = "-"
 


### PR DESCRIPTION
## Summary
Issue numbers in the campaign HTML report crash table are now clickable links.

## Changes
When an issue number is present in the crash data:
- Uses the `issue_url` from the registry if available
- Falls back to `https://github.com/python/cpython/issues/<number>` otherwise

Links open in a new tab (`target="_blank"`).

## Before
```
#12345
```

## After
```html
<a href="https://github.com/python/cpython/issues/12345" target="_blank">#12345</a>
```

Fixes #306

---
Generated with [Claude Code](https://claude.com/claude-code)