### PR TITLE
Add TypeVersionInvalidator mutator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project should be documented in this file.
 - A `ComprehensiveFunctionMutator` that systematically attacks all function modification rare events, by @devdanzin.
 - A `DynamicClassSwapper` that aggressively swaps objects between incompatible classes (built-in type subclasses, classes with/without `__slots__`, different MRO depths, incompatible `__dict__` attributes) to stress JIT type guards and deoptimization logic, targeting the `set_class` rare event, by @devdanzin.
 - A `BasesRewriteMutator` that creatively manipulates `__bases__` tuples (removal, builtin injection, inheritance toggling, complete replacement) to attack MRO caching assumptions, targeting the `set_bases` rare event, by @devdanzin.
+- A `TypeVersionInvalidator` that targets `_GUARD_TYPE_VERSION` by modifying class attributes at runtime (method injection, method replacement, attribute injection, dict modification) to invalidate JIT type caches, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -97,6 +97,7 @@ from lafleur.mutators.scenarios_types import (
     SuperResolutionAttacker,
     TypeInstabilityInjector,
     TypeIntrospectionMutator,
+    TypeVersionInvalidator,
 )
 from lafleur.mutators.utils import RedundantStatementSanitizer
 from lafleur.mutators.helper_injection import HelperFunctionInjector
@@ -208,6 +209,7 @@ class ASTMutator:
             MROShuffler,
             BasesRewriteMutator,
             DynamicClassSwapper,
+            TypeVersionInvalidator,
             FrameManipulator,
             ComprehensionBomb,
             SuperResolutionAttacker,


### PR DESCRIPTION
## Summary

Adds `TypeVersionInvalidator` mutator that targets `_GUARD_TYPE_VERSION` by modifying class attributes at runtime to invalidate JIT type caches.

## Attack Scenarios

1. **method_injection**: Add new methods to classes after warmup
   - Lambda methods
   - Full function methods
   - Properties
   - Via `type.__setattr__`

2. **method_replacement**: Replace existing methods with different implementations
   - Replace with new function
   - Replace with lambda
   - Set to None (makes uncallable)
   - Rapid replacement cycles

3. **attribute_injection**: Add class attributes after warmup
   - Simple attributes
   - Descriptors
   - Rapid attribute injection cycles

4. **dict_modification**: Modify class `__dict__` after warmup
   - Add via setattr
   - Delete and re-add
   - Rapid modification stress test

## Test Coverage

- 15 tests covering all attack scenarios
- Edge cases: empty functions, non-harness functions, probability threshold
- Warmup verification
- Code validity checks

## Target

`_GUARD_TYPE_VERSION` - JIT guard that caches type version numbers for optimized attribute/method access

Closes #352
Relates to #89

🤖 Generated with [Claude Code](https://claude.ai/code)