### PR TITLE
fix: make delta tachycardia exits check parent-relative with clamping

### DIFF
--- a/tests/orchestrator/test_jit_scoring.py
+++ b/tests/orchestrator/test_jit_scoring.py
@@ -110,6 +110,36 @@ class TestDeltaTachycardiaScoring(unittest.TestCase):
         score = scorer.calculate_score()
         self.assertEqual(score, 20.0)
 
+    def test_delta_exits_parent_relative_threshold(self):
+        """Parent with 100 delta exits, child with 110: 110 < max(20, 125) → no bonus."""
+        parent_stats = {"child_delta_total_exits": 100}
+        jit_stats = {"child_delta_max_exit_density": 0.1, "child_delta_total_exits": 110}
+        scorer = InterestingnessScorer(
+            jit_stats=jit_stats, parent_jit_stats=parent_stats, **self.scorer_args
+        )
+        score = scorer.calculate_score()
+        self.assertEqual(score, 0.0)
+
+    def test_delta_exits_parent_relative_threshold_exceeded(self):
+        """Parent with 100 delta exits, child with 130: 130 > max(20, 125) → bonus."""
+        parent_stats = {"child_delta_total_exits": 100}
+        jit_stats = {"child_delta_max_exit_density": 0.1, "child_delta_total_exits": 130}
+        scorer = InterestingnessScorer(
+            jit_stats=jit_stats, parent_jit_stats=parent_stats, **self.scorer_args
+        )
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
+
+    def test_delta_exits_floor_used_when_parent_low(self):
+        """Parent with 5 delta exits, child with 25: 25 > max(20, 6.25) = 20 → bonus."""
+        parent_stats = {"child_delta_total_exits": 5}
+        jit_stats = {"child_delta_max_exit_density": 0.1, "child_delta_total_exits": 25}
+        scorer = InterestingnessScorer(
+            jit_stats=jit_stats, parent_jit_stats=parent_stats, **self.scorer_args
+        )
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
+
     def test_delta_below_both_thresholds_no_bonus(self):
         """Both below thresholds — no tachycardia bonus."""
         jit_stats = {"child_delta_max_exit_density": 0.2, "child_delta_total_exits": 10}


### PR DESCRIPTION
## Summary

- Make the delta tachycardia exits threshold parent-relative: `max(20, parent * 1.25)`, preventing lineages with consistently high exit counts from earning the +20 bonus every generation indefinitely
- Apply clamping (`parent * 5` cap) and decay (`* 0.95`) to `child_delta_total_exits` before saving to corpus metadata, matching the existing density clamping/decay pattern
- Add 6 new tests: 3 for parent-relative threshold logic, 3 for exits clamping/decay

## Test plan

- [x] All 52 scoring tests pass (`test_jit_scoring.py`, `test_jit_differential.py`, `test_scoring.py`)
- [x] Existing `test_delta_exits_above_threshold_triggers_bonus` still passes (30 > 20, no parent → floor applies)
- [x] Existing `test_delta_density_with_parent_delta` still passes (no exits in parent stats → floor 20, child exits 5 < 20)
- [x] ruff format/check clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)