### PR TITLE
refactor: add _make_divergence_result helper to deduplicate divergence construction

### DIFF
--- a/tests/orchestrator/test_execution.py
+++ b/tests/orchestrator/test_execution.py
@@ -665,6 +665,36 @@ class TestVerifyTargetCapabilities(unittest.TestCase):
                 self.assertIn("env", call_kwargs)
 
 
+class TestMakeDivergenceResult(unittest.TestCase):
+    """Test ExecutionManager._make_divergence_result helper."""
+
+    def setUp(self):
+        """Set up minimal ExecutionManager instance."""
+        self.em = ExecutionManager.__new__(ExecutionManager)
+
+    def test_make_divergence_result_fields(self):
+        """All fields of the returned ExecutionResult match inputs."""
+        result, second = self.em._make_divergence_result(
+            child_source_path=Path("/tmp/child.py"),
+            child_log_path=Path("/tmp/child.log"),
+            parent_path=Path("/tmp/parent.py"),
+            reason="exit_code_mismatch",
+            jit_output="Exit Code: 1",
+            nojit_output="Exit Code: 0",
+        )
+
+        self.assertTrue(result.is_divergence)
+        self.assertEqual(result.divergence_reason, "exit_code_mismatch")
+        self.assertEqual(result.jit_output, "Exit Code: 1")
+        self.assertEqual(result.nojit_output, "Exit Code: 0")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.execution_time_ms, 0)
+        self.assertEqual(result.source_path, Path("/tmp/child.py"))
+        self.assertEqual(result.log_path, Path("/tmp/child.log"))
+        self.assertEqual(result.parent_path, Path("/tmp/parent.py"))
+        self.assertIsNone(second)
+
+
 class TestBuildEnv(unittest.TestCase):
     """Test ExecutionManager._build_env helper."""
 


### PR DESCRIPTION
## Summary
- Extract `_make_divergence_result` helper from three nearly identical `ExecutionResult` constructions in the differential testing stage
- Only the differing fields (reason, jit_output, nojit_output) are passed; boilerplate fields are centralized
- 1 new test verifying all returned fields

Closes #470

## Test plan
- [x] All 77 execution/crash detection tests pass (1 new)
- [x] Existing differential tests pass unchanged (they transitively test the helper)
- [x] Lint, format, type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)