### PR TITLE
fix: normalize run_stats increments to prevent KeyError

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -416,7 +416,7 @@ class LafleurOrchestrator:
             while mutation_index < max_mutations:
                 mutation_index += 1
                 mutation_id += 1
-                self.run_stats["total_mutations"] += 1
+                self.run_stats["total_mutations"] = self.run_stats.get("total_mutations", 0) + 1
                 self.mutations_since_last_find += 1
                 mutations_since_last_find_in_session += 1
 
@@ -492,9 +492,12 @@ class LafleurOrchestrator:
                                 found_new_coverage_in_cycle = True
 
                                 # --- Update stats and logs on every find ---
-                                self.run_stats["new_coverage_finds"] += 1
-                                self.run_stats["sum_of_mutations_per_find"] += (
-                                    self.mutations_since_last_find
+                                self.run_stats["new_coverage_finds"] = (
+                                    self.run_stats.get("new_coverage_finds", 0) + 1
+                                )
+                                self.run_stats["sum_of_mutations_per_find"] = (
+                                    self.run_stats.get("sum_of_mutations_per_find", 0)
+                                    + self.mutations_since_last_find
                                 )
                                 self.mutations_since_last_find = 0
                                 parent_metadata["total_finds"] = (


### PR DESCRIPTION
## Summary
- Replace three bare `+=` operations on `self.run_stats` with the safe `.get(key, 0)` pattern to prevent `KeyError` on fresh stats files
- The three affected counters: `total_mutations`, `new_coverage_finds`, `sum_of_mutations_per_find`
- Add test verifying empty `run_stats` dict doesn't raise `KeyError` during a `NEW_COVERAGE` cycle

Closes #360

## Test plan
- [x] New test `test_no_keyerror_on_empty_run_stats_with_new_coverage` passes
- [x] All 209 orchestrator tests pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)