### PR TITLE
fix: exit code 1 should always classify as PYTHON_UNCAUGHT

### DIFF
--- a/lafleur/analysis.py
+++ b/lafleur/analysis.py
@@ -220,6 +220,16 @@ class CrashFingerprinter:
                     signal_name=None,
                     fingerprint=f"PYTHON:{exc_type}",
                 )
+            # Exit code 1 without a recognizable traceback is still a Python
+            # error (SyntaxError has non-standard formatting, LLTRACE output
+            # can obscure tracebacks, etc.) — not an interesting JIT crash.
+            return CrashSignature(
+                category="PYTHON",
+                crash_type=CrashType.PYTHON_UNCAUGHT,
+                returncode=1,
+                signal_name=None,
+                fingerprint="PYTHON:unknown",
+            )
 
         # 5. Raw Signal (Segfault, etc.)
         if returncode < 0:


### PR DESCRIPTION
## Summary
- Exit code 1 without a recognizable traceback now returns `PYTHON_UNCAUGHT` with fingerprint `"PYTHON:unknown"` instead of falling through to `CrashType.UNKNOWN` / `"EXIT:1"`
- By this point in `analyze()`, ASAN, assertion, panic, and signal checks have already run — exit code 1 is always a Python-level error, never an interesting JIT crash

## Test plan
- [x] Updated `test_python_exception_ignored_if_not_traceback` for new classification
- [x] Added `test_syntax_error_without_traceback_is_python_uncaught`
- [x] Added `test_exit_code_1_with_lltrace_noise`
- [x] Added `test_unexpected_exit_code_remains_unknown` (exit code 2 → `EXIT:2`)
- [x] All 1481 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)