### PR TITLE
fix: Only record attempt for the chosen mutation strategy

### DIFF
--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -387,10 +387,6 @@ class MutationController:
             s.__name__.replace("_run_", "").replace("_stage", "") for s in strategy_candidates
         ]
 
-        # Record an attempt for each strategy to help with exploration.
-        for name in strategy_names:
-            self.score_tracker.attempts[name] += 1
-
         dynamic_weights = self.score_tracker.get_weights(strategy_names)
 
         # Boost sniper weight if available (simple heuristic for now)
@@ -401,6 +397,10 @@ class MutationController:
             dynamic_weights[sniper_idx] = max(dynamic_weights[sniper_idx], avg_weight * 1.5)
 
         chosen_strategy = random.choices(strategy_candidates, weights=dynamic_weights, k=1)[0]
+
+        # Record the attempt for the chosen strategy only
+        chosen_name = chosen_strategy.__name__.replace("_run_", "").replace("_stage", "")
+        self.score_tracker.attempts[chosen_name] += 1
 
         # The `seed` argument is used by the deterministic stage for its own
         # seeding, and the other stages use the globally seeded RANDOM instance.


### PR DESCRIPTION
## Summary
- Moves strategy attempt tracking from a loop over all strategies to a single increment for the chosen strategy
- Fixes diluted learning signal where all strategies appeared equally attempted

Closes #402

## Test plan
- [x] 1 existing test updated: verifies only chosen strategy gets attempt
- [x] 1 new test: verifies attempt counts accumulate correctly across calls
- [x] All 61 tests in test_mutation_strategies + test_execution pass
- [x] mypy clean
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)