### PR TITLE
refactor: pre-compute map references in CoverageManager

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -167,6 +167,11 @@ class TestCoverageManager(unittest.TestCase):
         self.assertEqual(self.state["next_id_map"]["edge"], 0)
         self.assertEqual(self.state["next_id_map"]["rare_event"], 0)
 
+    def test_get_or_create_id_invalid_type_raises(self):
+        """Test that an invalid item_type raises KeyError."""
+        with self.assertRaises(KeyError):
+            self.manager.get_or_create_id("invalid_type", "foo")
+
 
 class TestParseLogForEdgeCoverage(unittest.TestCase):
     """Test the parse_log_for_edge_coverage function."""


### PR DESCRIPTION
## Summary
- Pre-compute `_type_maps` dict in `__init__` mapping item_type to `(forward_map, reverse_map)` tuples
- Replace per-call string formatting, computed dict keys, and `getattr` in `get_or_create_id` with direct references
- Use `.get()` for single-lookup cache hits instead of `in` + subscript (two lookups)
- Add test for invalid item_type raising `KeyError`

Closes #495

## Test plan
- [x] All 68 coverage/CLI tests pass
- [x] Lint and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)