### PR TITLE
refactor: move MutationStrategy type alias to module level

### DIFF
--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -38,6 +38,8 @@ RANDOM = random.Random()
 BOILERPLATE_START_MARKER = "# FUSIL_BOILERPLATE_START"
 BOILERPLATE_END_MARKER = "# FUSIL_BOILERPLATE_END"
 
+MutationStrategy = Callable[..., tuple[ast.AST, dict[str, Any]]]
+
 
 class MutationController:
     """
@@ -376,7 +378,6 @@ class MutationController:
         normalizer = FuzzerSetupNormalizer()
         tree_copy = normalizer.visit(tree_copy)
 
-        MutationStrategy = Callable[..., tuple[ast.AST, dict[str, Any]]]
         strategy_candidates: list[MutationStrategy] = [
             self._run_deterministic_stage,
             self._run_havoc_stage,


### PR DESCRIPTION
## Summary
- Moved `MutationStrategy` type alias from inline inside `apply_mutation_strategy` to module level (after `BOILERPLATE_END_MARKER`)
- Makes the alias visible to static analysis tools and reusable across the module
- Pure move — no behavioral change

Closes #406

## Test plan
- [x] 34 tests in test_mutation_strategies.py pass (existing tests already exercise the type via strategy_candidates)
- [x] mypy clean
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)