### PR TITLE
feat: Add EvalFrameHookMutator to attack JIT eval frame assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project should be documented in this file.
 - An `UnpackingChaosMutator` that attacks JIT optimizations for `UNPACK_SEQUENCE` and `UNPACK_EX` by wrapping iterables in a chaotic iterator that lies about its length and changes behavior (grow, shrink, type_switch) after JIT warmup to trigger deoptimization bugs, by @devdanzin.
 - A `PatternMatchingChaosMutator` that attacks JIT optimizations for structural pattern matching (`MATCH_MAPPING`, `MATCH_SEQUENCE`, `MATCH_CLASS`) by injecting classes with dynamic `__match_args__`, guards with side effects, type-switching subjects, walrus operators in guards, and converting `isinstance` checks and for-loop unpacking to match statements, by @devdanzin.
 - A `ClosureStompMutator` that attacks JIT closure optimizations by injecting helper functions to randomly corrupt `func.__closure__[i].cell_contents`, invalidating type/value assumptions for nested functions, by @devdanzin.
+- An `EvalFrameHookMutator` that targets the `set_eval_frame_func` rare event by installing/removing custom eval frame hooks mid-execution, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -81,6 +81,7 @@ from lafleur.mutators.scenarios_runtime import (
     SideEffectInjector,
     StressPatternInjector,
     WeakRefCallbackChaos,
+    EvalFrameHookMutator,
 )
 from lafleur.mutators.scenarios_types import (
     CodeObjectSwapper,
@@ -206,6 +207,7 @@ class ASTMutator:
             SuperResolutionAttacker,
             CoroutineStateCorruptor,
             WeakRefCallbackChaos,
+            EvalFrameHookMutator,
             ExceptionHandlerMaze,
             BuiltinNamespaceCorruptor,
             CodeObjectSwapper,


### PR DESCRIPTION
## Summary

- Adds `EvalFrameHookMutator` that targets the `set_eval_frame_func` rare event
- Installs/removes custom eval frame hooks mid-execution to force JIT deoptimization
- Uses `_testinternalcapi.set_eval_frame_record` and `set_eval_frame_default`

## Attack Scenarios

1. **frame_record_toggle**: Warmup without recording, then toggle frame recording on/off
2. **custom_eval_install**: Install custom eval after JIT has compiled the hot path
3. **eval_default_cycle**: Rapidly cycle between eval modes (20 cycles) to stress deoptimization

## Implementation Details

- Imports `_testinternalcapi` via `test.support.import_helper` for safety
- Wraps attacks in try/except to handle missing module gracefully
- Uses unique prefixes (eval_XXXX) to avoid variable collisions
- 15% injection probability

## Test plan

- [x] 15 new tests covering all attack scenarios
- [x] All tests pass
- [x] mypy clean
- [x] ruff format/check clean

Closes #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)