### PR TITLE
feat: score tachycardia using delta executor metrics

### DIFF
--- a/tests/orchestrator/test_jit_differential.py
+++ b/tests/orchestrator/test_jit_differential.py
@@ -63,6 +63,18 @@ class TestDifferentialJITScoring(unittest.TestCase):
         score = scorer.calculate_score()
         self.assertEqual(score, 50.0)
 
+    def test_delta_density_with_parent_delta(self):
+        """Test delta scoring uses fixed threshold, not parent-relative comparison."""
+        parent_stats = {"child_delta_max_exit_density": 2.0}
+        # Child delta 0.8 > 0.5 threshold → bonus, regardless of parent delta
+        child_stats = {"child_delta_max_exit_density": 0.8, "child_delta_total_exits": 5}
+
+        scorer = InterestingnessScorer(
+            jit_stats=child_stats, parent_jit_stats=parent_stats, **self.scorer_args
+        )
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/orchestrator/test_jit_scoring.py
+++ b/tests/orchestrator/test_jit_scoring.py
@@ -80,5 +80,75 @@ class TestJITScoring(unittest.TestCase):
         self.assertEqual(score, 85.0)
 
 
+class TestDeltaTachycardiaScoring(unittest.TestCase):
+    """Tests for delta-based tachycardia scoring."""
+
+    def setUp(self):
+        self.base_coverage = NewCoverageInfo()
+        self.scorer_args = {
+            "coverage_info": self.base_coverage,
+            "parent_file_size": 100,
+            "parent_lineage_edge_count": 50,
+            "child_file_size": 110,
+            "is_timing_mode": False,
+            "jit_avg_time_ms": None,
+            "nojit_avg_time_ms": None,
+            "nojit_cv": None,
+        }
+
+    def test_delta_density_above_threshold_triggers_bonus(self):
+        """Density 1.0 > 0.5 threshold should trigger bonus."""
+        jit_stats = {"child_delta_max_exit_density": 1.0, "child_delta_total_exits": 5}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
+
+    def test_delta_exits_above_threshold_triggers_bonus(self):
+        """Exits 30 > 20 threshold should trigger bonus even with low density."""
+        jit_stats = {"child_delta_max_exit_density": 0.1, "child_delta_total_exits": 30}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
+
+    def test_delta_below_both_thresholds_no_bonus(self):
+        """Both below thresholds — no tachycardia bonus."""
+        jit_stats = {"child_delta_max_exit_density": 0.2, "child_delta_total_exits": 10}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        self.assertEqual(score, 0.0)
+
+    def test_delta_metrics_take_priority_over_absolute(self):
+        """Delta path is taken when delta fields are present, even if absolute is high."""
+        jit_stats = {
+            "max_exit_density": 50.0,  # Would trigger absolute path
+            "child_delta_max_exit_density": 0.1,  # Below delta threshold
+            "child_delta_total_exits": 5,  # Below delta threshold
+        }
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        # Delta path taken, both below threshold → no bonus
+        self.assertEqual(score, 0.0)
+
+    def test_fallback_to_absolute_when_no_delta_metrics(self):
+        """Without delta fields, fall back to absolute scoring."""
+        jit_stats = {"max_exit_density": 15.0}
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        # Absolute: 15.0 > 10.0 threshold → bonus
+        self.assertEqual(score, 20.0)
+
+    def test_fallback_to_absolute_when_delta_metrics_all_zero(self):
+        """Zero deltas → fallback to absolute."""
+        jit_stats = {
+            "max_exit_density": 15.0,
+            "child_delta_max_exit_density": 0.0,
+            "child_delta_total_exits": 0,
+        }
+        scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
+        score = scorer.calculate_score()
+        # Both deltas are 0, so fallback to absolute (15.0 > 10.0)
+        self.assertEqual(score, 20.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Prefer delta executor metrics (`child_delta_max_exit_density`, `child_delta_total_exits`) over absolute metrics for tachycardia scoring, with automatic fallback to absolute when no deltas are present
- Extract delta fields from `[DRIVER:STATS]` lines using last-line-wins (overwrite) semantics in `parse_jit_stats`
- Add delta density clamping (`MAX_DENSITY_GROWTH_FACTOR=5.0`) and decay (`TACHYCARDIA_DECAY_FACTOR=0.95`) in `_prepare_new_coverage_result`
- Add 14 new tests across 4 test files covering delta extraction, scoring, fallback, clamping, and decay

Closes #460

## Test plan
- [x] All 86 scoring-related tests pass
- [x] Delta extraction: last-line-wins, defaults to zero when absent
- [x] Delta scoring: density and exit thresholds trigger bonus independently
- [x] Fallback: absolute scoring used when delta fields are zero or absent
- [x] Clamping: child delta density capped at parent * 5.0
- [x] Decay: saved delta density multiplied by 0.95
- [x] Original `mutation_info` dict not mutated
- [x] Lint, format, type-check all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)