### PR TITLE
fix: prevent syntax error corpus poisoning

### DIFF
--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -500,6 +500,15 @@ class LafleurOrchestrator:
             self.mutation_controller._get_nodes_from_parent(parent_path)
         )
         if base_harness_node is None or parent_core_tree is None:
+            # Mark the parent as sterile so it's deprioritized by the scheduler.
+            # Without this, unparseable files retain their score and get selected
+            # repeatedly, burning cycles on parents that can never produce children.
+            if parent_metadata is not None:
+                parent_metadata["is_sterile"] = True
+                print(
+                    f"  [!] Marking {parent_id} as sterile (unparseable or missing harness).",
+                    file=sys.stderr,
+                )
             return None
 
         # Retrieve watched dependencies from parent metadata


### PR DESCRIPTION
## Summary
- Validate extracted core code with `ast.parse()` before saving to corpus, discarding unparseable files that would otherwise poison the corpus
- Mark unparseable parents as sterile in `_prepare_parent_context` so the scheduler deprioritizes them instead of repeatedly selecting broken files
- Use `is not None` check for parent metadata to handle empty-dict edge case correctly

## Test plan
- [x] 2 new tests in `test_scoring.py` verify syntax error detection and valid code passthrough
- [x] 3 new tests in `test_main_loop.py` verify sterile marking for unparseable parents, empty metadata, and unknown parents
- [x] All 1547 tests pass
- [x] mypy clean, ruff clean

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)