### PR TITLE
fix: comment all lines in mutate() SyntaxError handler

### DIFF
--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -298,7 +298,8 @@ class ASTMutator:
         try:
             tree = ast.parse(dedent(code_string))
         except SyntaxError:
-            return f"# Original code failed to parse:\n# {'#'.join(code_string.splitlines())}"
+            commented_lines = "\n# ".join(code_string.splitlines())
+            return f"# Original code failed to parse:\n# {commented_lines}"
 
         mutated_tree, _ = self.mutate_ast(tree, seed=seed, mutations=mutations)
 

--- a/tests/mutators/test_engine.py
+++ b/tests/mutators/test_engine.py
@@ -116,9 +116,27 @@ class TestASTMutator(unittest.TestCase):
         mutator = ASTMutator()
         result = mutator.mutate(code)
 
-        # Should return error comment
+        # Should return error comment with each line properly commented
         self.assertIn("# Original code failed to parse:", result)
         self.assertIn("def broken", result)
+        for line in result.splitlines():
+            self.assertTrue(line.startswith("#"), f"Uncommented line: {line!r}")
+
+    def test_mutate_syntax_error_comments_all_lines(self):
+        """Test that SyntaxError fallback comments every line of multi-line input."""
+        code = "line one\nline two\nline three"
+
+        mutator = ASTMutator()
+        result = mutator.mutate(code)
+
+        lines = result.splitlines()
+        # Header + 3 original lines = 4 lines
+        self.assertEqual(len(lines), 4)
+        for line in lines:
+            self.assertTrue(line.startswith("#"), f"Uncommented line: {line!r}")
+        self.assertIn("line one", lines[1])
+        self.assertIn("line two", lines[2])
+        self.assertIn("line three", lines[3])
 
     def test_mutate_handles_unparsing_errors(self):
         """Test handling of AST unparsing failures."""
@@ -311,8 +329,10 @@ class TestASTMutator(unittest.TestCase):
         mutator = ASTMutator()
         result = mutator.mutate(code)
 
-        # Should return error comment
+        # Should return error comment with all lines commented
         self.assertIn("# Original code failed to parse:", result)
+        for line in result.splitlines():
+            self.assertTrue(line.startswith("#"), f"Uncommented line: {line!r}")
 
     def test_mutate_list_as_tree(self):
         """Test mutating when tree is a list."""


### PR DESCRIPTION
## Summary
- Fix `mutate()` SyntaxError handler which used `'#'.join()` producing a single long line instead of commenting each line separately
- Replace with `'\n# '.join()` so each original line gets its own `# ` prefix
- Tighten existing syntax error tests to verify all output lines are commented
- Add `test_mutate_syntax_error_comments_all_lines` for multi-line input

## Test plan
- [x] All 43 engine tests pass
- [x] ruff check/format clean
- [x] mypy passes

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)