### PR TITLE
refactor: Accept strategies as constructor parameter in MutatorScoreTracker

### DIFF
--- a/lafleur/learning.py
+++ b/lafleur/learning.py
@@ -28,11 +28,17 @@ class MutatorScoreTracker:
     WEIGHT_FLOOR = 0.05  # Minimum weight to ensure all mutators get some chance
     DEFAULT_EPSILON = 0.1  # Probability of random exploration vs exploitation
 
+    DEFAULT_STRATEGIES = ["deterministic", "havoc", "spam"]
+
     def __init__(
-        self, all_transformers: list[type], decay_factor: float = 0.995, min_attempts: int = 10
+        self,
+        all_transformers: list[type],
+        decay_factor: float = 0.995,
+        min_attempts: int = 10,
+        strategies: list[str] | None = None,
     ):
         self.all_transformers = [t.__name__ for t in all_transformers]
-        self.strategies = ["deterministic", "havoc", "spam"]
+        self.strategies = strategies if strategies is not None else list(self.DEFAULT_STRATEGIES)
         self.decay_factor = decay_factor
         self.min_attempts = min_attempts
 

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -138,7 +138,10 @@ class LafleurOrchestrator:
         self.run_stats = run_stats if run_stats is not None else load_run_stats()
 
         self.timing_fuzz = timing_fuzz
-        self.score_tracker = MutatorScoreTracker(ast_mutator.transformers)
+        self.score_tracker = MutatorScoreTracker(
+            ast_mutator.transformers,
+            strategies=["deterministic", "havoc", "spam", "helper_sniper", "sniper"],
+        )
 
         # Initialize the mutation controller for managing mutation strategies
         self.mutation_controller = MutationController(

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -259,13 +259,23 @@ class TestMutatorScoreTracker(unittest.TestCase):
 
         tracker = MutatorScoreTracker(self.transformers)
 
-        # Should have the three standard strategies
+        # Should have the three default strategies
         self.assertEqual(tracker.strategies, ["deterministic", "havoc", "spam"])
 
         # Should have transformer names
         self.assertIn("MockTransformer1", tracker.all_transformers)
         self.assertIn("MockTransformer2", tracker.all_transformers)
         self.assertIn("MockTransformer3", tracker.all_transformers)
+
+    @patch("lafleur.learning.MUTATOR_SCORES_FILE")
+    def test_custom_strategies(self, mock_file_path):
+        """Test that custom strategies can be passed to the constructor."""
+        mock_file_path.is_file.return_value = False
+
+        custom = ["deterministic", "havoc", "spam", "helper_sniper", "sniper"]
+        tracker = MutatorScoreTracker(self.transformers, strategies=custom)
+
+        self.assertEqual(tracker.strategies, custom)
 
     @patch("lafleur.learning.MUTATOR_SCORES_FILE")
     def test_load_state_handles_corrupted_file(self, mock_file_path):


### PR DESCRIPTION
## Summary
- Add optional `strategies` parameter to `MutatorScoreTracker.__init__`, defaulting to `DEFAULT_STRATEGIES`
- Update orchestrator to pass full strategy list including `helper_sniper` and `sniper`
- Ensures telemetry `success_rates` covers all strategies used by `MutationController`
- Add `test_custom_strategies` test

## Test plan
- [x] `pytest tests/test_learning.py -v` — 15 tests pass (1 new)
- [x] `pytest tests/orchestrator/ -v` — 309 tests pass
- [x] `ruff check && ruff format --check` clean
- [x] `mypy lafleur/learning.py lafleur/orchestrator.py` clean

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)