### PR TITLE
Health monitor: enrich events with mutation context, fix sterility spam

### DIFF
--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -610,6 +610,8 @@ class ScoringManager:
             exec_result.log_path,
             exec_result.parent_path,
             exec_result.session_files,
+            parent_id=parent_id,
+            mutation_info=mutation_info,
         ):
             return {"status": "CRASH"}
 
@@ -680,7 +682,11 @@ class ScoringManager:
                 file=sys.stderr,
             )
             if self.health_monitor:
-                self.health_monitor.record_core_code_syntax_error(parent_id, str(e))
+                self.health_monitor.record_core_code_syntax_error(
+                    parent_id,
+                    str(e),
+                    strategy=mutation_info.get("strategy") if mutation_info else None,
+                )
             return {"status": "NO_CHANGE"}
 
         content_hash = hashlib.sha256(core_code_to_save.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
- **Fix sterility spam**: `corpus_sterility_reached` now fires only on the `is_sterile` False→True transition, not on every subsequent mutation
- **Skip sterile files in `select_parent()`**: Sterile files are filtered out entirely before scoring, preventing wasted sessions on permanently sterile parents
- **Enrich `ignored_crash` events**: Added `parent_id`, `strategy`, and `error_excerpt` fields for traceability
- **Add `extract_error_excerpt()` helper**: Searches backwards through log content for Python error patterns, falling back to the last non-empty line
- **Add `strategy` to mutation pipeline events**: `child_script_none` and `core_code_syntax_error` now include the mutation strategy
- **Thread mutation context through crash detection**: `parent_id` and `mutation_info` flow from orchestrator → scoring → artifacts for full event attribution

Closes #640

## Test plan
- [x] New `TestExtractErrorExcerpt` (5 tests): empty, None, error lines, fallback, truncation
- [x] New `TestIgnoredCrashEnriched` (4 tests): parent_id, strategy, error_excerpt, omission of None fields
- [x] New `TestChildScriptNoneEnriched` (2 tests): strategy present/absent
- [x] New `TestCoreSyntaxErrorEnriched` (2 tests): strategy present/absent
- [x] New `TestCorpusSterilityOnce` (1 test): verifies monitor is stateless about sterility
- [x] New `TestSelectParentSterileFiltering` (3 tests): sterile skip, all-sterile fallback, empty corpus
- [x] All 1587 existing tests pass
- [x] ruff check + format clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)