### PR TITLE
refactor: fix solo session crash label ordering

### DIFF
--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -330,10 +330,10 @@ class ArtifactManager:
         # Copy scripts with sequential prefixes
         script_names = []
         for i, script_path in enumerate(scripts):
-            if i == 0:
-                dest_name = f"{i:02d}_warmup.py"
-            elif i == len(scripts) - 1:
+            if i == len(scripts) - 1:
                 dest_name = f"{i:02d}_attack.py"
+            elif i == 0:
+                dest_name = f"{i:02d}_warmup.py"
             else:
                 dest_name = f"{i:02d}_script.py"
 


### PR DESCRIPTION
## Summary
- Reverse if/elif in `save_session_crash` so the `attack` label takes priority over `warmup` for single-script sessions (solo mode)
- Previously, when `scripts` had one element, both `i == 0` and `i == len(scripts) - 1` were true, mislabeling the child as `00_warmup.py`
- Add 3 tests covering solo, two-script, and three-script labeling

Closes #478

## Test plan
- [x] `test_solo_session_labels_attack` — single-script session labels as `00_attack.py`
- [x] `test_two_scripts_labels_correctly` — warmup + attack
- [x] `test_three_scripts_labels_correctly` — warmup + script + attack

🤖 Generated with [Claude Code](https://claude.com/claude-code)