### PR TITLE
refactor: Replace direct attempts manipulation with record_attempt

### DIFF
--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -219,8 +219,7 @@ class MutationController:
             transformer_class = RANDOM.choices(
                 self.ast_mutator.transformers, weights=dynamic_weights, k=1
             )[0]
-            # Record the attempt
-            self.score_tracker.attempts[transformer_class.__name__] += 1
+            self.score_tracker.record_attempt(transformer_class.__name__)
             transformers_applied.append(transformer_class.__name__)
 
             tree = transformer_class().visit(tree)
@@ -371,9 +370,8 @@ class MutationController:
 
         chosen_strategy = RANDOM.choices(strategy_candidates, weights=dynamic_weights, k=1)[0]
 
-        # Record the attempt for the chosen strategy only
         chosen_name = chosen_strategy.__name__.replace("_run_", "").replace("_stage", "")
-        self.score_tracker.attempts[chosen_name] += 1
+        self.score_tracker.record_attempt(chosen_name)
 
         # Check if the AST is large enough to require slicing
         len_body = (

--- a/tests/orchestrator/test_mutation_strategies.py
+++ b/tests/orchestrator/test_mutation_strategies.py
@@ -27,9 +27,14 @@ class TestApplyMutationStrategy(unittest.TestCase):
         self.controller.ast_mutator = MagicMock()
         self.controller.ast_mutator.transformers = [MagicMock, MagicMock]
 
-        # Mock score_tracker
+        # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
+        self.controller.score_tracker.record_attempt.side_effect = (
+            lambda name: self.controller.score_tracker.attempts.__setitem__(
+                name, self.controller.score_tracker.attempts[name] + 1
+            )
+        )
         self.controller.score_tracker.get_weights.return_value = [1.0, 1.0, 1.0, 1.0]
 
         # Create default mock strategy methods with __name__ attributes
@@ -317,9 +322,14 @@ class TestRunHavocStage(unittest.TestCase):
         self.mock_transformer.return_value.visit = MagicMock(side_effect=lambda x: x)
         self.controller.ast_mutator.transformers = [self.mock_transformer]
 
-        # Mock score_tracker
+        # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
+        self.controller.score_tracker.record_attempt.side_effect = (
+            lambda name: self.controller.score_tracker.attempts.__setitem__(
+                name, self.controller.score_tracker.attempts[name] + 1
+            )
+        )
         self.controller.score_tracker.get_weights.return_value = [1.0]
 
     def test_small_ast_applies_multiple_mutations(self):
@@ -524,9 +534,14 @@ class TestRunSniperStage(unittest.TestCase):
         self.mock_transformer.return_value.visit = MagicMock(side_effect=lambda x: x)
         self.controller.ast_mutator.transformers = [self.mock_transformer]
 
-        # Mock score_tracker (needed by havoc fallback)
+        # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
+        self.controller.score_tracker.record_attempt.side_effect = (
+            lambda name: self.controller.score_tracker.attempts.__setitem__(
+                name, self.controller.score_tracker.attempts[name] + 1
+            )
+        )
         self.controller.score_tracker.get_weights.return_value = [1.0]
 
         self.tree = ast.parse(
@@ -588,9 +603,14 @@ class TestRunHelperSniperStage(unittest.TestCase):
         self.mock_transformer.return_value.visit = MagicMock(side_effect=lambda x: x)
         self.controller.ast_mutator.transformers = [self.mock_transformer]
 
-        # Mock score_tracker (needed by havoc fallback)
+        # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
+        self.controller.score_tracker.record_attempt.side_effect = (
+            lambda name: self.controller.score_tracker.attempts.__setitem__(
+                name, self.controller.score_tracker.attempts[name] + 1
+            )
+        )
         self.controller.score_tracker.get_weights.return_value = [1.0]
 
         self.tree = ast.parse(


### PR DESCRIPTION
## Summary
- Replace `self.score_tracker.attempts[name] += 1` with `self.score_tracker.record_attempt(name)` in `apply_mutation_strategy` and `_run_havoc_stage`
- Ensures periodic decay is triggered through the proper API instead of bypassing it
- Update test mocks to wire `record_attempt` to the real `attempts` dict via side_effect

## Test plan
- [x] `pytest tests/orchestrator/test_mutation_strategies.py -v` — 33 tests pass
- [x] `pytest tests/test_learning.py -v` — 15 tests pass
- [x] `ruff check && ruff format --check` clean
- [x] `mypy lafleur/mutation_controller.py` clean

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)