### PR TITLE
refactor: stop mutating caller's mutation_info in analyze_run

### DIFF
--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -611,8 +611,8 @@ class ScoringManager:
             jit_stats_for_save = jit_stats.copy()
             jit_stats_for_save["max_exit_density"] = saved_density
 
-            # Inject jit_stats into mutation_info so it gets saved with the file
-            mutation_info["jit_stats"] = jit_stats_for_save
+            # Create a copy so we don't mutate the caller's dict
+            saved_mutation_info = {**mutation_info, "jit_stats": jit_stats_for_save}
 
             return {
                 "status": "NEW_COVERAGE",
@@ -622,11 +622,10 @@ class ScoringManager:
                 "coverage_hash": coverage_hash,
                 "execution_time_ms": exec_result.execution_time_ms,
                 "parent_id": parent_id,
-                "mutation_info": mutation_info,
+                "mutation_info": saved_mutation_info,
                 "mutation_seed": mutation_seed,
                 "jit_avg_time_ms": exec_result.jit_avg_time_ms,
                 "nojit_avg_time_ms": exec_result.nojit_avg_time_ms,
-                # jit_stats is now inside mutation_info, no need to pass separately if not used by caller
             }
 
         return {"status": "NO_CHANGE"}


### PR DESCRIPTION
## Summary
- Replace in-place `mutation_info["jit_stats"] = ...` with a shallow copy via `{**mutation_info, "jit_stats": jit_stats_for_save}`
- Prevents `analyze_run` from modifying the caller's dictionary as a side-effect
- Add `TestAnalyzeRunMutationInfo` with test verifying caller's dict remains unchanged

## Test plan
- [x] `test_mutation_info_not_mutated_on_new_coverage` — verifies returned dict has `jit_stats` but caller's original is untouched
- [x] All existing scoring tests pass (23 total)
- [x] mypy clean, ruff clean

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)