### PR TITLE
fix: comment all lines in mutate() AttributeError handler

### DIFF
--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -306,4 +306,5 @@ class ASTMutator:
         try:
             return ast.unparse(mutated_tree)
         except AttributeError:
-            return f"# AST unparsing failed. Original code was:\n# {code_string}"
+            commented_lines = "\n# ".join(code_string.splitlines())
+            return f"# AST unparsing failed. Original code was:\n# {commented_lines}"

--- a/tests/mutators/test_engine.py
+++ b/tests/mutators/test_engine.py
@@ -149,6 +149,21 @@ class TestASTMutator(unittest.TestCase):
         self.assertIsInstance(result, str)
         self.assertNotIn("# AST unparsing failed", result)
 
+    def test_mutate_unparse_error_comments_all_lines(self):
+        """Test that AttributeError fallback comments every line of multi-line input."""
+        code = "x = 1\ny = 2\nz = 3"
+        mutator = ASTMutator()
+
+        with patch("ast.unparse", side_effect=AttributeError("bad node")):
+            result = mutator.mutate(code, seed=42)
+
+        self.assertIn("# AST unparsing failed", result)
+        lines = result.splitlines()
+        for line in lines:
+            self.assertTrue(line.startswith("#"), f"Uncommented line: {line!r}")
+        # Should have header + 3 original lines
+        self.assertEqual(len(lines), 4)
+
     def test_mutate_complex_code_structure(self):
         """Test mutating complex code with multiple constructs."""
         code = dedent("""


### PR DESCRIPTION
## Summary
- Fix `mutate()` AttributeError handler which used bare f-string interpolation, leaving multi-line input uncommented after the first line
- Apply the same `'\n# '.join()` pattern used in the SyntaxError handler
- Add `test_mutate_unparse_error_comments_all_lines` using mocked `ast.unparse`

## Test plan
- [x] All 44 engine tests pass
- [x] ruff check/format clean
- [x] mypy passes

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)