### PR TITLE
fix: add per-statement probability gate to GuardInjector

### DIFF
--- a/lafleur/mutators/generic.py
+++ b/lafleur/mutators/generic.py
@@ -349,21 +349,22 @@ class GuardInjector(ast.NodeTransformer):
         node = visited
 
         if isinstance(node, ast.stmt) and not isinstance(node, ast.FunctionDef):
-            # The test uses our fuzzer-provided, seeded RNG instance.
-            test = ast.Compare(
-                left=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="fuzzer_rng", ctx=ast.Load()),
-                        attr="random",
-                        ctx=ast.Load(),
+            if random.random() < 0.3:
+                # The test uses our fuzzer-provided, seeded RNG instance.
+                test = ast.Compare(
+                    left=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="fuzzer_rng", ctx=ast.Load()),
+                            attr="random",
+                            ctx=ast.Load(),
+                        ),
+                        args=[],
+                        keywords=[],
                     ),
-                    args=[],
-                    keywords=[],
-                ),
-                ops=[ast.Lt()],
-                comparators=[ast.Constant(value=0.1)],  # Low probability
-            )
-            return ast.If(test=test, body=[node], orelse=[])
+                    ops=[ast.Lt()],
+                    comparators=[ast.Constant(value=0.1)],  # Low probability
+                )
+                return ast.If(test=test, body=[node], orelse=[])
         return node
 
 


### PR DESCRIPTION
## Summary
- Add `random.random() < 0.3` per-statement probability gate to `GuardInjector`
- Previously wrapped every single statement unconditionally, causing excessive code bloat
- Now only ~30% of statements get wrapped, consistent with other mutators
- Update `test_guard_injector` and `test_guard_injector_output` to patch `random.random`
- Add `test_guard_injector_skips_with_low_probability`

## Test plan
- [x] All 114 generic mutator tests pass
- [x] All 45 engine tests pass (no regression)
- [x] ruff check/format clean
- [x] mypy passes

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)