### PR TITLE
refactor: avoid full corpus re-scoring during deepening sessions

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -554,11 +554,11 @@ class LafleurOrchestrator:
                                         file=sys.stderr,
                                     )
                                     current_parent_path = CORPUS_DIR / new_child_filename
-                                    current_parent_score = (
-                                        self.corpus_manager.scheduler.calculate_scores().get(
-                                            new_child_filename, 100.0
-                                        )
-                                    )
+                                    # During deepening, inherit parent's score with a bonus
+                                    # rather than re-scoring the entire corpus.
+                                    # The exact score only affects mutation count via
+                                    # _calculate_mutations(), which doesn't need precision here.
+                                    current_parent_score = current_parent_score * 1.1
                                     mutations_since_last_find_in_session = 0
                             break  # Break inner multi-run loop
                     finally:


### PR DESCRIPTION
## Summary
- Replace O(corpus_size) `calculate_scores()` call in deepening path with simple `score * 1.1` inheritance
- Initial parent scoring from `select_parent()` in `run_evolutionary_loop` still uses full scoring system
- Add test verifying `calculate_scores` is never called during deepening and score increases correctly

Closes #370

## Test plan
- [x] New test `test_deepening_does_not_rescore_corpus` passes
- [x] All 222 orchestrator tests pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)