### PR TITLE
feat: Split mutation statistics into strategies vs. mutators

### DIFF
--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -416,15 +416,25 @@ def generate_report(instance_dir: Path) -> str:
         lines.append(f"Avg File Size:  {format_number(avg_size, ' bytes') if avg_size else 'N/A'}")
         lines.append(f"Avg Exec Time:  {format_number(avg_exec, ' ms') if avg_exec else 'N/A'}")
 
-        # Top mutations
-        successful_mutations = corpus_stats.get("successful_mutations", {})
-        if successful_mutations:
-            # Get top 3 mutations
-            top_mutations = list(successful_mutations.items())[:3]
-            top_str = ", ".join(f"{name} ({count})" for name, count in top_mutations)
-            lines.append(f"Top Mutations:  {top_str}")
+        # Top strategies (with backwards compatibility)
+        successful_strategies = corpus_stats.get("successful_strategies", {})
+        if not successful_strategies:
+            successful_strategies = corpus_stats.get("successful_mutations", {})
+        if successful_strategies:
+            top_strategies = list(successful_strategies.items())[:3]
+            top_str = ", ".join(f"{name} ({count})" for name, count in top_strategies)
+            lines.append(f"Top Strategies: {top_str}")
         else:
-            lines.append("Top Mutations:  N/A")
+            lines.append("Top Strategies: N/A")
+
+        # Top mutators
+        successful_mutators = corpus_stats.get("successful_mutators", {})
+        if successful_mutators:
+            top_mutators = list(successful_mutators.items())[:3]
+            top_str = ", ".join(f"{name} ({count})" for name, count in top_mutators)
+            lines.append(f"Top Mutators:   {top_str}")
+        else:
+            lines.append("Top Mutators:   N/A")
     else:
         lines.append("No corpus statistics available.")
 


### PR DESCRIPTION
## Summary
Separates the "Top Mutations" section into two distinct lists:
- **Top Strategies**: High-level mutation approaches (havoc, spam, deterministic, slicing, sniper, etc.)
- **Top Mutators**: Individual AST transformers (StatementDuplicator, GuardInjector, TypeInstabilityInjector, etc.)

This provides better visibility into which strategies and which specific mutators are most effective at finding interesting behavior.

## Changes

### corpus_analysis.py
- Track transformers separately in `mutator_counter`
- Output both `successful_strategies` and `successful_mutators` in corpus stats

### campaign.py
- Aggregate both strategies and mutators from corpus stats
- Add `get_top_strategies()` and `get_top_mutators()` methods
- Update text report to show both lists
- Update HTML report to show both lists
- Backwards compatible with old `successful_mutations` field

### report.py
- Update single-instance report to show both strategies and mutators
- Backwards compatible with old data format

## Example Output

### Text Report
```
Top Strategies: havoc (1,234), spam (567), deterministic (234)
Top Mutators:   StatementDuplicator (890), GuardInjector (456), TypeInstabilityInjector (234)
```

### HTML Report
Both lists shown in the Fleet Corpus Summary section with styled badges.

Fixes #307

---
Generated with [Claude Code](https://claude.com/claude-code)