### PR TITLE
refactor: reduce stats save and timeseries logging frequency

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -285,9 +285,11 @@ class LafleurOrchestrator:
                     print(f"[*] Logging time-series data point at session {session_num}...")
                     self.artifact_manager.log_timeseries_datapoint()
         finally:
+            # Crash-safety: save stats even if interrupted mid-session.
+            # The per-session save above handles the normal case.
             print("\n[+] Fuzzing loop terminating. Saving final stats...")
             self.artifact_manager.update_and_save_run_stats(self.global_seed_counter)
-            self.artifact_manager.log_timeseries_datapoint()  # Log one final data point on exit
+            self.artifact_manager.log_timeseries_datapoint()
 
             self.score_tracker.save_state()
 
@@ -406,8 +408,6 @@ class LafleurOrchestrator:
         current_parent_path = initial_parent_path
         current_parent_score = initial_parent_score
         mutations_since_last_find_in_session = 0
-        new_finds_this_session = 0
-
         mutation_id = 0
 
         # --- This loop controls the deepening process ---
@@ -546,16 +546,6 @@ class LafleurOrchestrator:
                                     parent_metadata.get("total_finds", 0) + 1
                                 )
                                 parent_metadata["mutations_since_last_find"] = 0
-                                self.artifact_manager.update_and_save_run_stats(
-                                    self.global_seed_counter
-                                )
-
-                                new_finds_this_session += 1
-                                if new_finds_this_session % 10 == 0:
-                                    print(
-                                        f"[*] Logging time-series data point after {new_finds_this_session} finds in this session."
-                                    )
-                                    self.artifact_manager.log_timeseries_datapoint()
 
                                 if is_deepening_session:
                                     new_child_filename = analysis_data["new_filename"]


### PR DESCRIPTION
## Summary
- Remove per-find `update_and_save_run_stats` call from inside `execute_mutation_and_analysis_cycle`
- Remove per-find timeseries logging (`new_finds_this_session % 10`) from inside the cycle method
- Remove unused `new_finds_this_session` counter variable
- Add clarifying comment above `finally` block crash-safety saves
- Stats are now saved at per-session granularity only

Closes #368

## Test plan
- [x] New test `test_no_stats_save_from_within_cycle` verifies no stats save/timeseries calls from cycle
- [x] All 221 orchestrator tests pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)