### PR TITLE
refactor: Add error handling to save_run_stats

### DIFF
--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -71,11 +71,15 @@ def load_run_stats() -> dict[str, Any]:
 
 
 def save_run_stats(stats: dict[str, Any]) -> None:
-    """
-    Save the updated run statistics to the JSON file.
-    """
-    with open(RUN_STATS_FILE, "w", encoding="utf-8") as f:
-        json.dump(stats, f, indent=2, sort_keys=True)
+    """Save the updated run statistics to the JSON file."""
+    try:
+        with open(RUN_STATS_FILE, "w", encoding="utf-8") as f:
+            json.dump(stats, f, indent=2, sort_keys=True)
+    except (IOError, OSError) as e:
+        print(
+            f"Warning: Could not save run stats: {e}",
+            file=sys.stderr,
+        )
 
 
 class TeeLogger:

--- a/tests/test_utils_core.py
+++ b/tests/test_utils_core.py
@@ -212,6 +212,24 @@ class TestSaveRunStats(unittest.TestCase):
             self.assertLess(a_pos, m_pos)
             self.assertLess(m_pos, z_pos)
 
+    def test_save_handles_write_error(self):
+        """Test that IOError during save is caught and warned."""
+        with patch("builtins.open", side_effect=IOError("disk full")):
+            with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+                save_run_stats({"total_sessions": 1})
+
+        self.assertIn("Warning", mock_stderr.getvalue())
+        self.assertIn("disk full", mock_stderr.getvalue())
+
+    def test_save_handles_permission_error(self):
+        """Test that PermissionError during save is caught and warned."""
+        with patch("builtins.open", side_effect=PermissionError("access denied")):
+            with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+                save_run_stats({"total_sessions": 1})
+
+        self.assertIn("Warning", mock_stderr.getvalue())
+        self.assertIn("access denied", mock_stderr.getvalue())
+
 
 class TestTeeLogger(unittest.TestCase):
     """Tests for TeeLogger class."""


### PR DESCRIPTION
## Summary
- Wrap `save_run_stats` file write in try/except for `IOError`/`OSError`
- Prints a warning to stderr instead of crashing the fuzzer on disk full or permission errors

## Test plan
- [x] `pytest tests/test_utils_core.py -v` — 21 tests pass (2 new)
- [x] `ruff check && ruff format --check` clean
- [x] `mypy lafleur/utils.py` clean

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)