### PR TITLE
fix: remove commented-out max_exit_count line

### DIFF
--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -108,7 +108,6 @@ class InterestingnessScorer:
 
         # --- JIT Vitals Scoring ---
         zombie_traces = self.jit_stats.get("zombie_traces", 0)
-        # max_exit_count = self.jit_stats.get("max_exit_count", 0) # Superseded by density
         max_chain_depth = self.jit_stats.get("max_chain_depth", 0)
         min_code_size = self.jit_stats.get("min_code_size", 0)  # Less critical
 


### PR DESCRIPTION
## Summary
- Remove dead commented-out `max_exit_count` line from `calculate_score()`

## Test plan
- [x] 60 scoring tests pass
- [x] Lint/format/mypy clean

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)