### PR TITLE
feat: implement hygiene mutator system with ImportPrunerMutator

### DIFF
--- a/lafleur/mutators/__init__.py
+++ b/lafleur/mutators/__init__.py
@@ -14,7 +14,7 @@ from lafleur.mutators.utils import (
     HarnessInstrumentor,
     RedundantStatementSanitizer,
 )
-from lafleur.mutators.generic import VariableRenamer
+from lafleur.mutators.generic import ImportPrunerMutator, VariableRenamer
 
 __all__ = [
     "ASTMutator",
@@ -22,6 +22,7 @@ __all__ = [
     "FuzzerSetupNormalizer",
     "EmptyBodySanitizer",
     "HarnessInstrumentor",
+    "ImportPrunerMutator",
     "RedundantStatementSanitizer",
     "VariableRenamer",
 ]

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -29,7 +29,6 @@ from lafleur.mutators.generic import (
     ForLoopInjector,
     GuardInjector,
     GuardRemover,
-    ImportChaosMutator,
     LiteralTypeSwapMutator,
     NewUnpackingMutator,
     OperatorSwapper,
@@ -100,7 +99,6 @@ from lafleur.mutators.scenarios_types import (
     TypeIntrospectionMutator,
     TypeVersionInvalidator,
 )
-from lafleur.mutators.utils import RedundantStatementSanitizer
 from lafleur.mutators.helper_injection import HelperFunctionInjector
 # Note: SniperMutator is NOT imported here - it's only used in orchestrator._run_sniper_stage
 # because it requires watched_keys parameter from Bloom introspection
@@ -170,7 +168,6 @@ class ASTMutator:
             SideEffectInjector,
             # StatementDuplicator,
             ForLoopInjector,
-            ImportChaosMutator,
             GlobalInvalidator,
             LoadAttrPolluter,
             ManyVarsInjector,
@@ -229,7 +226,6 @@ class ASTMutator:
             ExceptionGroupMutator,
             AsyncConstructMutator,
             SysMonitoringMutator,
-            RedundantStatementSanitizer,
         ]
         # Note: SniperMutator is NOT in this list - it's applied separately
         # via orchestrator._run_sniper_stage() with Bloom-detected watched_keys

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -391,7 +391,10 @@ class LafleurOrchestrator:
             strategy = mutation_info.get("strategy")
             transformers = mutation_info.get("transformers", [])
             if strategy and transformers:
-                self.score_tracker.record_success(strategy, transformers)
+                hygiene_names = {cls.__name__ for cls, _ in MutationController.HYGIENE_MUTATORS}
+                filtered = [t for t in transformers if t not in hygiene_names]
+                if filtered:
+                    self.score_tracker.record_success(strategy, filtered)
 
         if status == "DIVERGENCE":
             self.run_stats["divergences_found"] = self.run_stats.get("divergences_found", 0) + 1

--- a/tests/mutators/test_engine.py
+++ b/tests/mutators/test_engine.py
@@ -15,7 +15,13 @@ from unittest.mock import patch
 
 import lafleur.mutators.engine as engine_module
 from lafleur.mutators.engine import ASTMutator, SlicingMutator
-from lafleur.mutators.generic import ConstantPerturbator, OperatorSwapper
+from lafleur.mutators.generic import (
+    ConstantPerturbator,
+    ImportChaosMutator,
+    ImportPrunerMutator,
+    OperatorSwapper,
+)
+from lafleur.mutators.utils import RedundantStatementSanitizer
 from lafleur.mutators.utils import (
     FuzzerSetupNormalizer,
     genStatefulBoolObject,
@@ -396,6 +402,9 @@ class TestASTMutator(unittest.TestCase):
         excluded = {
             SlicingMutator,  # Meta-mutator, not a pool member
             ASTMutator,  # The engine itself (not a NodeTransformer, but just in case)
+            ImportChaosMutator,  # Hygiene mutator, applied separately
+            ImportPrunerMutator,  # Hygiene mutator, applied separately
+            RedundantStatementSanitizer,  # Hygiene mutator, applied separately
         }
         expected = imported_transformers - excluded
 


### PR DESCRIPTION
## Summary
- Move `ImportChaosMutator` and `RedundantStatementSanitizer` from the weighted mutation pool to a fixed-probability hygiene pass applied after the main strategy
- Add `ImportPrunerMutator` to counteract accumulated import bloat from `ImportChaosMutator`
- Add `HYGIENE_MUTATORS` class constant on `MutationController` with per-mutator probabilities (0.15, 0.20, 0.25)
- Filter hygiene mutator names from `record_success` calls so they don't pollute the learning system
- Add 13 new tests across 3 test files

## Test plan
- [x] All 1624 tests pass
- [x] ruff check clean
- [x] mypy clean
- [x] `TestImportPrunerMutator` (8 tests) verifies bare imports, from-imports, try/except-wrapped imports, probability, and edge cases
- [x] `TestHygienePass` (4 tests) verifies hygiene mutators fire/skip based on RANDOM thresholds
- [x] `TestRecordSuccessHygieneFiltering` (1 test) verifies hygiene names are stripped before record_success

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)