### PR TITLE
fix: equalize ContainerChanger probability distribution

### DIFF
--- a/lafleur/mutators/generic.py
+++ b/lafleur/mutators/generic.py
@@ -368,9 +368,10 @@ class ContainerChanger(ast.NodeTransformer):
     """Change container types, e.g., from a list to a tuple or set."""
 
     def visit_List(self, node: ast.List) -> ast.expr:
-        if random.random() < 0.5:
+        roll = random.random()
+        if roll < 0.33:
             return ast.Set(elts=node.elts)
-        elif random.random() < 0.5:
+        elif roll < 0.66:
             return ast.Tuple(elts=node.elts, ctx=node.ctx)
         return node
 


### PR DESCRIPTION
## Summary
- Fix skewed probability distribution in `ContainerChanger.visit_List` (was 50%/25%/25%, now ~33% each)
- Replace two sequential `random.random()` calls with a single call using evenly spaced thresholds
- Add `test_container_changer_list_to_tuple` and `test_container_changer_equal_distribution`

## Test plan
- [x] All 113 generic mutator tests pass
- [x] ruff check/format clean
- [x] mypy passes

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)