### PR TITLE
fix: add return type and fix measure_execution_time timeout

### DIFF
--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -64,7 +64,12 @@ def measure_execution_time(cmd: list[str], timeout: int) -> float:
     try:
         subprocess.run(cmd, capture_output=True, timeout=timeout, env=_make_repro_env())
     except subprocess.TimeoutExpired:
-        pass
+        elapsed = time.monotonic() - start_time
+        print(
+            f"  [!] Warning: Baseline measurement timed out after {elapsed:.1f}s. "
+            f"Using {timeout}s as baseline.",
+        )
+        return float(timeout)
     return time.monotonic() - start_time
 
 
@@ -131,7 +136,7 @@ def check_reproduction(
     return code_match and grep_match
 
 
-def minimize_session(crash_dir: Path, target_python: str, force_overwrite: bool):
+def minimize_session(crash_dir: Path, target_python: str, force_overwrite: bool) -> None:
     """Main logic to minimize a session crash."""
     print(f"[*] Minimizing crash bundle: {crash_dir}")
 


### PR DESCRIPTION
## Summary
- Add `-> None` return type annotation to `minimize_session`
- Fix `measure_execution_time` to return the timeout value (not wall-clock time) on timeout
- Print a warning when baseline measurement times out

Closes #561

## Test plan
- [x] `test_measure_execution_time_timeout_returns_timeout_value` validates return value and warning
- [x] All 46 tests pass
- [x] `ruff check`, `ruff format`, `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)