### PR TITLE
feat: uncomment StatementDuplicator and move to hygiene layer

### DIFF
--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -25,7 +25,7 @@ from lafleur.mutators import (
     RedundantStatementSanitizer,
     SlicingMutator,
 )
-from lafleur.mutators.generic import ImportChaosMutator, ImportPrunerMutator
+from lafleur.mutators.generic import ImportChaosMutator, ImportPrunerMutator, StatementDuplicator
 from lafleur.mutators.sniper import SniperMutator
 from lafleur.mutators.helper_injection import HelperFunctionInjector
 
@@ -56,7 +56,8 @@ class MutationController:
     HYGIENE_MUTATORS: list[tuple[type[ast.NodeTransformer], float]] = [
         (ImportChaosMutator, 0.15),
         (ImportPrunerMutator, 0.20),
-        (RedundantStatementSanitizer, 0.25),
+        (StatementDuplicator, 0.08),
+        (RedundantStatementSanitizer, 0.05),
     ]
 
     def __init__(

--- a/lafleur/mutators/__init__.py
+++ b/lafleur/mutators/__init__.py
@@ -14,7 +14,7 @@ from lafleur.mutators.utils import (
     HarnessInstrumentor,
     RedundantStatementSanitizer,
 )
-from lafleur.mutators.generic import ImportPrunerMutator, VariableRenamer
+from lafleur.mutators.generic import ImportPrunerMutator, StatementDuplicator, VariableRenamer
 
 __all__ = [
     "ASTMutator",
@@ -24,5 +24,6 @@ __all__ = [
     "HarnessInstrumentor",
     "ImportPrunerMutator",
     "RedundantStatementSanitizer",
+    "StatementDuplicator",
     "VariableRenamer",
 ]

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -34,7 +34,6 @@ from lafleur.mutators.generic import (
     OperatorSwapper,
     PatternMatchingMutator,
     SliceMutator,
-    # StatementDuplicator,
     StringInterpolationMutator,
     SysMonitoringMutator,
     UnpackingMutator,
@@ -166,7 +165,7 @@ class ASTMutator:
             GuardExhaustionGenerator,
             InlineCachePolluter,
             SideEffectInjector,
-            # StatementDuplicator,
+            # StatementDuplicator — moved to hygiene layer (MutationController.HYGIENE_MUTATORS)
             ForLoopInjector,
             GlobalInvalidator,
             LoadAttrPolluter,

--- a/tests/mutators/test_engine.py
+++ b/tests/mutators/test_engine.py
@@ -20,6 +20,7 @@ from lafleur.mutators.generic import (
     ImportChaosMutator,
     ImportPrunerMutator,
     OperatorSwapper,
+    StatementDuplicator,
 )
 from lafleur.mutators.utils import RedundantStatementSanitizer
 from lafleur.mutators.utils import (
@@ -405,6 +406,7 @@ class TestASTMutator(unittest.TestCase):
             ImportChaosMutator,  # Hygiene mutator, applied separately
             ImportPrunerMutator,  # Hygiene mutator, applied separately
             RedundantStatementSanitizer,  # Hygiene mutator, applied separately
+            StatementDuplicator,  # Hygiene mutator, applied separately
         }
         expected = imported_transformers - excluded
 


### PR DESCRIPTION
## Summary
- Uncomment `StatementDuplicator` and add it to `HYGIENE_MUTATORS` at 8% probability
- Lower `RedundantStatementSanitizer` probability from 25% to 5% for natural equilibrium
- StatementDuplicator's indirect value (warming loops for JIT tracing) can't be measured by the learning system, making it a perfect hygiene candidate
- Update pool validation test and hygiene pass tests for the 4-entry list

## Test plan
- [x] All 1624 tests pass
- [x] ruff check clean
- [x] mypy clean
- [x] `test_all_imported_transformers_in_pool` passes with StatementDuplicator excluded
- [x] `test_statement_duplicator` (existing isolation test) passes
- [x] `TestHygienePass` tests updated for 4 hygiene mutators
- [x] `TestRecordSuccessHygieneFiltering` test includes StatementDuplicator

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)