### PR TITLE
fix: handle boundary Unicode chars in ConstantPerturbator

### DIFF
--- a/lafleur/mutators/generic.py
+++ b/lafleur/mutators/generic.py
@@ -129,7 +129,10 @@ class ConstantPerturbator(ast.NodeTransformer):
         elif isinstance(node.value, str) and node.value and random.random() < 0.3:
             pos = random.randint(0, len(node.value) - 1)
             char_val = ord(node.value[pos])
-            new_char = chr(char_val + random.choice([-1, 1]))
+            try:
+                new_char = chr(char_val + random.choice([-1, 1]))
+            except ValueError:
+                return node  # At Unicode boundary, leave unchanged
             node.value = node.value[:pos] + new_char + node.value[pos + 1 :]
         return node
 


### PR DESCRIPTION
## Summary
- Fix `ConstantPerturbator` crash when mutating strings containing null bytes or max Unicode codepoints
- Wrap `chr()` call in try/except to leave string unchanged at Unicode boundaries
- Add `test_constant_perturbator_null_byte_string` and `test_constant_perturbator_max_codepoint_string`

## Test plan
- [x] All 111 generic mutator tests pass
- [x] ruff check/format clean
- [x] mypy passes

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)