### PR TITLE
Fix timezone consistency in main()

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -705,7 +705,7 @@ def _format_run_summary(
     start_stats: dict,
 ) -> str:
     """Format the summary footer printed at the end of a fuzzing run."""
-    end_time = datetime.now()
+    end_time = datetime.now(timezone.utc)
     duration = end_time - run_start_time
     end_stats = load_run_stats()
 
@@ -838,7 +838,7 @@ def main():
 
     LOGS_DIR.mkdir(exist_ok=True)
     # Use a consistent timestamp for the whole run
-    run_start_time = datetime.now()
+    run_start_time = datetime.now(timezone.utc)
     timestamp_iso = run_start_time.isoformat()
     safe_timestamp = timestamp_iso.replace(":", "-").replace("+", "Z")
     orchestrator_log_path = LOGS_DIR / f"deep_fuzzer_run_{safe_timestamp}.log"

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -1377,7 +1377,7 @@ class TestFormatRunSummary(unittest.TestCase):
             "crashes_found": 2,
         }
         start = {"total_mutations": 100, "new_coverage_finds": 3, "crashes_found": 1}
-        run_start = datetime.now()
+        run_start = datetime.now(timezone.utc)
 
         result = _format_run_summary("Completed", run_start, start)
 
@@ -1395,7 +1395,7 @@ class TestFormatRunSummary(unittest.TestCase):
         """Summary handles zero-duration run without division error."""
         mock_load.return_value = {}
         start = {}
-        run_start = datetime.now()
+        run_start = datetime.now(timezone.utc)
 
         result = _format_run_summary("Completed", run_start, start)
 
@@ -1407,7 +1407,7 @@ class TestFormatRunSummary(unittest.TestCase):
         mock_load.return_value = {"total_mutations": 10}
         start = {}
 
-        result = _format_run_summary("KeyboardInterrupt", datetime.now(), start)
+        result = _format_run_summary("KeyboardInterrupt", datetime.now(timezone.utc), start)
 
         self.assertIn("KeyboardInterrupt", result)
         self.assertIn("Total Executions: 10", result)


### PR DESCRIPTION
## Summary

- Change `run_start_time` in `main()` to use `datetime.now(timezone.utc)`
- Change `end_time` in `_format_run_summary()` to use `datetime.now(timezone.utc)`
- Update test timestamps to be timezone-aware
- Ensures consistent UTC timestamps across logs and run_stats

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)