### PR TITLE
docs: clarify OperatorSwapper LShift comment

### DIFF
--- a/lafleur/mutators/generic.py
+++ b/lafleur/mutators/generic.py
@@ -31,7 +31,10 @@ class OperatorSwapper(ast.NodeTransformer):
         ast.Div: [ast.Mult, ast.Add, ast.Sub, ast.FloorDiv],
         ast.FloorDiv: [ast.Div, ast.Mult, ast.Add, ast.Sub, ast.Mod],
         ast.Mod: [ast.FloorDiv, ast.Add, ast.Sub],
-        # Bitwise Operators, without LShift because it generates huge numbers
+        # Bitwise Operators
+        # Note: LShift can be replaced BY other operators (it's a key) but is never
+        # used AS a replacement (absent from all value lists) to avoid generating
+        # huge numbers. Same principle applied to Pow in arithmetic operators above.
         ast.LShift: [ast.RShift, ast.BitAnd, ast.BitOr, ast.BitXor],
         ast.RShift: [ast.BitAnd, ast.BitOr, ast.BitXor],
         ast.BitAnd: [ast.BitOr, ast.BitXor, ast.RShift],


### PR DESCRIPTION
## Summary
- Clarify misleading "without LShift" comment in `OperatorSwapper.OP_MAP`
- LShift IS a key (can be swapped away from) but never appears as a replacement value (to avoid huge numbers)
- Comment-only change, no behavior changes

## Test plan
- [x] ruff check/format clean
- [x] mypy passes

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)