### PR TITLE
refactor: Align no-JIT return dict with JIT return dict

### DIFF
--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -266,6 +266,8 @@ def get_jit_stats(namespace: dict, baseline: dict[tuple[int, int], int] | None =
             "functions_scanned": 0,
             "jit_available": False,
             "zombie_traces": 0,
+            "valid_traces": 0,
+            "warm_traces": 0,
             "max_exit_count": 0,
             "max_chain_depth": 0,
             "min_code_size": 0,

--- a/tests/test_driver_internals.py
+++ b/tests/test_driver_internals.py
@@ -218,6 +218,8 @@ class TestGetJitStats(unittest.TestCase):
         self.assertEqual(stats["executors"], 0)
         self.assertEqual(stats["functions_scanned"], 0)
         self.assertFalse(stats["jit_available"])
+        self.assertEqual(stats["valid_traces"], 0)
+        self.assertEqual(stats["warm_traces"], 0)
 
     def test_get_jit_stats_with_empty_namespace(self):
         """Test get_jit_stats with empty namespace."""


### PR DESCRIPTION
## Summary
- Add missing `valid_traces` and `warm_traces` keys to the no-JIT fallback return in `get_jit_stats`
- Update test to verify the new keys

## Test plan
- [x] All 51 driver tests pass
- [x] Ruff check/format clean, mypy passes

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)