### PR TITLE
fix: remove false-alarm error print on missing child source file

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -574,8 +574,6 @@ class LafleurOrchestrator:
                     finally:
                         if child_source_path.exists():
                             child_source_path.unlink()
-                        else:
-                            print(f"Error deleting {child_source_path}, file doesn't exist!")
                         self._cleanup_log_file(child_log_path, parent_id, mutation_seed, run_num)
 
                 if found_new_coverage_in_cycle and is_deepening_session:


### PR DESCRIPTION
## Summary
- Remove the `else` branch that printed "Error deleting" when `child_source_path` doesn't exist during cleanup
- This message fired during normal operation (e.g. when `prepare_child_script` returns `None`)
- Add test confirming no false-alarm output is produced

Closes #366

## Test plan
- [x] New test `test_no_false_alarm_when_child_source_missing` passes
- [x] All 220 orchestrator tests pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)