### PR TITLE
refactor: extract _get_log_suffix helper in ArtifactManager

### DIFF
--- a/tests/orchestrator/test_crash_detection.py
+++ b/tests/orchestrator/test_crash_detection.py
@@ -736,5 +736,24 @@ class TestSafeCopy(unittest.TestCase):
             mock_copy2.assert_called_once()
 
 
+class TestGetLogSuffix(unittest.TestCase):
+    """Test ArtifactManager._get_log_suffix helper."""
+
+    def test_truncated_log(self):
+        """Test that _truncated.log suffix is detected."""
+        result = ArtifactManager._get_log_suffix(Path("/tmp/child_test_truncated.log"))
+        self.assertEqual(result, "_truncated.log")
+
+    def test_compressed_log(self):
+        """Test that .log.zst suffix is detected."""
+        result = ArtifactManager._get_log_suffix(Path("/tmp/child_test.log.zst"))
+        self.assertEqual(result, ".log.zst")
+
+    def test_plain_log(self):
+        """Test that plain .log suffix is returned as default."""
+        result = ArtifactManager._get_log_suffix(Path("/tmp/child_test.log"))
+        self.assertEqual(result, ".log")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `_get_log_suffix(processed_log_path)` static method to deduplicate log filename extension logic
- Update `handle_timeout`, session crash saving, and standard crash saving in `check_for_crash`
- Add 3 tests covering truncated, compressed, and plain log suffixes

Closes #484

## Test plan
- [x] `test_truncated_log` — returns `_truncated.log`
- [x] `test_compressed_log` — returns `.log.zst`
- [x] `test_plain_log` — returns `.log`
- [x] All 43 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)