### PR TITLE
fix: add cleanup phase to RareEventStressTester combination attacks

### DIFF
--- a/lafleur/mutators/scenarios_runtime.py
+++ b/lafleur/mutators/scenarios_runtime.py
@@ -1021,6 +1021,27 @@ class RareEventStressTester(ast.NodeTransformer):
                 pass
                 """)
 
+        # Phase 3.5: Cleanup persistent state
+        if "set_eval_frame" in events:
+            attack_code += dedent("""
+            # Cleanup: Remove any installed trace functions
+            try:
+                sys.settrace(None)
+            except Exception:
+                pass
+            """)
+
+        if "builtin_dict" in events:
+            attack_code += dedent(f"""
+            # Cleanup: Remove any injected builtin keys
+            try:
+                for _cleanup_key_{prefix} in list(builtins.__dict__.keys()):
+                    if _cleanup_key_{prefix}.startswith('RARE_TEST_{prefix}'):
+                        del builtins.__dict__[_cleanup_key_{prefix}]
+            except Exception:
+                pass
+            """)
+
         # Add final verification
         attack_code += dedent(f"""
             # Phase 4: Verification - use objects after rare events


### PR DESCRIPTION
## Summary
- Add Phase 3.5 cleanup in `_create_combination_attack` between event triggers and verification
- Conditionally call `sys.settrace(None)` when `set_eval_frame` events are included
- Conditionally remove injected `RARE_TEST_` keys from `builtins.__dict__` when `builtin_dict` events are included
- Add 3 new tests: `test_combination_attack_cleans_up_trace`, `test_combination_attack_cleans_up_builtins`, `test_combination_no_unnecessary_cleanup`

## Test plan
- [x] 76 scenarios_runtime tests pass (3 new)
- [x] ruff check/format clean
- [x] mypy clean

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)