### PR TITLE
refactor: replace os.rename with Path.rename in save_coverage_state

### DIFF
--- a/lafleur/coverage.py
+++ b/lafleur/coverage.py
@@ -9,7 +9,6 @@ fuzzer's persistent state with integer-based IDs.
 """
 
 import argparse
-import os
 import pickle
 import re
 import secrets
@@ -300,7 +299,7 @@ def save_coverage_state(state: dict[str, Any]) -> None:
         with open(tmp_path, "wb") as f:  # Open in binary write mode
             pickle.dump(state, f)
         # The write was successful, now atomically rename the file.
-        os.rename(tmp_path, COVERAGE_STATE_FILE)
+        tmp_path.rename(COVERAGE_STATE_FILE)
     except (IOError, OSError, pickle.PicklingError) as e:
         print(f"[!] Error during atomic save of coverage state: {e}", file=sys.stderr)
         # If an error occurred, try to clean up the temporary file.


### PR DESCRIPTION
## Summary
- Replace `os.rename(tmp_path, COVERAGE_STATE_FILE)` with `tmp_path.rename(COVERAGE_STATE_FILE)` for consistent pathlib usage
- Remove `import os` which is no longer needed

Closes #501

## Test plan
- [x] All 72 coverage/CLI tests pass
- [x] Lint and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)