### PR TITLE
docs: document unused prefix parameter in _create_pow_attack

### DIFF
--- a/lafleur/mutators/scenarios_data.py
+++ b/lafleur/mutators/scenarios_data.py
@@ -61,7 +61,13 @@ for i_hash in range(100):
 
 
 def _create_pow_attack(prefix: str) -> list[ast.stmt]:
-    """Generate calls to pow() with tricky arguments."""
+    """Generate calls to pow() with tricky arguments.
+
+    Note: The prefix parameter is accepted but unused because this attack
+    generates only bare pow() calls with no variables or classes that need
+    namespacing. The parameter is kept to maintain a uniform Callable[[str],
+    list[ast.stmt]] interface with _create_len_attack and _create_hash_attack.
+    """
     attack_code = dedent("""
         # pow() attack injected by fuzzer
         try:


### PR DESCRIPTION
## Summary
- Adds a docstring note to `_create_pow_attack` explaining why the `prefix` parameter is accepted but unused
- It maintains a uniform `Callable[[str], list[ast.stmt]]` interface with `_create_len_attack` and `_create_hash_attack`

Closes #593

## Test plan
- [x] Docstring-only change, no behavioral changes
- [x] `ruff check` and `ruff format` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)