### PR TITLE
docs: add clarifying comment to RecursionWrappingMutator recursive call

### DIFF
--- a/lafleur/mutators/scenarios_control.py
+++ b/lafleur/mutators/scenarios_control.py
@@ -246,6 +246,9 @@ class RecursionWrappingMutator(ast.NodeTransformer):
             )
 
             # 3. Create the recursive call to the function itself.
+            # No depth guard by design — the try/except RecursionError in step 5
+            # catches the eventual stack overflow, which is the intended stress
+            # behavior for the JIT's stack unwinding path.
             recursive_call = ast.Expr(
                 value=ast.Call(
                     func=ast.Name(id=recursive_func_name, ctx=ast.Load()), args=[], keywords=[]


### PR DESCRIPTION
## Summary
- Add comment explaining that the recursive call in step 3 has no depth guard by design
- The try/except RecursionError in step 5 catches the eventual stack overflow
- This is the intended stress behavior for JIT stack unwinding

## Test plan
- [x] 89 scenarios_control tests pass (comment-only change)
- [x] ruff check/format clean
- [x] mypy clean

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)