### PR TITLE
Add Claude Code skills and mutator-reviewer agent

### DIFF
--- a/.claude/agents/mutator-reviewer/SKILL.md
+++ b/.claude/agents/mutator-reviewer/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: mutator-reviewer
+description: Reviews new or modified AST mutator code for correctness, edge cases, and JIT-targeting effectiveness
+model: sonnet
+tools: Read, Grep, Glob
+disallowedTools: Write, Edit, Bash
+maxTurns: 15
+---
+
+# Mutator Code Reviewer
+
+You are a specialized reviewer for AST mutator code in the lafleur fuzzer. Your job is to review mutator implementations and their tests for correctness, safety, and JIT-targeting effectiveness.
+
+## Review Checklist
+
+For each mutator class under review, check the following:
+
+### 1. Structural Correctness
+
+- [ ] Inherits from `ast.NodeTransformer`
+- [ ] Has a docstring explaining its purpose
+- [ ] Visitor methods return the correct node type (not accidentally returning `None`)
+- [ ] `ast.fix_missing_locations(node)` is called after modifying node bodies
+- [ ] Injected code uses `textwrap.dedent()` and passes through `ast.parse()` correctly
+
+### 2. Probabilistic Gating
+
+- [ ] Mutation is gated by `random.random() < threshold` (not applied unconditionally)
+- [ ] Threshold is reasonable (typically 0.05-0.15 for scenario injectors, up to 0.3 for simple transforms)
+- [ ] For `visit_FunctionDef`: early return with `if not node.name.startswith("uop_harness")` to skip non-harness functions
+
+### 3. Edge Case Handling
+
+- [ ] Empty function bodies don't cause crashes (check `if not node.body`)
+- [ ] Missing variables are handled (don't assume variables exist in scope)
+- [ ] Deeply nested ASTs don't cause infinite recursion
+- [ ] `ast.unparse()` succeeds on the mutated tree (no broken AST invariants)
+- [ ] `compile()` succeeds on the unparsed code
+
+### 4. Registration
+
+- [ ] Imported in `lafleur/mutators/engine.py` in the correct import block
+- [ ] Added to `ASTMutator.__init__()` `self.transformers` list
+- [ ] Import is alphabetically sorted within its block
+
+### 5. Test Coverage
+
+Check the corresponding test file in `tests/mutators/`:
+
+- [ ] Has a test for basic mutation application (patching `random.random` low)
+- [ ] Has a test verifying mutation is skipped at high probability
+- [ ] Has a test that the output is valid, parseable Python code
+- [ ] Has a test for skipping non-harness functions
+- [ ] Has a test for empty function body handling
+- [ ] Tests use `unittest.TestCase` (not pytest style)
+- [ ] Tests use `unittest.mock.patch("random.random", return_value=...)` for determinism
+
+### 6. JIT Targeting Effectiveness
+
+- [ ] The mutator targets a specific JIT optimization or weakness (not just random code changes)
+- [ ] Injected code includes warmup loops where needed (JIT needs ~16 iterations to compile)
+- [ ] Type instability or guard failure is introduced _after_ warmup, not before
+- [ ] If targeting specific uops or guards, the approach is documented in the docstring
+
+## Output Format
+
+Produce a structured review with these sections:
+
+```
+## Summary
+<one paragraph overall assessment>
+
+## Issues Found
+### Critical (must fix)
+- <issue description with file:line reference>
+
+### Warnings (should fix)
+- <issue description with file:line reference>
+
+### Suggestions (nice to have)
+- <suggestion>
+
+## Test Coverage Assessment
+<are there gaps in test coverage?>
+
+## JIT Targeting Assessment
+<is this mutator effectively targeting JIT behavior?>
+```
+
+If no issues are found, say so explicitly. Don't invent problems.

--- a/.claude/skills/new-mutator/SKILL.md
+++ b/.claude/skills/new-mutator/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: new-mutator
+description: Scaffold a new AST mutator class with tests and register it in the engine
+argument-hint: <MutatorName> [scenario-module]
+disable-model-invocation: true
+user-invocable: true
+---
+
+# New Mutator Scaffold
+
+Create a new AST mutator named `$ARGUMENTS`.
+
+## Step 1: Choose the module
+
+Pick the correct scenario module based on the mutator's purpose:
+
+| Module | Purpose |
+|--------|---------|
+| `lafleur/mutators/generic.py` | General-purpose structural mutations (operator swap, constant perturbation, loop injection) |
+| `lafleur/mutators/scenarios_types.py` | Type system and caching attacks (type instability, inline cache, MRO) |
+| `lafleur/mutators/scenarios_control.py` | Control flow stress testing (deep calls, recursion, exception mazes, coroutines) |
+| `lafleur/mutators/scenarios_data.py` | Data structure manipulation (dict pollution, comprehension bombs, magic methods) |
+| `lafleur/mutators/scenarios_runtime.py` | Runtime state corruption (frame manipulation, GC stress, eval frame hooks) |
+
+If the user specified a module as the second argument, use that. Otherwise, infer from the mutator name and purpose.
+
+## Step 2: Implement the mutator class
+
+Read the chosen module first to understand existing patterns. Then add the new class following one of these patterns:
+
+### Pattern 1: Scenario Injection (preferred for complex mutations)
+
+```python
+class MyMutator(ast.NodeTransformer):
+    """One-line description of what this mutator does."""
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        if not node.name.startswith("uop_harness"):
+            return node
+        if random.random() < 0.1:  # Probabilistic application
+            scenario = ast.parse(textwrap.dedent("""\
+                # injected code here
+            """)).body
+            node.body = scenario + node.body
+            ast.fix_missing_locations(node)
+        return node
+```
+
+### Pattern 2: In-Place Modification (for simple transformations)
+
+```python
+class MyMutator(ast.NodeTransformer):
+    """One-line description of what this mutator does."""
+
+    def visit_BinOp(self, node: ast.BinOp) -> ast.BinOp:
+        if random.random() < 0.3:
+            node.op = ast.Sub()
+        return node
+```
+
+### Requirements
+
+- Class must inherit from `ast.NodeTransformer`
+- Must have a one-line docstring
+- Must gate mutations with `random.random() < threshold` (typically 0.05-0.15)
+- For `visit_FunctionDef`: check `node.name.startswith("uop_harness")` and skip non-harness functions
+- Call `ast.fix_missing_locations(node)` after modifying node bodies
+- Handle edge cases: empty function bodies, no variables available
+- Use `textwrap.dedent()` for multi-line injected code
+
+## Step 3: Register in engine.py
+
+1. Add the import to `lafleur/mutators/engine.py` in the appropriate import block (sorted alphabetically within the block for the source module)
+2. Add the class to the `self.transformers` list in `ASTMutator.__init__()`, placed near related mutators
+
+## Step 4: Write tests
+
+Add tests to the matching test file under `tests/mutators/`:
+
+| Source module | Test file |
+|--------------|-----------|
+| `generic.py` | `tests/mutators/test_generic.py` |
+| `scenarios_types.py` | `tests/mutators/test_scenarios_types.py` |
+| `scenarios_control.py` | `tests/mutators/test_scenarios_control.py` |
+| `scenarios_data.py` | `tests/mutators/test_scenarios_data.py` |
+| `scenarios_runtime.py` | `tests/mutators/test_scenarios_runtime.py` |
+
+Read the target test file first to follow the existing test class pattern. Every mutator test class needs:
+
+1. **test_basic_mutation**: Apply the mutator with `random.random` patched low (e.g. 0.05), verify the AST is modified
+2. **test_skipped_at_high_probability**: Patch `random.random` to return 0.99, verify no mutation applied
+3. **test_produces_valid_code**: `ast.unparse(mutated_tree)` succeeds and `compile()` succeeds
+4. **test_skips_non_harness_functions**: Functions not named `uop_harness*` are left unchanged
+5. **test_handles_empty_body**: Empty function body doesn't crash the mutator
+
+```python
+class TestMyMutator(unittest.TestCase):
+    def test_basic_mutation(self):
+        code = textwrap.dedent("""\
+            def uop_harness_test():
+                x = 1
+                y = x + 2
+        """)
+        tree = ast.parse(code)
+        with patch("random.random", return_value=0.05):
+            mutated = MyMutator().visit(tree)
+        result = ast.unparse(mutated)
+        # Assert mutation was applied...
+
+    def test_skipped_at_high_probability(self):
+        code = textwrap.dedent("""\
+            def uop_harness_test():
+                x = 1
+        """)
+        tree = ast.parse(code)
+        original = ast.dump(tree)
+        with patch("random.random", return_value=0.99):
+            mutated = MyMutator().visit(tree)
+        self.assertEqual(ast.dump(mutated), original)
+```
+
+## Step 5: Verify
+
+Run these commands:
+
+```bash
+ruff format lafleur/mutators/<module>.py tests/mutators/<test_file>.py lafleur/mutators/engine.py
+ruff check lafleur/mutators/<module>.py tests/mutators/<test_file>.py lafleur/mutators/engine.py
+~/venvs/jit_cpython_venv/bin/python -m pytest tests/mutators/<test_file>.py -v -k TestMyMutator
+~/venvs/jit_cpython_venv/bin/python -m pytest tests/ -v
+```

--- a/.claude/skills/task-workflow/SKILL.md
+++ b/.claude/skills/task-workflow/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: task-workflow
+description: Execute the standard issue, branch, code, test, commit, PR, merge workflow for a task
+argument-hint: <task-description>
+disable-model-invocation: false
+user-invocable: true
+---
+
+# Task Workflow
+
+Execute the standard development workflow for this task: `$ARGUMENTS`
+
+Follow these steps in order. Do NOT skip any step.
+
+## Step 1: Create GitHub Issue
+
+```bash
+gh issue create --title "<title>" --body "<description>" --label "<label>"
+```
+
+Common labels: `enhancement`, `bug`, `tests`, `documentation`, `refactor`
+
+Use the task description to write a clear issue title and body. The body should explain the context, what needs to change, and why.
+
+## Step 2: Create Feature Branch
+
+Branch naming convention:
+- `feat/<slug>` for new features
+- `fix/<slug>` for bug fixes
+- `refactor/<slug>` for refactoring
+- `test/<slug>` for test-only changes
+- `docs/<slug>` for documentation
+
+```bash
+git checkout -b <prefix>/<short-slug>
+```
+
+## Step 3: Implement Changes
+
+Read existing code before modifying it. Follow patterns already established in the codebase. Key conventions:
+- Line length: 100 characters
+- Double quotes for strings
+- Complete type hints on all functions
+- Docstrings on classes and public methods
+
+## Step 4: Verify
+
+Run all verification commands. ALL must pass before committing:
+
+```bash
+ruff format <changed-files>
+ruff check <changed-files>
+~/venvs/jit_cpython_venv/bin/python -m pytest tests/ -v
+```
+
+If any tests fail, fix them before proceeding. If `ruff format` changes files, that's fine — they'll be committed in the next step.
+
+## Step 5: Commit
+
+Stage only the files you changed. Use conventional commit format. Always include the issue reference.
+
+```bash
+git add <specific-files>
+git commit -m "$(cat <<'EOF'
+<type>: <description>
+
+<optional body>
+
+Closes #<issue-number>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Step 6: Push and Create PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+## Test plan
+- [x] <verification items>
+
+Closes #<issue-number>
+
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Step 7: Merge and Cleanup
+
+```bash
+gh pr merge <pr-number> --merge
+git checkout main
+git pull
+git push origin --delete <branch-name>
+```
+
+## Step 8: Report
+
+Tell the user:
+- Issue URL
+- PR URL (merged)
+- Summary of changes made
+- Test results (pass count)


### PR DESCRIPTION
## Summary
- Add `/new-mutator` skill: scaffolds a new AST mutator with tests and engine registration
- Add `/task-workflow` skill: codifies the standard issue→branch→code→test→PR→merge workflow
- Add `mutator-reviewer` agent: read-only subagent that reviews mutator code for correctness, edge cases, and JIT-targeting effectiveness

## Test plan
- [x] 1531 tests pass (1 pre-existing failure in `test_engine.py` unrelated to this change)
- [x] No Python source files modified — markdown-only change

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)