### PR TITLE
refactor: Add comprehensive docstring to walk_code_objects

### DIFF
--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -162,7 +162,18 @@ if hasattr(sys, "set_int_max_str_digits"):
 def walk_code_objects(
     code_obj: CodeType, visited: set | None = None
 ) -> collections.abc.Generator[CodeType, None, None]:
-    """Recursively yield a code object and all its nested code objects."""
+    """Recursively yield a code object and all its nested code objects.
+
+    Walks the constant pool of each code object to find nested functions,
+    classes, and comprehensions.
+
+    Args:
+        code_obj: Root code object to start from.
+        visited: Set of already-visited code objects (for cycle detection).
+
+    Yields:
+        Each code object reachable from the root.
+    """
     if visited is None:
         visited = set()
     if code_obj in visited:

--- a/tests/test_driver_internals.py
+++ b/tests/test_driver_internals.py
@@ -415,6 +415,18 @@ class TestWalkCodeObjects(unittest.TestCase):
         result = list(walk_code_objects(simple.__code__))
         self.assertGreaterEqual(len(result), 1)
 
+    def test_walk_shared_visited_prevents_duplicates(self):
+        """Passing the same code object with a shared visited set yields no duplicates."""
+
+        def func():
+            pass
+
+        visited: set = set()
+        first = list(walk_code_objects(func.__code__, visited))
+        second = list(walk_code_objects(func.__code__, visited))
+        self.assertGreaterEqual(len(first), 1)
+        self.assertEqual(len(second), 0)
+
 
 class TestSnapshotExecutorState(unittest.TestCase):
     """Tests for snapshot_executor_state function."""


### PR DESCRIPTION
## Summary
- Add detailed docstring to `walk_code_objects` documenting recursive behavior and cycle detection
- Add test for shared `visited` set preventing duplicate yields

## Test plan
- [x] All 52 driver tests pass (1 new)
- [x] Ruff check/format clean, mypy passes

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)