### PR TITLE
fix: always log dynamic run count with session type context

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -451,8 +451,8 @@ class LafleurOrchestrator:
             if self.use_dynamic_runs:
                 num_runs = 2 + int(math.floor(math.log(max(1.0, current_parent_score / 15))))
                 num_runs = min(num_runs, 10)
-                if not is_deepening_session:  # Only log this once per breadth session
-                    print(f"    -> Dynamically set run count to {num_runs} for this parent.")
+                session_type = "deepening" if is_deepening_session else "breadth"
+                print(f"    -> Dynamic run count: {num_runs} for {parent_id} ({session_type})")
             else:
                 num_runs = self.base_runs
 


### PR DESCRIPTION
## Summary
- Remove deepening session suppression for dynamic run count logging
- Always print run count with session type (deepening/breadth) and parent ID for context
- Update existing test assertion to match new format
- Add new test verifying deepening sessions also produce the log message

Closes #376

## Test plan
- [x] Updated `test_uses_dynamic_runs_when_enabled` for new format
- [x] New `test_dynamic_runs_logged_for_deepening` verifies deepening logging
- [x] All 223 orchestrator tests pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)