### PR TITLE
fix: prevent MagicMock from destroying stdout fd in tests

### DIFF
--- a/tests/orchestrator/test_crash_detection.py
+++ b/tests/orchestrator/test_crash_detection.py
@@ -736,6 +736,32 @@ class TestSafeCopy(unittest.TestCase):
             )
             mock_copy2.assert_called_once()
 
+    def test_returns_false_for_non_path_src(self):
+        """Non-path src (e.g. MagicMock) is rejected before reaching shutil."""
+        from unittest.mock import MagicMock
+
+        with patch("shutil.copy") as mock_copy:
+            with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+                result = self.artifact_manager._safe_copy(
+                    MagicMock(), Path("/tmp/dst.py"), "test file"
+                )
+                self.assertFalse(result)
+                self.assertIn("invalid src type", mock_stderr.getvalue())
+                mock_copy.assert_not_called()
+
+    def test_returns_false_for_non_path_dst(self):
+        """Non-path dst (e.g. MagicMock) is rejected before reaching shutil."""
+        from unittest.mock import MagicMock
+
+        with patch("shutil.copy") as mock_copy:
+            with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+                result = self.artifact_manager._safe_copy(
+                    Path("/tmp/src.py"), MagicMock(), "test file"
+                )
+                self.assertFalse(result)
+                self.assertIn("invalid dst type", mock_stderr.getvalue())
+                mock_copy.assert_not_called()
+
 
 class TestGetLogSuffix(unittest.TestCase):
     """Test ArtifactManager._get_log_suffix helper."""


### PR DESCRIPTION
## Summary
- Harden `_safe_copy` with `isinstance` validation for `src`/`dst` args, rejecting non-path objects (e.g. `MagicMock`) before they reach `shutil.copy` — prevents `MagicMock.__index__() == 1` from wrapping stdout's fd
- Widen `except IOError` to `except OSError` for broader error coverage
- Fix `test_solo_session_crash_bundle_single_file`: set `save_session_crash` mock `return_value` to a real `Path` and mock `shutil.copy`
- Fix `TestHandleTimeout` tests: replace `MagicMock` log paths with real `Path` objects, mock `Path.exists` and `Path.unlink`
- Add `_safe_copy` validation tests for non-path `src` and `dst`

## Root cause
`MagicMock.__index__()` returns `1` by default. When a `MagicMock` reaches `shutil.copy` → `open(mock)` → `os.fspath(mock)` → `mock.__fspath__()` → `MagicMock` → `operator.index()` → `1`, it opens `fd 1` (stdout) for writing. When the copy completes and the file object is garbage-collected, `os.close(1)` permanently destroys stdout. pytest masks this via its own capture objects, but `unittest discover` does not.

## Test plan
- [x] All 1466 tests pass with both `pytest` and `unittest discover`
- [x] No "bad file descriptor" errors
- [x] `ruff check` + `ruff format` clean
- [x] `mypy lafleur/artifacts.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)