### PR TITLE
fix: add warning logging for malformed JIT stats lines

### DIFF
--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -336,8 +336,12 @@ class ScoringManager:
                     if code_size > 0:
                         min_code_sizes.append(code_size)
 
-                except (json.JSONDecodeError, IndexError):
-                    pass
+                except (json.JSONDecodeError, IndexError) as e:
+                    print(
+                        f"  [!] Warning: Failed to parse JIT stats line: {e}. "
+                        f"Line content: {line[:200]}",
+                        file=sys.stderr,
+                    )
             elif line.startswith("[EKG] WATCHED:"):
                 try:
                     variables = line.split("[EKG] WATCHED:", 1)[1].strip()
@@ -346,8 +350,12 @@ class ScoringManager:
                             var = var.strip()
                             if var:
                                 watched_dependencies.add(var)
-                except IndexError:
-                    pass
+                except IndexError as e:
+                    print(
+                        f"  [!] Warning: Failed to parse EKG watched line: {e}. "
+                        f"Line content: {line[:200]}",
+                        file=sys.stderr,
+                    )
 
         if min_code_sizes:
             aggregated_stats["min_code_size"] = min(min_code_sizes)


### PR DESCRIPTION
## Summary
- Replace silent `pass` in `parse_jit_stats` except blocks with warning messages on stderr
- Warnings include exception details and truncated line content (first 200 chars)
- Add 3 new tests: malformed JSON warning verification, EKG parsing, empty EKG handling

## Test plan
- [x] `test_parse_jit_stats_malformed_json_warns_stderr` — verifies warning on stderr for invalid JSON and that valid lines still parse
- [x] `test_parse_jit_stats_ekg_parsing` — verifies correct EKG variable extraction
- [x] `test_parse_jit_stats_ekg_empty_watched` — verifies graceful handling of empty EKG content
- [x] All 1307 tests pass (6 pre-existing integration failures unrelated)
- [x] mypy clean, ruff clean

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)