### PR TITLE
refactor: Add CPython version comment to ctypes struct definitions

### DIFF
--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -49,6 +49,22 @@ BLOOM_K = 6
 BLOOM_WORDS = 8
 
 
+# ---------------------------------------------------------------------------
+# ctypes mirrors of CPython JIT internals from pycore_optimizer.h
+#
+# These structs must match the memory layout of the corresponding C structs
+# in CPython. If CPython's struct layout changes (fields added, reordered,
+# or resized), these definitions will silently read wrong memory.
+#
+# Target: CPython 3.15 (main branch as of 2026-02)
+# Source: Include/internal/pycore_optimizer.h
+#
+# If introspection produces unexpected values after a CPython update,
+# compare ctypes.sizeof(PyExecutorObject) against the C struct size
+# and update these definitions accordingly.
+# ---------------------------------------------------------------------------
+
+
 class _PyBloomFilter(ctypes.Structure):
     _fields_ = [("bits", ctypes.c_uint32 * BLOOM_WORDS)]
 


### PR DESCRIPTION
## Summary
- Add documentation comment block above ctypes struct definitions noting CPython 3.15 target version
- Note the risk of silent breakage on struct layout changes

## Test plan
- [x] Documentation-only, all 52 driver tests pass
- [x] Ruff check/format clean, mypy passes

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)