### PR TITLE
fix: remove dead run_stats.get() statement

### DIFF
--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -128,7 +128,6 @@ class CorpusManager:
 
         self.scheduler = CorpusScheduler(self.coverage_state)
         self.known_hashes: set[tuple[str, str]] = set()
-        self.run_stats.get("corpus_file_counter", 0)
         self.corpus_file_counter = self.run_stats.get("corpus_file_counter", 0)
 
         self.fusil_path_is_valid = False


### PR DESCRIPTION
## Summary
- Removed bare `self.run_stats.get("corpus_file_counter", 0)` whose result was discarded
- The actual assignment happens on the following line

Closes #414

## Test plan
- [x] 25 tests in test_corpus_manager.py pass
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)