### PR TITLE
fix: add unique prefix to GuardExhaustionGenerator hardcoded names

### DIFF
--- a/tests/mutators/test_scenarios_control.py
+++ b/tests/mutators/test_scenarios_control.py
@@ -777,12 +777,17 @@ class TestStressPatternMutators(unittest.TestCase):
         tree = ast.parse(code)
 
         with patch("random.random", return_value=0.05):
-            mutator = GuardExhaustionGenerator()
-            mutated = mutator.visit(tree)
+            with patch("random.randint", return_value=5555):
+                mutator = GuardExhaustionGenerator()
+                mutated = mutator.visit(tree)
 
-        # Should have injected isinstance chain
+        # Should have injected isinstance chain with prefixed names
         func = mutated.body[0]
-        # Should have poly_list setup and loop
+        result = ast.unparse(func)
+        self.assertIn("poly_list_ge_5555", result)
+        self.assertIn("x_ge_5555", result)
+        self.assertIn("y_ge_5555", result)
+        self.assertIn("i_ge_5555", result)
         self.assertGreater(len(func.body), 1)
 
     def test_exit_stresser(self):


### PR DESCRIPTION
## Summary
- Add `ge_NNNN` prefix to all hardcoded variable names (`poly_list`, `x`, `y`, `i`) in `GuardExhaustionGenerator`
- Add `ast.fix_missing_locations` for the manually created For node
- Update test to verify prefixed names

## Test plan
- [x] 89 scenarios_control tests pass
- [x] ruff check/format clean
- [x] mypy clean

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)