### PR TITLE
refactor: Add encoding, isatty, and fileno to TeeLogger

### DIFF
--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -108,6 +108,24 @@ class TeeLogger:
         """Close the log file."""
         self.log_file.close()
 
+    @property
+    def encoding(self) -> str:
+        """Return the encoding of the original stream."""
+        return getattr(self.original_stream, "encoding", "utf-8")
+
+    def isatty(self) -> bool:
+        """Return whether the original stream is a TTY."""
+        return hasattr(self.original_stream, "isatty") and self.original_stream.isatty()
+
+    def fileno(self) -> int:
+        """Return the file descriptor of the original stream.
+
+        Raises OSError if the original stream doesn't have a file descriptor.
+        """
+        if hasattr(self.original_stream, "fileno"):
+            return self.original_stream.fileno()
+        raise OSError("TeeLogger does not have a file descriptor")
+
 
 @dataclass
 class ExecutionResult:

--- a/tests/test_utils_core.py
+++ b/tests/test_utils_core.py
@@ -296,6 +296,76 @@ class TestTeeLogger(unittest.TestCase):
 
             logger.close()
 
+    def test_encoding_delegates_to_stream(self):
+        """Test that encoding property delegates to the original stream."""
+        mock_stream = MagicMock()
+        mock_stream.encoding = "utf-8"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "test.log"
+            logger = TeeLogger(log_path, mock_stream)
+
+            self.assertEqual(logger.encoding, "utf-8")
+            logger.close()
+
+    def test_encoding_defaults_to_utf8(self):
+        """Test that encoding defaults to utf-8 when stream has no encoding."""
+        mock_stream = MagicMock(spec=[])  # No attributes at all
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "test.log"
+            logger = TeeLogger(log_path, mock_stream)
+
+            self.assertEqual(logger.encoding, "utf-8")
+            logger.close()
+
+    def test_isatty_false_for_stringio(self):
+        """Test that isatty returns False for StringIO."""
+        original_stream = StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "test.log"
+            logger = TeeLogger(log_path, original_stream)
+
+            self.assertFalse(logger.isatty())
+            logger.close()
+
+    def test_isatty_delegates_to_tty_stream(self):
+        """Test that isatty delegates True when stream is a TTY."""
+        mock_stream = MagicMock()
+        mock_stream.isatty.return_value = True
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "test.log"
+            logger = TeeLogger(log_path, mock_stream)
+
+            self.assertTrue(logger.isatty())
+            logger.close()
+
+    def test_fileno_raises_for_stringio(self):
+        """Test that fileno raises OSError for StringIO."""
+        original_stream = StringIO()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "test.log"
+            logger = TeeLogger(log_path, original_stream)
+
+            with self.assertRaises(OSError):
+                logger.fileno()
+            logger.close()
+
+    def test_fileno_delegates_to_stream(self):
+        """Test that fileno delegates to the original stream."""
+        mock_stream = MagicMock()
+        mock_stream.fileno.return_value = 1
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "test.log"
+            logger = TeeLogger(log_path, mock_stream)
+
+            self.assertEqual(logger.fileno(), 1)
+            logger.close()
+
 
 class TestExecutionResult(unittest.TestCase):
     """Tests for ExecutionResult dataclass."""


### PR DESCRIPTION
## Summary
- Add `encoding` property delegating to the original stream (defaults to `"utf-8"`)
- Add `isatty()` method delegating to the original stream
- Add `fileno()` method delegating to the original stream (raises `OSError` if unavailable)
- Prevents `AttributeError` when libraries probe `sys.stdout.encoding` or `sys.stdout.isatty()`

## Test plan
- [x] `pytest tests/test_utils_core.py -v` — 27 tests pass (6 new)
- [x] `ruff check && ruff format --check` clean
- [x] `mypy lafleur/utils.py` clean

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)