### PR TITLE
refactor: Make MutationController.corpus_manager genuinely optional

### DIFF
--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -54,7 +54,7 @@ class MutationController:
         self,
         ast_mutator: "ASTMutator",
         score_tracker: "MutatorScoreTracker",
-        corpus_manager: "CorpusManager",
+        corpus_manager: "CorpusManager | None" = None,
         differential_testing: bool = False,
     ):
         """
@@ -63,12 +63,13 @@ class MutationController:
         Args:
             ast_mutator: ASTMutator instance for applying transformations
             score_tracker: MutatorScoreTracker for adaptive strategy selection
-            corpus_manager: CorpusManager for parent selection in splicing
+            corpus_manager: CorpusManager for parent selection in splicing.
+                Can be None at construction and set later via the corpus_manager attribute.
             differential_testing: Whether differential testing mode is enabled
         """
         self.ast_mutator = ast_mutator
         self.score_tracker = score_tracker
-        self.corpus_manager = corpus_manager
+        self.corpus_manager: CorpusManager | None = corpus_manager
         self.differential_testing = differential_testing
         self.boilerplate_code: str | None = None
 
@@ -304,6 +305,10 @@ class MutationController:
     ) -> ast.AST | list[ast.stmt]:
         """Perform a crossover by splicing the harness from a second parent."""
         print("  [~] Attempting SPLICING stage...", file=__import__("sys").stderr)
+
+        if self.corpus_manager is None:
+            print("  [!] Splicing unavailable: no corpus_manager set.", file=sys.stderr)
+            return base_core_ast
 
         # Handle both Module and list inputs
         if isinstance(base_core_ast, ast.Module):

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -141,11 +141,9 @@ class LafleurOrchestrator:
         self.score_tracker = MutatorScoreTracker(ast_mutator.transformers)
 
         # Initialize the mutation controller for managing mutation strategies
-        # Note: corpus_manager is set to a placeholder and updated after CorpusManager init
         self.mutation_controller = MutationController(
             ast_mutator=ast_mutator,
             score_tracker=self.score_tracker,
-            corpus_manager=None,  # type: ignore[arg-type]  # Set after CorpusManager init
             differential_testing=differential_testing,
         )
 
@@ -159,7 +157,7 @@ class LafleurOrchestrator:
             target_python=target_python,
         )
 
-        # Now set the corpus_manager reference in mutation_controller
+        # Set the corpus_manager after CorpusManager is created (breaks circular dependency)
         self.mutation_controller.corpus_manager = self.corpus_manager
 
         fingerprinter = CrashFingerprinter()


### PR DESCRIPTION
## Summary
- Makes `corpus_manager` parameter optional (default `None`) in `MutationController.__init__`
- Adds runtime guard in `_run_splicing_stage` that returns original AST when `corpus_manager` is `None`
- Removes `type: ignore` hack from `orchestrator.py` constructor

Closes #392

## Test plan
- [x] 2 new tests: splicing returns original AST when no corpus_manager, splicing works after post-construction assignment
- [x] All 248 existing orchestrator tests pass
- [x] mypy clean on both files
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)