### PR TITLE
fix: correct parent_id type annotation to str | None

### DIFF
--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -319,7 +319,7 @@ class CorpusManager:
         core_code: str,
         baseline_coverage: dict[str, Any],
         execution_time_ms: int,
-        parent_id: int,
+        parent_id: str | None,
         mutation_info: dict[str, Any],
         mutation_seed: int,
         content_hash: str,


### PR DESCRIPTION
## Summary
- Changed `parent_id: int` to `parent_id: str | None` in `add_new_file` to match actual runtime usage
- All callers pass filename strings or None, never ints

Closes #416

## Test plan
- [x] 25 tests pass, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)