### PR TITLE
refactor: Add source comments to bloom filter constants

### DIFF
--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -42,11 +42,13 @@ except ImportError:
     HAS_TESTINTERNALCAPI = False
 
 
-# Bloom filter constants
-BLOOM_SEED = 20221211
-PyHASH_MULTIPLIER = 1000003
-BLOOM_K = 6
-BLOOM_WORDS = 8
+# Bloom filter constants from CPython's pycore_optimizer.h.
+# These must match the values used by the JIT's bloom filter implementation
+# to correctly replicate bloom_filter_may_contain().
+BLOOM_SEED = 20221211  # _Py_BLOOM_SEED
+PyHASH_MULTIPLIER = 1000003  # _PyHASH_MULTIPLIER (from pyhash.h)
+BLOOM_K = 6  # _Py_BLOOM_K (number of hash probes)
+BLOOM_WORDS = 8  # _Py_BLOOM_WORDS (uint32 words in filter)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Document bloom filter magic numbers with CPython source identifiers (`_Py_BLOOM_SEED`, `_PyHASH_MULTIPLIER`, etc.)

## Test plan
- [x] Documentation-only, all 52 driver tests pass
- [x] Ruff check/format clean, mypy passes

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)