### PR TITLE
feat: add HealthMonitor observability layer for adverse event tracking

### DIFF
--- a/lafleur/health.py
+++ b/lafleur/health.py
@@ -1,0 +1,207 @@
+"""
+Health monitoring for the lafleur fuzzer.
+
+Records discrete adverse events to a JSONL log file for observability.
+The HealthMonitor is designed to be non-intrusive: it never raises
+exceptions and adds negligible overhead to the fuzzing loop.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+# Threshold for consecutive timeout warnings
+CONSECUTIVE_TIMEOUT_THRESHOLD = 5
+
+# Threshold for file size warnings (bytes)
+FILE_SIZE_WARNING_THRESHOLD = 100_000  # 100KB
+
+
+class HealthMonitor:
+    """Track and record adverse fuzzing events for observability.
+
+    Writes events to a JSONL log file and maintains in-memory counters
+    for rate-based detection (e.g. consecutive timeouts from one parent).
+
+    All public methods silently swallow exceptions to ensure the monitor
+    never crashes the fuzzer.
+    """
+
+    def __init__(self, log_path: Path) -> None:
+        """Initialize the HealthMonitor.
+
+        Args:
+            log_path: Path to the JSONL health events log file.
+        """
+        self.log_path = log_path
+        self.counters: dict[str, int] = {}
+
+        # State for consecutive timeout tracking
+        self._timeout_parent: str | None = None
+        self._timeout_streak: int = 0
+
+    def _write_event(self, category: str, event: str, **kwargs: Any) -> None:
+        """Append a single event to the JSONL log.
+
+        Args:
+            category: Event category (mutation_pipeline, execution, corpus_health).
+            event: Event type name.
+            **kwargs: Additional event-specific fields.
+        """
+        try:
+            record: dict[str, Any] = {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "cat": category,
+                "event": event,
+            }
+            record.update(kwargs)
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, default=str) + "\n")
+        except OSError:
+            pass  # Never crash the fuzzer for a health event
+
+        # Update in-memory counter
+        counter_key = f"{category}.{event}"
+        self.counters[counter_key] = self.counters.get(counter_key, 0) + 1
+
+    # =========================================================================
+    # Mutation Pipeline Events
+    # =========================================================================
+
+    def record_parent_parse_failure(self, parent_id: str, error: str) -> None:
+        """Record a parent file that could not be parsed into AST."""
+        self._write_event(
+            "mutation_pipeline",
+            "parent_parse_failure",
+            parent_id=parent_id,
+            error=error,
+        )
+
+    def record_mutation_recursion_error(self, parent_id: str) -> None:
+        """Record a RecursionError during AST transformation."""
+        self._write_event(
+            "mutation_pipeline",
+            "mutation_recursion_error",
+            parent_id=parent_id,
+        )
+
+    def record_unparse_recursion_error(self, parent_id: str) -> None:
+        """Record a RecursionError during ast.unparse()."""
+        self._write_event(
+            "mutation_pipeline",
+            "unparse_recursion_error",
+            parent_id=parent_id,
+        )
+
+    def record_child_script_none(self, parent_id: str, mutation_seed: int) -> None:
+        """Record a mutation that produced no usable child script."""
+        self._write_event(
+            "mutation_pipeline",
+            "child_script_none",
+            parent_id=parent_id,
+            mutation_seed=mutation_seed,
+        )
+
+    def record_core_code_syntax_error(self, parent_id: str | None, error: str) -> None:
+        """Record core code that failed ast.parse() validation before saving."""
+        self._write_event(
+            "mutation_pipeline",
+            "core_code_syntax_error",
+            parent_id=parent_id or "seed",
+            error=error,
+        )
+
+    # =========================================================================
+    # Execution Events
+    # =========================================================================
+
+    def record_timeout(self, parent_id: str) -> None:
+        """Record a timeout and track consecutive streaks per parent.
+
+        Writes a consecutive_timeouts event when the streak for a single
+        parent reaches CONSECUTIVE_TIMEOUT_THRESHOLD.
+        """
+        if parent_id == self._timeout_parent:
+            self._timeout_streak += 1
+        else:
+            self._timeout_parent = parent_id
+            self._timeout_streak = 1
+
+        if self._timeout_streak == CONSECUTIVE_TIMEOUT_THRESHOLD:
+            self._write_event(
+                "execution",
+                "consecutive_timeouts",
+                parent_id=parent_id,
+                count=self._timeout_streak,
+            )
+
+    def reset_timeout_streak(self) -> None:
+        """Reset the timeout streak (call after a non-timeout result)."""
+        self._timeout_streak = 0
+        self._timeout_parent = None
+
+    def record_ignored_crash(self, reason: str, returncode: int) -> None:
+        """Record a crash that was detected but filtered out."""
+        self._write_event(
+            "execution",
+            "ignored_crash",
+            reason=reason,
+            returncode=returncode,
+        )
+
+    def record_deepening_sterility(
+        self, parent_id: str, depth: int, mutations_attempted: int
+    ) -> None:
+        """Record a deepening session that hit the sterility limit."""
+        self._write_event(
+            "execution",
+            "deepening_sterility",
+            parent_id=parent_id,
+            depth=depth,
+            mutations_attempted=mutations_attempted,
+        )
+
+    # =========================================================================
+    # Corpus Health Events
+    # =========================================================================
+
+    def record_file_size_warning(self, file_id: str, size_bytes: int) -> None:
+        """Record a corpus file that exceeds the size warning threshold."""
+        self._write_event(
+            "corpus_health",
+            "file_size_warning",
+            file_id=file_id,
+            size_bytes=size_bytes,
+        )
+
+    def record_duplicate_rejected(self, content_hash: str, coverage_hash: str) -> None:
+        """Record an interesting child rejected as a duplicate."""
+        self._write_event(
+            "corpus_health",
+            "duplicate_rejected",
+            content_hash=content_hash[:10],
+            coverage_hash=coverage_hash[:10],
+        )
+
+    def record_corpus_sterility(self, parent_id: str, mutations_since_last_find: int) -> None:
+        """Record a parent reaching the corpus sterility limit."""
+        self._write_event(
+            "corpus_health",
+            "corpus_sterility_reached",
+            parent_id=parent_id,
+            mutations_since_last_find=mutations_since_last_find,
+        )
+
+    # =========================================================================
+    # Summary
+    # =========================================================================
+
+    def get_summary(self) -> dict[str, int]:
+        """Return a copy of the in-memory event counters.
+
+        Returns:
+            Dict mapping "category.event" keys to occurrence counts.
+        """
+        return dict(self.counters)

--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -29,6 +29,7 @@ from lafleur.mutators.helper_injection import HelperFunctionInjector
 
 if TYPE_CHECKING:
     from lafleur.corpus_manager import CorpusManager
+    from lafleur.health import HealthMonitor
     from lafleur.learning import MutatorScoreTracker
 
 # Module-level RNG for mutation operations
@@ -72,6 +73,7 @@ class MutationController:
         self.corpus_manager: CorpusManager | None = corpus_manager
         self.differential_testing = differential_testing
         self.boilerplate_code: str | None = None
+        self.health_monitor: HealthMonitor | None = None
 
     def get_boilerplate(self) -> str:
         """Return the cached boilerplate code."""
@@ -435,6 +437,8 @@ class MutationController:
                 "  [!] Warning: Skipping mutation due to RecursionError during AST transformation.",
                 file=sys.stderr,
             )
+            if self.health_monitor:
+                self.health_monitor.record_mutation_recursion_error("unknown")
             return None, None
 
     def prepare_child_script(
@@ -482,6 +486,8 @@ class MutationController:
                 "  [!] Warning: Skipping mutation due to RecursionError during ast.unparse.",
                 file=sys.stderr,
             )
+            if self.health_monitor:
+                self.health_monitor.record_unparse_recursion_error("unknown")
             return None
 
         except (AttributeError, TypeError, ValueError) as e:

--- a/tests/orchestrator/test_execution.py
+++ b/tests/orchestrator/test_execution.py
@@ -31,6 +31,7 @@ class TestPrepareChildScript(unittest.TestCase):
         self.controller = MutationController.__new__(MutationController)
         self.controller.boilerplate_code = "# Boilerplate\n"
         self.controller.differential_testing = False
+        self.controller.health_monitor = None
 
     def test_assembles_complete_script(self):
         """Test that script includes boilerplate, RNG setup, and core code."""

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -381,6 +381,7 @@ class TestExecuteMutationAndAnalysisCycle(unittest.TestCase):
         self.orchestrator.use_dynamic_runs = False
         self.orchestrator.base_runs = 3
         self.orchestrator._last_heartbeat_time = float("inf")
+        self.orchestrator.health_monitor = MagicMock()
         self.orchestrator.corpus_manager = MagicMock()
         self.orchestrator.execution_manager = MagicMock()
         self.orchestrator.mutation_controller = MagicMock()
@@ -742,6 +743,7 @@ class TestRunStatsKeyErrorWithEmptyStats(unittest.TestCase):
         self.orchestrator.base_runs = 1
         self.orchestrator.keep_tmp_logs = False
         self.orchestrator._last_heartbeat_time = float("inf")
+        self.orchestrator.health_monitor = MagicMock()
         self.orchestrator.corpus_manager = MagicMock()
         self.orchestrator.corpus_manager.add_new_file.return_value = "new_child.py"
         self.orchestrator.corpus_manager.scheduler = MagicMock()
@@ -859,6 +861,7 @@ class TestHandleAnalysisDataFlowControl(unittest.TestCase):
         self.orchestrator.artifact_manager = MagicMock()
         self.orchestrator.score_tracker = MagicMock()
         self.orchestrator.timing_fuzz = False
+        self.orchestrator.health_monitor = MagicMock()
         self.parent_metadata = {}
 
     def test_divergence_returns_break_with_filename(self):
@@ -951,6 +954,7 @@ class TestPrepareParentContext(unittest.TestCase):
                 }
             }
         }
+        self.orchestrator.health_monitor = MagicMock()
         self.orchestrator.mutation_controller = MagicMock()
         self.orchestrator.use_dynamic_runs = False
         self.orchestrator.base_runs = 3
@@ -1133,6 +1137,7 @@ class TestExecuteSingleMutation(unittest.TestCase):
         self.orchestrator.keep_tmp_logs = False
         self.orchestrator.differential_testing = False
         self.orchestrator.timing_fuzz = False
+        self.orchestrator.health_monitor = MagicMock()
         self.orchestrator.corpus_manager = MagicMock()
         self.orchestrator.corpus_manager.add_new_file.return_value = "new_child.py"
         self.orchestrator.execution_manager = MagicMock()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,259 @@
+"""Tests for the HealthMonitor observability layer."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from lafleur.health import (
+    CONSECUTIVE_TIMEOUT_THRESHOLD,
+    FILE_SIZE_WARNING_THRESHOLD,
+    HealthMonitor,
+)
+
+
+class TestHealthMonitorInit(unittest.TestCase):
+    """Test HealthMonitor initialization."""
+
+    def test_creates_with_log_path(self):
+        """HealthMonitor accepts a log path and initializes empty counters."""
+        monitor = HealthMonitor(log_path=Path("/tmp/test_health.jsonl"))
+        self.assertEqual(monitor.counters, {})
+        self.assertIsNone(monitor._timeout_parent)
+        self.assertEqual(monitor._timeout_streak, 0)
+
+
+class TestHealthMonitorWriteEvent(unittest.TestCase):
+    """Test the internal _write_event method."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.log_path = Path(self.tmp_dir) / "health_events.jsonl"
+        self.monitor = HealthMonitor(log_path=self.log_path)
+
+    def test_writes_valid_jsonl(self):
+        """Events are written as valid JSONL with expected fields."""
+        self.monitor._write_event("test_cat", "test_event", key1="val1")
+
+        lines = self.log_path.read_text().strip().split("\n")
+        self.assertEqual(len(lines), 1)
+
+        record = json.loads(lines[0])
+        self.assertIn("ts", record)
+        self.assertEqual(record["cat"], "test_cat")
+        self.assertEqual(record["event"], "test_event")
+        self.assertEqual(record["key1"], "val1")
+
+    def test_appends_multiple_events(self):
+        """Multiple events are appended, not overwritten."""
+        self.monitor._write_event("cat1", "event1")
+        self.monitor._write_event("cat2", "event2")
+
+        lines = self.log_path.read_text().strip().split("\n")
+        self.assertEqual(len(lines), 2)
+
+    def test_increments_counters(self):
+        """Each event increments the correct counter."""
+        self.monitor._write_event("cat", "evt")
+        self.monitor._write_event("cat", "evt")
+        self.monitor._write_event("cat", "other")
+
+        self.assertEqual(self.monitor.counters["cat.evt"], 2)
+        self.assertEqual(self.monitor.counters["cat.other"], 1)
+
+    def test_survives_oserror(self):
+        """OSError during write is silently swallowed."""
+        monitor = HealthMonitor(log_path=Path("/nonexistent/dir/health.jsonl"))
+        # Should not raise
+        monitor._write_event("cat", "evt")
+        # Counter should still increment (it's in-memory, independent of I/O)
+        self.assertEqual(monitor.counters["cat.evt"], 1)
+
+
+class TestMutationPipelineEvents(unittest.TestCase):
+    """Test mutation pipeline event recording."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.log_path = Path(self.tmp_dir) / "health_events.jsonl"
+        self.monitor = HealthMonitor(log_path=self.log_path)
+
+    def test_record_parent_parse_failure(self):
+        """Parent parse failure is recorded with parent_id and error."""
+        self.monitor.record_parent_parse_failure("42.py", "SyntaxError: unexpected EOF")
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["cat"], "mutation_pipeline")
+        self.assertEqual(record["event"], "parent_parse_failure")
+        self.assertEqual(record["parent_id"], "42.py")
+        self.assertIn("SyntaxError", record["error"])
+
+    def test_record_mutation_recursion_error(self):
+        """Mutation RecursionError is recorded."""
+        self.monitor.record_mutation_recursion_error("55.py")
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "mutation_recursion_error")
+        self.assertEqual(record["parent_id"], "55.py")
+
+    def test_record_unparse_recursion_error(self):
+        """Unparse RecursionError is recorded."""
+        self.monitor.record_unparse_recursion_error("66.py")
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "unparse_recursion_error")
+
+    def test_record_child_script_none(self):
+        """Child script None is recorded with mutation seed."""
+        self.monitor.record_child_script_none("77.py", 12345)
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "child_script_none")
+        self.assertEqual(record["mutation_seed"], 12345)
+
+    def test_record_core_code_syntax_error(self):
+        """Core code SyntaxError is recorded."""
+        self.monitor.record_core_code_syntax_error("88.py", "unexpected indent")
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "core_code_syntax_error")
+        self.assertEqual(record["parent_id"], "88.py")
+
+    def test_record_core_code_syntax_error_seed(self):
+        """Core code SyntaxError with None parent defaults to 'seed'."""
+        self.monitor.record_core_code_syntax_error(None, "error")
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["parent_id"], "seed")
+
+
+class TestExecutionEvents(unittest.TestCase):
+    """Test execution event recording."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.log_path = Path(self.tmp_dir) / "health_events.jsonl"
+        self.monitor = HealthMonitor(log_path=self.log_path)
+
+    def test_timeout_streak_fires_at_threshold(self):
+        """consecutive_timeouts event fires at CONSECUTIVE_TIMEOUT_THRESHOLD."""
+        for _ in range(CONSECUTIVE_TIMEOUT_THRESHOLD - 1):
+            self.monitor.record_timeout("42.py")
+
+        # Should not have written yet
+        self.assertFalse(self.log_path.exists())
+
+        # This one hits the threshold
+        self.monitor.record_timeout("42.py")
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "consecutive_timeouts")
+        self.assertEqual(record["parent_id"], "42.py")
+        self.assertEqual(record["count"], CONSECUTIVE_TIMEOUT_THRESHOLD)
+
+    def test_timeout_streak_resets_on_different_parent(self):
+        """Switching parents resets the timeout streak."""
+        for _ in range(CONSECUTIVE_TIMEOUT_THRESHOLD - 1):
+            self.monitor.record_timeout("42.py")
+
+        # Switch parent — resets streak
+        self.monitor.record_timeout("99.py")
+
+        # No event should have been written
+        self.assertFalse(self.log_path.exists())
+
+    def test_timeout_streak_resets_on_explicit_reset(self):
+        """reset_timeout_streak clears the streak."""
+        for _ in range(CONSECUTIVE_TIMEOUT_THRESHOLD - 1):
+            self.monitor.record_timeout("42.py")
+
+        self.monitor.reset_timeout_streak()
+        self.monitor.record_timeout("42.py")
+
+        # Should not fire — streak was reset
+        self.assertFalse(self.log_path.exists())
+
+    def test_record_ignored_crash(self):
+        """Ignored crash is recorded with reason and returncode."""
+        self.monitor.record_ignored_crash("SyntaxError", 1)
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "ignored_crash")
+        self.assertEqual(record["reason"], "SyntaxError")
+        self.assertEqual(record["returncode"], 1)
+
+    def test_record_deepening_sterility(self):
+        """Deepening sterility is recorded with depth and mutation count."""
+        self.monitor.record_deepening_sterility("55.py", depth=4, mutations_attempted=30)
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "deepening_sterility")
+        self.assertEqual(record["depth"], 4)
+        self.assertEqual(record["mutations_attempted"], 30)
+
+
+class TestCorpusHealthEvents(unittest.TestCase):
+    """Test corpus health event recording."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.log_path = Path(self.tmp_dir) / "health_events.jsonl"
+        self.monitor = HealthMonitor(log_path=self.log_path)
+
+    def test_record_file_size_warning(self):
+        """File size warning is recorded with file_id and size."""
+        self.monitor.record_file_size_warning("123.py", 131072)
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "file_size_warning")
+        self.assertEqual(record["file_id"], "123.py")
+        self.assertEqual(record["size_bytes"], 131072)
+
+    def test_record_duplicate_rejected(self):
+        """Duplicate rejection is recorded with truncated hashes."""
+        self.monitor.record_duplicate_rejected("abcdef1234567890", "1234567890abcdef")
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "duplicate_rejected")
+        self.assertEqual(record["content_hash"], "abcdef1234")
+        self.assertEqual(record["coverage_hash"], "1234567890")
+
+    def test_record_corpus_sterility(self):
+        """Corpus sterility is recorded with parent_id and mutation count."""
+        self.monitor.record_corpus_sterility("33.py", 600)
+
+        record = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(record["event"], "corpus_sterility_reached")
+        self.assertEqual(record["parent_id"], "33.py")
+        self.assertEqual(record["mutations_since_last_find"], 600)
+
+
+class TestGetSummary(unittest.TestCase):
+    """Test get_summary method."""
+
+    def test_returns_copy_of_counters(self):
+        """get_summary returns a dict copy, not the internal reference."""
+        monitor = HealthMonitor(log_path=Path("/tmp/test.jsonl"))
+        monitor.counters["test.event"] = 5
+
+        summary = monitor.get_summary()
+        self.assertEqual(summary["test.event"], 5)
+
+        # Modifying the returned dict should not affect internals
+        summary["test.event"] = 99
+        self.assertEqual(monitor.counters["test.event"], 5)
+
+    def test_empty_summary(self):
+        """Empty monitor returns empty summary."""
+        monitor = HealthMonitor(log_path=Path("/tmp/test.jsonl"))
+        self.assertEqual(monitor.get_summary(), {})
+
+
+class TestFileConstants(unittest.TestCase):
+    """Test module-level constants have sensible values."""
+
+    def test_timeout_threshold_is_positive(self):
+        self.assertGreater(CONSECUTIVE_TIMEOUT_THRESHOLD, 0)
+
+    def test_file_size_threshold_is_positive(self):
+        self.assertGreater(FILE_SIZE_WARNING_THRESHOLD, 0)


### PR DESCRIPTION
## Summary
- Add `lafleur/health.py` with `HealthMonitor` class that records adverse fuzzing events to `logs/health_events.jsonl` (append-only JSONL)
- Wire health monitoring into 5 existing modules at natural failure points:
  - **orchestrator**: parent parse failures, child script None, timeout streaks, deepening sterility, corpus sterility
  - **mutation_controller**: RecursionError during AST transformation and unparse
  - **scoring**: core code SyntaxError (corpus poisoning), duplicate rejection
  - **artifacts**: ignored crashes (SIGKILL/SIGTERM, IGNORE type, PYTHON_UNCAUGHT)
  - **corpus_manager**: oversized file warnings (>100KB)
- In-memory counters for rate-based alerts (e.g. 5 consecutive timeouts from same parent)
- All I/O wrapped in try/except — monitor never crashes the fuzzer

## Test plan
- [x] 23 new tests in `tests/test_health.py` covering all event types, JSONL format, counters, OSError resilience, timeout streaks, and summary
- [x] Updated 6 existing test setups to include `health_monitor` attribute
- [x] All 1570 tests pass
- [x] mypy clean, ruff clean

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)