### PR TITLE
refactor: add type annotations to ASTMutator.__init__

### DIFF
--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -151,8 +151,8 @@ class ASTMutator:
     then unparsed back into a string of Python code.
     """
 
-    def __init__(self):
-        self.transformers = [
+    def __init__(self) -> None:
+        self.transformers: list[type[ast.NodeTransformer]] = [
             HelperFunctionInjector,  # Injects helpers for Sniper to target
             OperatorSwapper,
             ComparisonSwapper,


### PR DESCRIPTION
## Summary
- Add `-> None` return type to `ASTMutator.__init__`
- Add `list[type[ast.NodeTransformer]]` type annotation to `self.transformers`

## Test plan
- [x] All 45 engine tests pass
- [x] ruff check/format clean
- [x] mypy passes

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)