### PR TITLE
fix: fix CrashSignature keyword arg and driver ASAN leak detection

### DIFF
--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -464,7 +464,7 @@ class ArtifactManager:
                     crash_reason = f"keyword_{safe_kw}"
                     # Retroactively create a signature
                     crash_signature = CrashSignature(
-                        type="KEYWORD",
+                        category="KEYWORD",
                         crash_type=CrashType.UNKNOWN,
                         returncode=return_code,
                         signal_name=None,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -7,6 +7,7 @@ lafleur/driver.py
 """
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -37,11 +38,13 @@ class TestSessionFuzzingDriver(unittest.TestCase):
     def _run_driver(self, *script_paths: Path, expect_success: bool = True) -> tuple[str, str, int]:
         """Run the driver on the given scripts."""
         cmd = [sys.executable, "-m", "lafleur.driver"] + [str(p) for p in script_paths]
+        env = {**os.environ, "ASAN_OPTIONS": "detect_leaks=0"}
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
         )
         if expect_success and result.returncode != 0:
             print(f"stdout: {result.stdout}")


### PR DESCRIPTION
## Summary

- Fix `TypeError` in keyword-crash detection path: `CrashSignature(type=...)` → `CrashSignature(category=...)` in `artifacts.py:466` — the dataclass field was renamed but this call site was missed
- Fix driver subprocess tests: add `ASAN_OPTIONS=detect_leaks=0` to subprocess env so LeakSanitizer doesn't cause non-zero exit codes on the ASAN-enabled JIT CPython build

## Test plan

- [x] All 45 crash_detection tests pass (6 previously failing)
- [x] All 12 driver tests pass (9 previously failing)
- [x] Full suite: 1464 passed, 0 failed
- [x] ruff format/check clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)