### PR TITLE
refactor: extract sterility thresholds to named constants

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -53,6 +53,12 @@ DIVERGENCES_DIR = Path("divergences")
 LOGS_DIR = Path("logs")
 RUN_LOGS_DIR = LOGS_DIR / "run_logs"
 
+# --- Sterility Thresholds ---
+# Maximum sterile mutations in a deepening session before abandoning the lineage.
+DEEPENING_STERILITY_LIMIT = 30
+# Maximum sterile mutations for a corpus file before marking it permanently sterile.
+CORPUS_STERILITY_LIMIT = 599
+
 
 class LafleurOrchestrator:
     """
@@ -357,7 +363,7 @@ class LafleurOrchestrator:
             parent_metadata["mutations_since_last_find"] = (
                 parent_metadata.get("mutations_since_last_find", 0) + 1
             )
-            if parent_metadata["mutations_since_last_find"] > 599:
+            if parent_metadata["mutations_since_last_find"] > CORPUS_STERILITY_LIMIT:
                 parent_metadata["is_sterile"] = True
             return FlowControl.NONE
 
@@ -460,7 +466,10 @@ class LafleurOrchestrator:
                 self.mutations_since_last_find += 1
                 mutations_since_last_find_in_session += 1
 
-                if is_deepening_session and mutations_since_last_find_in_session > 30:
+                if (
+                    is_deepening_session
+                    and mutations_since_last_find_in_session > DEEPENING_STERILITY_LIMIT
+                ):
                     print(
                         "  [~] Deepening session became sterile. Returning to breadth-first search."
                     )

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -15,7 +15,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from lafleur.mutation_controller import MutationController
-from lafleur.orchestrator import FlowControl, LafleurOrchestrator
+from lafleur.orchestrator import (
+    DEEPENING_STERILITY_LIMIT,
+    FlowControl,
+    LafleurOrchestrator,
+)
 
 
 class TestCalculateMutations(unittest.TestCase):
@@ -397,7 +401,7 @@ class TestExecuteMutationAndAnalysisCycle(unittest.TestCase):
                         self.assertEqual(self.orchestrator.mutations_since_last_find, 2)
 
     def test_stops_deepening_when_sterile(self):
-        """Test that deepening session stops after 30 sterile mutations."""
+        """Test that deepening session stops after DEEPENING_STERILITY_LIMIT sterile mutations."""
         parent_path = Path("/corpus/parent_test.py")
         mock_harness = MagicMock()
         mock_harness.name = "uop_harness_test"
@@ -423,8 +427,11 @@ class TestExecuteMutationAndAnalysisCycle(unittest.TestCase):
 
                         stdout_output = mock_stdout.getvalue()
                         self.assertIn("Deepening session became sterile", stdout_output)
-                        # Should stop after 31 mutations (30 sterile + 1 triggers the check)
-                        self.assertLessEqual(self.orchestrator.run_stats["total_mutations"], 31)
+                        # Should stop after DEEPENING_STERILITY_LIMIT + 1 mutations
+                        self.assertLessEqual(
+                            self.orchestrator.run_stats["total_mutations"],
+                            DEEPENING_STERILITY_LIMIT + 1,
+                        )
 
     def test_uses_dynamic_runs_when_enabled(self):
         """Test that run count is calculated dynamically when use_dynamic_runs=True."""


### PR DESCRIPTION
## Summary
- Define `DEEPENING_STERILITY_LIMIT = 30` and `CORPUS_STERILITY_LIMIT = 599` as module-level constants
- Replace magic numbers in `execute_mutation_and_analysis_cycle` and `_handle_analysis_data`
- Update test to reference the constant instead of hardcoded `31`

Closes #374

## Test plan
- [x] Existing `test_stops_deepening_when_sterile` updated to use `DEEPENING_STERILITY_LIMIT`
- [x] All 222 orchestrator tests pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)