### PR TITLE
refactor: document why differential testing skips session mode

### DIFF
--- a/lafleur/execution.py
+++ b/lafleur/execution.py
@@ -308,6 +308,10 @@ class ExecutionManager:
         nojit_cv: float | None = None
 
         # --- Stage 1: Differential Correctness Fuzzing (if enabled) ---
+        # Note: Differential testing always runs the child in isolation, even when
+        # session fuzzing is enabled. Session mode introduces non-determinism
+        # (mixer polluters, shared JIT state) that would cause false positives
+        # in the JIT vs non-JIT comparison.
         if self.differential_testing:
             instrumented_code = source_code + "\n" + SERIALIZATION_SNIPPET
             child_source_path.write_text(instrumented_code)


### PR DESCRIPTION
## Summary
- Add comment explaining that differential testing intentionally runs in isolation even when session_fuzz is enabled
- Documentation-only change, no code logic changes

Closes #472

## Test plan
- [x] All 77 execution/crash detection tests pass unchanged
- [x] Lint, format, type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)