### PR TITLE
refactor: extract ENV to shared FUZZING_ENV in utils.py

### DIFF
--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -17,20 +17,10 @@ from pathlib import Path
 from typing import Any, Callable
 
 from lafleur.coverage import save_coverage_state, CoverageManager
-from lafleur.utils import ExecutionResult
+from lafleur.utils import ExecutionResult, FUZZING_ENV
 
 TMP_DIR = Path("tmp_fuzz_run")
 CORPUS_DIR = Path("corpus") / "jit_interesting_tests"
-
-ENV = os.environ.copy()
-ENV.update(
-    {
-        "PYTHON_LLTRACE": "2",
-        "PYTHON_OPT_DEBUG": "4",
-        "PYTHON_JIT": "1",
-        "ASAN_OPTIONS": "detect_leaks=0",
-    }
-)
 
 
 class CorpusScheduler:
@@ -223,7 +213,7 @@ class CorpusManager:
                         stdout=log_file,
                         stderr=subprocess.STDOUT,
                         timeout=self.execution_timeout,  # Use configurable timeout
-                        env=ENV,
+                        env=FUZZING_ENV,
                     )
                     end_time = time.monotonic()
                 execution_time_ms = int((end_time - start_time) * 1000)
@@ -406,7 +396,7 @@ class CorpusManager:
             # "--keep-sessions",
         ]
         print(f"[*] Generating new seed with command: {' '.join(command)}")
-        subprocess.run(command, capture_output=True, env=ENV)
+        subprocess.run(command, capture_output=True, env=FUZZING_ENV)
 
         # Execute it to get a log (also using the configurable timeout)
         try:
@@ -416,7 +406,7 @@ class CorpusManager:
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
                     timeout=self.execution_timeout,  # Use configurable timeout here too
-                    env=ENV,
+                    env=FUZZING_ENV,
                 )
         except subprocess.TimeoutExpired:
             print(

--- a/lafleur/execution.py
+++ b/lafleur/execution.py
@@ -19,23 +19,12 @@ from textwrap import dedent, indent
 from typing import TYPE_CHECKING
 
 from lafleur.coverage import PROTO_TRACE_REGEX, OPTIMIZED_TRACE_REGEX
-from lafleur.utils import ExecutionResult
+from lafleur.utils import ExecutionResult, FUZZING_ENV
 
 if TYPE_CHECKING:
     from lafleur.artifacts import ArtifactManager
     from lafleur.corpus_manager import CorpusManager
 
-
-# Environment variables for JIT execution with debug logging
-ENV = os.environ.copy()
-ENV.update(
-    {
-        "PYTHON_LLTRACE": "2",
-        "PYTHON_OPT_DEBUG": "4",
-        "PYTHON_JIT": "1",
-        "ASAN_OPTIONS": "detect_leaks=0",
-    }
-)
 
 # Session fuzzing: The Mixer strategy
 MIXER_PROBABILITY = 0.3  # 30% chance to prepend polluter scripts
@@ -260,7 +249,7 @@ class ExecutionManager:
             # Run Non-JIT
             nojit_run = None
             try:
-                nojit_env = ENV.copy()
+                nojit_env = FUZZING_ENV.copy()
                 nojit_env["PYTHON_JIT"] = "0"
                 # Disable debug logs for a clean stderr comparison
                 nojit_env["PYTHON_LLTRACE"] = "0"
@@ -280,7 +269,7 @@ class ExecutionManager:
             # Run JIT
             jit_run = None
             try:
-                jit_env = ENV.copy()
+                jit_env = FUZZING_ENV.copy()
                 jit_env["PYTHON_JIT"] = "1"
                 jit_env["PYTHON_LLTRACE"] = "0"
                 jit_env["PYTHON_OPT_DEBUG"] = "0"
@@ -421,7 +410,7 @@ class ExecutionManager:
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
                     timeout=self.timeout,
-                    env=ENV,  # Use the global ENV with debug flags for coverage
+                    env=FUZZING_ENV,  # Use the global env with debug flags for coverage
                 )
                 end_time = time.monotonic()
 
@@ -478,7 +467,7 @@ class ExecutionManager:
         """)
 
         # Use the exact environment we rely on for coverage
-        env = ENV.copy()
+        env = FUZZING_ENV.copy()
 
         try:
             # Run the stimulus

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -5,6 +5,7 @@ It includes utilities for logging, managing run statistics, and structuring data
 """
 
 import json
+import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -12,6 +13,18 @@ from pathlib import Path
 from typing import Any, TextIO
 
 RUN_STATS_FILE = Path("fuzz_run_stats.json")
+
+# Standard environment variables for running JIT-enabled Python targets.
+# Used by both CorpusManager (sync/seed) and ExecutionManager (fuzzing runs).
+FUZZING_ENV = os.environ.copy()
+FUZZING_ENV.update(
+    {
+        "PYTHON_LLTRACE": "2",
+        "PYTHON_OPT_DEBUG": "4",
+        "PYTHON_JIT": "1",
+        "ASAN_OPTIONS": "detect_leaks=0",
+    }
+)
 
 
 def load_run_stats() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Extracted duplicate `ENV` dict from `corpus_manager.py` and `execution.py` into a single `FUZZING_ENV` constant in `lafleur/utils.py`
- Updated all references in both consumer files

Closes #420

## Test plan
- [x] Full suite: 1290 tests pass
- [x] mypy clean across all 3 files
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)