### PR TITLE
fix: remove unused is_differential_mode parameter from analyze_run

### DIFF
--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -467,7 +467,6 @@ class ScoringManager:
         mutation_seed: int,
         parent_file_size: int,
         parent_lineage_edge_count: int,
-        is_differential_mode: bool = False,
     ) -> dict:
         """Orchestrate the analysis of a run and return a dictionary of findings."""
         if self.artifact_manager is None or self.corpus_manager is None:


### PR DESCRIPTION
## Summary
- Remove vestigial `is_differential_mode` parameter from `analyze_run` signature

## Test plan
- [x] 60 scoring tests pass
- [x] Lint/format/mypy clean

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)