### PR TITLE
refactor: Handle corrupted mutator scores file gracefully

### DIFF
--- a/lafleur/learning.py
+++ b/lafleur/learning.py
@@ -44,11 +44,19 @@ class MutatorScoreTracker:
     def load_state(self):
         """Load the last known scores and attempts from a file."""
         if MUTATOR_SCORES_FILE.is_file():
-            print("[+] Loading mutator scores from previous run.")
-            with open(MUTATOR_SCORES_FILE, "r") as f:
-                data = json.load(f)
+            try:
+                with open(MUTATOR_SCORES_FILE, "r") as f:
+                    data = json.load(f)
                 self.scores = defaultdict(float, data.get("scores", {}))
                 self.attempts = defaultdict(int, data.get("attempts", {}))
+                print("[+] Loading mutator scores from previous run.")
+            except (json.JSONDecodeError, KeyError, TypeError) as e:
+                print(
+                    f"[!] Warning: Corrupted mutator scores file, starting fresh: {e}",
+                    file=sys.stderr,
+                )
+                self.scores = defaultdict(float)
+                self.attempts = defaultdict(int)
 
     def save_state(self):
         """Save the current scores and attempts to a file."""

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -252,6 +252,18 @@ class TestMutatorScoreTracker(unittest.TestCase):
         self.assertIn("MockTransformer2", tracker.all_transformers)
         self.assertIn("MockTransformer3", tracker.all_transformers)
 
+    @patch("lafleur.learning.MUTATOR_SCORES_FILE")
+    def test_load_state_handles_corrupted_file(self, mock_file_path):
+        """Test that corrupted state file is handled gracefully."""
+        mock_file_path.is_file.return_value = True
+
+        with patch("builtins.open", mock_open(read_data="{ corrupted json")):
+            tracker = MutatorScoreTracker(self.transformers, decay_factor=0.995)
+
+        # Should have fresh/empty state, not crash
+        self.assertEqual(dict(tracker.scores), {})
+        self.assertEqual(dict(tracker.attempts), {})
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Wrap `load_state`'s `json.load` in try/except for `JSONDecodeError`, `KeyError`, and `TypeError`
- On corruption, warn to stderr and start with fresh state instead of crashing
- Move success print after successful load
- Add `test_load_state_handles_corrupted_file` test

## Test plan
- [x] `pytest tests/test_learning.py -v` — 14 tests pass (1 new)
- [x] Full test suite passes (131 tests)
- [x] `ruff check && ruff format --check` clean
- [x] `mypy lafleur/learning.py` clean

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)