### PR TITLE
fix: guard metadata mutation behind dry_run check in prune_corpus

### DIFF
--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -515,8 +515,9 @@ class CorpusManager:
                     files_to_prune.add(filename_a)
                     prune_reasons[filename_a] = f"subsumed by {filename_b}"
 
-                    meta_b.setdefault("subsumed_children_count", 0)
-                    meta_b["subsumed_children_count"] += 1
+                    if not dry_run:
+                        meta_b.setdefault("subsumed_children_count", 0)
+                        meta_b["subsumed_children_count"] += 1
 
                     # Once a file is marked for pruning, we break the inner loop
                     # and move to the next candidate file.

--- a/tests/test_corpus_manager.py
+++ b/tests/test_corpus_manager.py
@@ -497,6 +497,24 @@ class TestCorpusManagerPruneCorpus(unittest.TestCase):
         self.assertIn("test1.py", self.state["per_file_coverage"])
         self.assertIn("test2.py", self.state["per_file_coverage"])
 
+    def test_dry_run_does_not_mutate_metadata(self):
+        """Dry run should not add subsumed_children_count to metadata."""
+        self.state["per_file_coverage"]["test1.py"] = {
+            "lineage_coverage_profile": {"f1": {"edges": {0, 1}}},
+            "file_size_bytes": 1000,
+            "execution_time_ms": 100,
+        }
+        self.state["per_file_coverage"]["test2.py"] = {
+            "lineage_coverage_profile": {"f1": {"edges": {0, 1, 2}}},
+            "file_size_bytes": 500,
+            "execution_time_ms": 50,
+        }
+
+        self.corpus_manager.prune_corpus(dry_run=True)
+
+        # No metadata should have been mutated
+        self.assertNotIn("subsumed_children_count", self.state["per_file_coverage"]["test2.py"])
+
     def test_prune_corpus_finds_no_prunable(self):
         """Test when no files are prunable."""
         # Files with disjoint coverage


### PR DESCRIPTION
## Summary
- Guard `subsumed_children_count` metadata mutation with `if not dry_run` in `prune_corpus`
- Add `test_dry_run_does_not_mutate_metadata` test

## Test plan
- [x] `pytest tests/test_corpus_manager.py -v` — 26 tests pass
- [x] `ruff check && ruff format --check` — clean
- [x] `mypy lafleur/corpus_manager.py` — clean

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)