### PR TITLE
feat: Add UnpackingChaosMutator to attack JIT unpacking optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project should be documented in this file.
 ### Added
 
 - GitHub Actions CI/CD workflow with lint, format, and JIT test jobs, by @devdanzin.
+- An `UnpackingChaosMutator` that attacks JIT optimizations for `UNPACK_SEQUENCE` and `UNPACK_EX` by wrapping iterables in a chaotic iterator that lies about its length and changes behavior (grow, shrink, type_switch) after JIT warmup to trigger deoptimization bugs, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -69,6 +69,7 @@ from lafleur.mutators.scenarios_data import (
     ReentrantSideEffectMutator,
     StackCacheThrasher,
     TypeShadowingMutator,
+    UnpackingChaosMutator,
     ZombieTraceMutator,
 )
 from lafleur.mutators.scenarios_runtime import (
@@ -179,6 +180,7 @@ class ASTMutator:
             CodeObjectHotSwapper,
             TypeShadowingMutator,
             ZombieTraceMutator,
+            UnpackingChaosMutator,
             GCInjector,
             DictPolluter,
             FunctionPatcher,


### PR DESCRIPTION
## Summary

- Add `UnpackingChaosMutator` that targets JIT optimizations for `UNPACK_SEQUENCE` and `UNPACK_EX` operations
- Wraps iterables in a `_JitChaosIterator` helper class that:
  - Lies about length via `__length_hint__` to confuse pre-allocation optimizations
  - Changes behavior after JIT warmup (configurable trigger count)
  - Supports three modes: `grow` (extra items), `shrink` (stop early), `type_switch` (wrong type)
- Transforms unpacking assignments and for loop unpacking targets
- Includes 15 comprehensive tests

Closes #336

## Test plan

- [x] All 15 new `TestUnpackingChaosMutator` tests pass
- [x] Full test suite passes (1118 tests)
- [x] `ruff check` passes
- [x] `ruff format` passes  
- [x] `mypy lafleur` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)