### PR TITLE
fix: handle null values from driver stats JSON

### DIFF
--- a/tests/orchestrator/test_jit_parsing.py
+++ b/tests/orchestrator/test_jit_parsing.py
@@ -184,5 +184,48 @@ class TestJITParsing(unittest.TestCase):
         self.assertEqual(parsed["child_delta_total_exits"], 20)
 
 
+    def test_parse_jit_stats_null_min_code_size(self):
+        """None value for min_code_size should not crash."""
+        stats = {"min_code_size": None, "max_exit_count": 5}
+        log_content = f"[DRIVER:STATS] {json.dumps(stats)}\n"
+        parsed = self.orch.scoring_manager.parse_jit_stats(log_content)
+        self.assertEqual(parsed["min_code_size"], 0)
+        self.assertEqual(parsed["max_exit_count"], 5)
+
+    def test_parse_jit_stats_null_values_throughout(self):
+        """All fields set to None should not crash and should default to zero."""
+        stats = {
+            "max_exit_count": None,
+            "max_chain_depth": None,
+            "zombie_traces": None,
+            "min_code_size": None,
+            "max_exit_density": None,
+        }
+        log_content = f"[DRIVER:STATS] {json.dumps(stats)}\n"
+        parsed = self.orch.scoring_manager.parse_jit_stats(log_content)
+        self.assertEqual(parsed["max_exit_count"], 0)
+        self.assertEqual(parsed["max_chain_depth"], 0)
+        self.assertEqual(parsed["zombie_traces"], 0)
+        self.assertEqual(parsed["min_code_size"], 0)
+        self.assertAlmostEqual(parsed["max_exit_density"], 0.0)
+
+    def test_parse_jit_stats_null_delta_values(self):
+        """None values in delta fields should not crash."""
+        stats = {
+            "delta_max_exit_density": None,
+            "delta_max_exit_count": None,
+            "delta_total_exits": None,
+            "delta_new_executors": None,
+            "delta_new_zombies": None,
+        }
+        log_content = f"[DRIVER:STATS] {json.dumps(stats)}\n"
+        parsed = self.orch.scoring_manager.parse_jit_stats(log_content)
+        self.assertAlmostEqual(parsed["child_delta_max_exit_density"], 0.0)
+        self.assertEqual(parsed["child_delta_max_exit_count"], 0)
+        self.assertEqual(parsed["child_delta_total_exits"], 0)
+        self.assertEqual(parsed["child_delta_new_executors"], 0)
+        self.assertEqual(parsed["child_delta_new_zombies"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Switch all `.get(key, default)` calls in `parse_jit_stats()` to `.get(key) or default` to handle JSON `null` values that would otherwise cause `TypeError` in comparisons and `max()` calls
- Apply the same fix to `calculate_score()` and `_prepare_new_coverage_result()` which read from the same parsed dicts

## Test plan

- [x] `test_parse_jit_stats_null_min_code_size` — None for min_code_size doesn't crash
- [x] `test_parse_jit_stats_null_values_throughout` — all fields None defaults to zero
- [x] `test_parse_jit_stats_null_delta_values` — all delta fields None defaults to zero
- [x] All 1490 tests pass, mypy clean, ruff clean

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)