### PR TITLE
fix: validate crash returncode in minimize_session

### DIFF
--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -134,6 +134,13 @@ def minimize_session(crash_dir: Path, target_python: str, force_overwrite: bool)
         print("[!] Error: Invalid metadata.json.")
         sys.exit(1)
 
+    # Validate that we have a non-zero crash return code
+    target_returncode = metadata.get("returncode")
+    if target_returncode is None or target_returncode == 0:
+        print("[!] Error: metadata.json has no crash return code (returncode is missing or 0).")
+        print("    Cannot determine crash reproduction without a non-zero exit code.")
+        sys.exit(1)
+
     grep_pattern = extract_grep_pattern(metadata)
     print(f"[*] Target Fingerprint: {metadata.get('fingerprint')}")
     print(f"[*] Grep Pattern: '{grep_pattern}'")


### PR DESCRIPTION
## Summary
- Add validation that `returncode` is present and non-zero in metadata.json
- Exit early with clear error message if returncode is missing or 0
- Prevents check_reproduction from incorrectly matching clean exits as crash reproductions

Closes #555

## Test plan
- [x] `test_missing_returncode_exits` — missing key causes exit(1)
- [x] `test_zero_returncode_exits` — zero value causes exit(1)
- [x] `test_valid_returncode_proceeds` — non-zero proceeds normally
- [x] All 39 tests pass
- [x] `ruff check`, `ruff format`, `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)