### PR TITLE
fix: remove stale differential_testing argument from analyze_run call

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -557,7 +557,6 @@ class LafleurOrchestrator:
                     mutation_seed,
                     ctx.parent_file_size,
                     ctx.parent_lineage_edge_count,
-                    self.differential_testing,
                 )
 
                 nojit_cv = exec_result.nojit_cv


### PR DESCRIPTION
## Summary
- Remove `self.differential_testing` from the `analyze_run()` call in `_execute_single_mutation`
- This parameter was removed from the `analyze_run` signature in PR #439 but the call site was not updated, causing a `TypeError` at runtime

## Test plan
- [x] All 258 orchestrator tests pass
- [x] mypy clean, ruff clean

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)