### PR TITLE
fix: use structured directories for legacy crash artifacts

### DIFF
--- a/lafleur/metadata.py
+++ b/lafleur/metadata.py
@@ -420,6 +420,7 @@ def generate_run_metadata(output_dir: Path, args: argparse.Namespace) -> dict:
         },
         # Configuration (always fresh - may change between runs)
         "configuration": {
+            "execution_mode": "session" if getattr(args, "session_fuzz", False) else "legacy",
             "args": vars(args),
             "env_vars": {
                 "PYTHON_JIT": os.environ.get("PYTHON_JIT"),

--- a/tests/orchestrator/test_integration.py
+++ b/tests/orchestrator/test_integration.py
@@ -519,14 +519,18 @@ class TestMutationCycleIntegration(unittest.TestCase):
                 is_deepening_session=False,
             )
 
-        # Verify crash was saved
-        crash_files = list(Path("crashes").glob("crash_*.py"))
-        self.assertGreater(len(crash_files), 0, "Crash file should be saved")
+        # Verify crash was saved in a structured directory
+        crash_dirs = [d for d in Path("crashes").iterdir() if d.is_dir()]
+        self.assertGreater(len(crash_dirs), 0, "Crash directory should be created")
 
-        # Verify log file exists
-        if crash_files:
-            log_file = crash_files[0].with_suffix(".log")
-            self.assertTrue(log_file.exists(), "Crash log should be saved")
+        # Verify directory contains metadata.json and crash_script.py
+        crash_dir = crash_dirs[0]
+        self.assertTrue(
+            (crash_dir / "metadata.json").exists(), "metadata.json should exist in crash dir"
+        )
+        self.assertTrue(
+            (crash_dir / "crash_script.py").exists(), "crash_script.py should exist in crash dir"
+        )
 
     def test_mutation_cycle_with_timeout_saves_artifact(self):
         """Mutation cycle detecting timeout saves timeout artifact."""


### PR DESCRIPTION
## Summary
- Add `save_standalone_crash()` method to `ArtifactManager` that creates the same directory structure as `save_session_crash()` (crash subdirectory with `metadata.json`, `crash_script.py`, `reproduce.sh`)
- Replace flat-file saving in `check_for_crash()` legacy branch with a call to the new method
- Add `execution_mode` field (`"session"` or `"legacy"`) to run metadata configuration
- Update existing tests and add 5 new tests for `save_standalone_crash()`

## Test plan
- [x] 5 new `TestSaveStandaloneCrash` tests: directory creation, metadata.json, source copy, reproduce.sh, campaign discoverability
- [x] Updated 3 existing tests for new directory structure (`test_saves_crash_artifacts`, `test_preserves_truncated_log_extension`, `test_preserves_compressed_log_extension`)
- [x] Updated integration test `test_mutation_cycle_with_crash_saves_artifact`
- [x] All 1500 tests pass
- [x] mypy clean, ruff lint/format clean

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)