### PR TITLE
refactor: convert REPRO_ENV to factory function

### DIFF
--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from lafleur.minimize import (
+    _make_repro_env,
     rename_harnesses,
     extract_grep_pattern,
     minimize_session,
@@ -369,6 +370,18 @@ class TestMinimizeEdgeCases(unittest.TestCase):
 
 class TestMinimizeHelperFunctions(unittest.TestCase):
     """Additional tests for helper functions."""
+
+    def test_repro_env_inherits_fuzzing_env(self):
+        """Test that _make_repro_env() includes FUZZING_ENV keys."""
+        env = _make_repro_env()
+        self.assertEqual(env["PYTHON_JIT"], "1")
+        self.assertEqual(env["ASAN_OPTIONS"], "detect_leaks=0")
+
+    def test_repro_env_disables_logging(self):
+        """Test that _make_repro_env() disables verbose logging."""
+        env = _make_repro_env()
+        self.assertEqual(env["PYTHON_LLTRACE"], "0")
+        self.assertEqual(env["PYTHON_OPT_DEBUG"], "0")
 
     def test_extract_grep_pattern_empty_fingerprint(self):
         """Test grep pattern extraction with empty fingerprint."""


### PR DESCRIPTION
## Summary
- Replace module-level `REPRO_ENV` dict with `_make_repro_env()` factory function
- Derive from `FUZZING_ENV` (lafleur.utils) with verbose logging disabled (`PYTHON_LLTRACE=0`, `PYTHON_OPT_DEBUG=0`)
- Avoids capturing `os.environ` at import time
- Centralizes environment variable definitions

Closes #559

## Test plan
- [x] `test_repro_env_inherits_fuzzing_env` — PYTHON_JIT and ASAN_OPTIONS present
- [x] `test_repro_env_disables_logging` — PYTHON_LLTRACE and PYTHON_OPT_DEBUG set to "0"
- [x] All 45 tests pass
- [x] `ruff check`, `ruff format`, `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)