### PR TITLE
refactor: fix main() CLI and extract merge_coverage_into_global

### DIFF
--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -15,7 +15,11 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
-from lafleur.coverage import CoverageManager, parse_log_for_edge_coverage
+from lafleur.coverage import (
+    CoverageManager,
+    merge_coverage_into_global,
+    parse_log_for_edge_coverage,
+)
 from lafleur.utils import ExecutionResult
 
 if TYPE_CHECKING:
@@ -496,13 +500,7 @@ class ScoringManager:
 
     def _update_global_coverage(self, child_coverage: dict) -> None:
         """Commit the coverage from a new, interesting child to the global state."""
-        global_coverage = self.coverage_manager.state["global_coverage"]
-        for harness_id, data in child_coverage.items():
-            for cov_type in COVERAGE_TYPES:
-                # The data already contains integer IDs from the parser.
-                for item_id, count in data.get(cov_type, {}).items():
-                    global_coverage[cov_type].setdefault(item_id, 0)
-                    global_coverage[cov_type][item_id] += count
+        merge_coverage_into_global(self.coverage_manager.state, child_coverage)
 
     def _calculate_coverage_hash(self, coverage_profile: dict) -> str:
         """Create a deterministic SHA256 hash of a coverage profile's edges."""

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -45,9 +45,8 @@ Optimized trace (length 50):
 
         # Mock load_coverage_state to return the structure main() expects
         mock_state = {
-            "uops": {},
-            "edges": {},
-            "rare_events": {},
+            "global_coverage": {"uops": {}, "edges": {}, "rare_events": {}},
+            "per_file_coverage": {},
             "uop_map": {},
             "edge_map": {},
             "rare_event_map": {},
@@ -106,9 +105,8 @@ ADD_TO_TRACE: _STORE_FAST
 
         # Mock load_coverage_state to return the structure main() expects
         mock_state = {
-            "uops": {},
-            "edges": {},
-            "rare_events": {},
+            "global_coverage": {"uops": {}, "edges": {}, "rare_events": {}},
+            "per_file_coverage": {},
             "uop_map": {},
             "edge_map": {},
             "rare_event_map": {},
@@ -141,9 +139,8 @@ Bailing on recursive call
 
         # Mock load_coverage_state to return the structure main() expects
         mock_state = {
-            "uops": {},
-            "edges": {},
-            "rare_events": {},
+            "global_coverage": {"uops": {}, "edges": {}, "rare_events": {}},
+            "per_file_coverage": {},
             "uop_map": {},
             "edge_map": {},
             "rare_event_map": {},


### PR DESCRIPTION
## Summary
- Fix broken `main()` CLI that accessed `global_coverage_state["uops"]` directly instead of `global_coverage_state["global_coverage"]["uops"]`
- Extract `merge_coverage_into_global()` as a shared function in `coverage.py`
- Update `ScoringManager._update_global_coverage` in `scoring.py` to delegate to the shared function
- Fix `mock_state` dicts in CLI tests to use correct nested structure
- Add 4 tests for `merge_coverage_into_global`: new items, existing items, mixed, multiple harnesses

Closes #499

## Test plan
- [x] All 72 coverage/CLI/scoring tests pass
- [x] Lint and type-check clean (`mypy lafleur/coverage.py lafleur/scoring.py`)
- [x] CLI test mock states updated to correct nested `global_coverage` structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)