### PR TITLE
refactor: generalize rename_harnesses for all harness variants

### DIFF
--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -67,13 +67,21 @@ def measure_execution_time(cmd: list[str], timeout: int) -> float:
 
 def rename_harnesses(source: str, suffix: str) -> str:
     """
-    Rename 'uop_harness_f1' to 'uop_harness_f1_{suffix}' to prevent collisions
+    Rename 'uop_harness_fN' to 'uop_harness_fN_{suffix}' to prevent collisions
     when concatenating multiple scripts.
     """
-    # Rename definitions
-    source = re.sub(r"def\s+uop_harness_f1\(\):", f"def uop_harness_f1_{suffix}():", source)
-    # Rename calls
-    source = re.sub(r"uop_harness_f1\(\)", f"uop_harness_f1_{suffix}()", source)
+    # Rename definitions (with or without parameters)
+    source = re.sub(
+        r"def\s+(uop_harness_f\d+)\s*\(",
+        rf"def \1_{suffix}(",
+        source,
+    )
+    # Rename calls (with or without arguments)
+    source = re.sub(
+        r"\b(uop_harness_f\d+)\s*\(",
+        rf"\1_{suffix}(",
+        source,
+    )
     return source
 
 

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -267,6 +267,43 @@ class TestMinimizeEdgeCases(unittest.TestCase):
         renamed = rename_harnesses(source, "0")
         self.assertEqual(source, renamed)
 
+    def test_rename_harnesses_f2(self):
+        """Test renaming uop_harness_f2."""
+        source = "def uop_harness_f2():\n    pass\nuop_harness_f2()"
+        renamed = rename_harnesses(source, "0")
+        self.assertIn("def uop_harness_f2_0(", renamed)
+        self.assertIn("uop_harness_f2_0()", renamed)
+        self.assertNotIn("def uop_harness_f2()", renamed)
+
+    def test_rename_harnesses_with_params(self):
+        """Test renaming harnesses that have parameters."""
+        source = "def uop_harness_f1(x, y):\n    pass\nuop_harness_f1(1, 2)"
+        renamed = rename_harnesses(source, "0")
+        self.assertIn("def uop_harness_f1_0(x, y):", renamed)
+        self.assertIn("uop_harness_f1_0(1, 2)", renamed)
+
+    def test_rename_harnesses_multiple_variants(self):
+        """Test renaming multiple harness variants independently."""
+        source = (
+            "def uop_harness_f1():\n    pass\n"
+            "def uop_harness_f2():\n    pass\n"
+            "uop_harness_f1()\nuop_harness_f2()"
+        )
+        renamed = rename_harnesses(source, "5")
+        self.assertIn("def uop_harness_f1_5(", renamed)
+        self.assertIn("def uop_harness_f2_5(", renamed)
+        self.assertIn("uop_harness_f1_5()", renamed)
+        self.assertIn("uop_harness_f2_5()", renamed)
+
+    def test_rename_harnesses_no_false_positives(self):
+        """Test that similar names are not falsely renamed."""
+        source = "def uop_harness_factory():\n    pass\nmy_uop_harness_f1()"
+        renamed = rename_harnesses(source, "0")
+        # uop_harness_factory should NOT be renamed (doesn't match f\d+)
+        self.assertIn("def uop_harness_factory():", renamed)
+        # my_uop_harness_f1 should NOT be renamed (\b word boundary)
+        self.assertIn("my_uop_harness_f1()", renamed)
+
     @patch("lafleur.minimize.run_session")
     @patch("lafleur.minimize.shutil.which")
     def test_crash_does_not_reproduce_initially(self, mock_which, mock_run_session):


### PR DESCRIPTION
## Summary
- Match `uop_harness_f\d+` instead of literal `uop_harness_f1` — handles f2, f3, etc.
- Use `\s*\(` instead of `\(\):` — handles harnesses with parameters
- Add `\b` word boundary on call pattern to prevent false matches on longer identifiers

Closes #557

## Test plan
- [x] `test_rename_harnesses_f2` — f2 variant renamed
- [x] `test_rename_harnesses_with_params` — parameters preserved
- [x] `test_rename_harnesses_multiple_variants` — f1 and f2 renamed independently
- [x] `test_rename_harnesses_no_false_positives` — factory/prefixed names not touched
- [x] All 43 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)