### PR TITLE
fix: remove redundant CORPUS_DIR.mkdir() from synchronize

### DIFF
--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -142,9 +142,6 @@ class CorpusManager:
         since the last run.
         """
         print("[*] Synchronizing corpus directory with state file...")
-        if not CORPUS_DIR.exists():
-            CORPUS_DIR.mkdir(parents=True, exist_ok=True)
-
         disk_files = {p.name for p in CORPUS_DIR.glob("*.py")}
         state_files = set(self.coverage_state.state["per_file_coverage"].keys())
 


### PR DESCRIPTION
## Summary
- Removed redundant `if not CORPUS_DIR.exists(): CORPUS_DIR.mkdir(...)` from `synchronize()`
- The constructor already creates the directory

Closes #422

## Test plan
- [x] 25 tests pass, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)