### PR TITLE
perf: use stat().st_size instead of read_text() for child file size

### DIFF
--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -561,7 +561,7 @@ class ScoringManager:
             mutation_info,
             parent_file_size,
             parent_lineage_edge_count,
-            len(exec_result.source_path.read_text().encode("utf-8")),
+            exec_result.source_path.stat().st_size,
             exec_result.jit_avg_time_ms,
             exec_result.nojit_avg_time_ms,
             exec_result.nojit_cv,

--- a/tests/orchestrator/test_scoring.py
+++ b/tests/orchestrator/test_scoring.py
@@ -341,6 +341,7 @@ class TestAnalyzeRunMutationInfo(unittest.TestCase):
         exec_result.log_path = MagicMock()
         exec_result.log_path.read_text.return_value = "log content"
         exec_result.source_path = MagicMock()
+        exec_result.source_path.stat.return_value.st_size = 150
         exec_result.source_path.read_text.return_value = "print('hello')"
         exec_result.returncode = 0
         exec_result.execution_time_ms = 100


### PR DESCRIPTION
## Summary
- Replace `len(exec_result.source_path.read_text().encode("utf-8"))` with `exec_result.source_path.stat().st_size`
- Avoids reading the entire source file just to measure its byte size
- Update test mock to set `stat().st_size` explicitly

## Test plan
- [x] All 23 scoring tests pass
- [x] mypy clean, ruff clean

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)