### PR TITLE
fix: make delta density threshold parent-relative

### DIFF
--- a/doc/dev/02_the_evolutionary_loop.md
+++ b/doc/dev/02_the_evolutionary_loop.md
@@ -127,7 +127,7 @@ The `InterestingnessScorer` evaluates the child using a multi-factor scoring sys
   * **Density penalty**: if the child has significantly grown in file size but only discovered relative (not global) coverage, a penalty discourages bloat.
   * **Zombie bonus (+50)**: massive reward if any `zombie_traces` (executors in `pending_deletion` state) were detected — these indicate potential Use-After-Free bugs.
   * **Tachycardia bonus (+20)**: rewards children that provoke high JIT exit density. Two scoring paths exist:
-      * **Delta path** (preferred, session mode): triggers if `child_delta_max_exit_density > 0.5` or `child_delta_total_exits > 20`. Uses fixed thresholds because delta metrics already isolate the child's contribution.
+      * **Delta path** (preferred, session mode): triggers if `child_delta_max_exit_density > max(0.135, parent_delta_density × 1.25)` or `child_delta_total_exits > max(20, parent_delta_exits × 1.25)`. Both thresholds are parent-relative to prevent lineages from coasting on inherited instability.
       * **Absolute path** (fallback, non-session mode): triggers if the child's `max_exit_density` exceeds `max(10.0, parent_density × 1.25)`. This parent-relative threshold prevents lineages from coasting on inherited instability.
   * **Chain depth bonus (+10)**: rewards children where the JIT built deep executor chains (depth > 3), indicating "Hyper-Extension."
   * **Stub bonus (+5)**: rewards children that produced very small compiled traces (code size < 5), which often indicate degenerate compilation.

--- a/tests/orchestrator/test_jit_differential.py
+++ b/tests/orchestrator/test_jit_differential.py
@@ -64,16 +64,16 @@ class TestDifferentialJITScoring(unittest.TestCase):
         self.assertEqual(score, 50.0)
 
     def test_delta_density_with_parent_delta(self):
-        """Test delta scoring uses fixed threshold, not parent-relative comparison."""
+        """Test delta density uses parent-relative threshold."""
         parent_stats = {"child_delta_max_exit_density": 2.0}
-        # Child delta 0.8 > 0.5 threshold → bonus, regardless of parent delta
+        # Child delta 0.8 < max(0.135, 2.0 * 1.25) = 2.5 → no bonus
         child_stats = {"child_delta_max_exit_density": 0.8, "child_delta_total_exits": 5}
 
         scorer = InterestingnessScorer(
             jit_stats=child_stats, parent_jit_stats=parent_stats, **self.scorer_args
         )
         score = scorer.calculate_score()
-        self.assertEqual(score, 20.0)
+        self.assertEqual(score, 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/orchestrator/test_jit_scoring.py
+++ b/tests/orchestrator/test_jit_scoring.py
@@ -142,10 +142,40 @@ class TestDeltaTachycardiaScoring(unittest.TestCase):
 
     def test_delta_below_both_thresholds_no_bonus(self):
         """Both below thresholds — no tachycardia bonus."""
-        jit_stats = {"child_delta_max_exit_density": 0.2, "child_delta_total_exits": 10}
+        jit_stats = {"child_delta_max_exit_density": 0.1, "child_delta_total_exits": 10}
         scorer = InterestingnessScorer(jit_stats=jit_stats, **self.scorer_args)
         score = scorer.calculate_score()
         self.assertEqual(score, 0.0)
+
+    def test_delta_density_parent_relative_threshold(self):
+        """Parent with 2.0 delta density, child with 2.2: 2.2 < max(0.135, 2.5) → no bonus."""
+        parent_stats = {"child_delta_max_exit_density": 2.0}
+        jit_stats = {"child_delta_max_exit_density": 2.2, "child_delta_total_exits": 5}
+        scorer = InterestingnessScorer(
+            jit_stats=jit_stats, parent_jit_stats=parent_stats, **self.scorer_args
+        )
+        score = scorer.calculate_score()
+        self.assertEqual(score, 0.0)
+
+    def test_delta_density_parent_relative_threshold_exceeded(self):
+        """Parent with 2.0 delta density, child with 3.0: 3.0 > max(0.135, 2.5) → bonus."""
+        parent_stats = {"child_delta_max_exit_density": 2.0}
+        jit_stats = {"child_delta_max_exit_density": 3.0, "child_delta_total_exits": 5}
+        scorer = InterestingnessScorer(
+            jit_stats=jit_stats, parent_jit_stats=parent_stats, **self.scorer_args
+        )
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
+
+    def test_delta_density_floor_used_when_parent_low(self):
+        """Parent with 0.05 delta density, child with 0.2: 0.2 > max(0.135, 0.0625) → bonus."""
+        parent_stats = {"child_delta_max_exit_density": 0.05}
+        jit_stats = {"child_delta_max_exit_density": 0.2, "child_delta_total_exits": 5}
+        scorer = InterestingnessScorer(
+            jit_stats=jit_stats, parent_jit_stats=parent_stats, **self.scorer_args
+        )
+        score = scorer.calculate_score()
+        self.assertEqual(score, 20.0)
 
     def test_delta_metrics_take_priority_over_absolute(self):
         """Delta path is taken when delta fields are present, even if absolute is high."""


### PR DESCRIPTION
## Summary

- Lower `TACHYCARDIA_DELTA_DENSITY_THRESHOLD` from 0.5 to 0.135
- Make delta density threshold parent-relative using `max(floor, parent_delta_density * 1.25)`, matching the pattern already used for exits and absolute density
- Update print statement to show the density threshold value
- Update docs to reflect the new parent-relative behavior

## Test plan

- [x] Updated `test_delta_below_both_thresholds_no_bonus` (density 0.2 → 0.1 to stay below new floor)
- [x] Added `test_delta_density_parent_relative_threshold` (child below parent-relative threshold → no bonus)
- [x] Added `test_delta_density_parent_relative_threshold_exceeded` (child above parent-relative threshold → bonus)
- [x] Added `test_delta_density_floor_used_when_parent_low` (floor used when parent is small → bonus)
- [x] Updated `test_delta_density_with_parent_delta` (now expects 0.0 since child 0.8 < threshold 2.5)
- [x] All 1484 tests pass, mypy clean, ruff clean

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)