### PR TITLE
refactor: Ensure parent directories exist in save_state and save_telemetry

### DIFF
--- a/lafleur/learning.py
+++ b/lafleur/learning.py
@@ -60,6 +60,7 @@ class MutatorScoreTracker:
 
     def save_state(self):
         """Save the current scores and attempts to a file."""
+        MUTATOR_SCORES_FILE.parent.mkdir(parents=True, exist_ok=True)
         data = {"scores": dict(self.scores), "attempts": dict(self.attempts)}
         with open(MUTATOR_SCORES_FILE, "w") as f:
             json.dump(data, f, indent=2)
@@ -108,6 +109,7 @@ class MutatorScoreTracker:
 
     def save_telemetry(self):
         """Save a snapshot of the current effectiveness metrics to a log."""
+        MUTATOR_TELEMETRY_LOG.parent.mkdir(parents=True, exist_ok=True)
         success_rates = {
             name: self.scores[name] / max(1, self.attempts.get(name, 1))
             for name in self.strategies + self.all_transformers


### PR DESCRIPTION
## Summary
- Add `parent.mkdir(parents=True, exist_ok=True)` before file writes in `save_state` and `save_telemetry`
- Prevents `FileNotFoundError` on fresh checkouts where `coverage/` or `logs/` don't exist yet
- Add `test_save_telemetry_creates_parent_dirs` and update `test_save_state_to_file` to verify mkdir calls

## Test plan
- [x] `pytest tests/test_learning.py -v` — 14 tests pass (1 new)
- [x] `ruff check && ruff format --check` clean
- [x] `mypy lafleur/learning.py` clean

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)