### PR TITLE
refactor: replace Optional with union syntax in analysis.py

### DIFF
--- a/lafleur/analysis.py
+++ b/lafleur/analysis.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, asdict
 from enum import Enum
 import re
 import signal
-from typing import Optional
 
 
 class CrashType(str, Enum):
@@ -20,7 +19,7 @@ class CrashSignature:
     category: str  # High-level category (ASAN, ASSERT, etc)
     crash_type: CrashType  # Enum for programmatic handling
     returncode: int
-    signal_name: Optional[str]
+    signal_name: str | None
     fingerprint: str  # Unique string for minimization matching
 
     def to_dict(self) -> dict:
@@ -106,7 +105,7 @@ class CrashFingerprinter:
         }
     )
 
-    def _parse_asan_stack(self, log_content: str) -> Optional[str]:
+    def _parse_asan_stack(self, log_content: str) -> str | None:
         """
         Parse ASan stack trace to find the first meaningful CPython function.
 


### PR DESCRIPTION
## Summary
- Replace `Optional[str]` with `str | None` in `CrashSignature.signal_name` and `_parse_asan_stack` return type
- Remove unused `from typing import Optional` import
- ASAN casing already consistent: `ASAN_*` for identifiers, `ASan` in prose comments

Closes #549

## Test plan
- [x] All 11 tests in `tests/test_analysis.py` pass
- [x] `ruff check` and `ruff format` clean
- [x] `mypy lafleur/analysis.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)