### PR TITLE
feat: implement crash-attribution feedback for the learning system

### DIFF
--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -95,6 +95,7 @@ class ArtifactManager:
         self.max_crash_log_bytes = max_crash_log_bytes
         self.session_fuzz = session_fuzz
         self.health_monitor = health_monitor
+        self.last_crash_fingerprint: str = ""
 
         # Ensure directories exist
         self.crashes_dir.mkdir(parents=True, exist_ok=True)
@@ -577,6 +578,7 @@ class ArtifactManager:
 
         # 3. Save Artifacts if Crash Detected
         if crash_reason:
+            self.last_crash_fingerprint = crash_reason
             print(f"  [!!!] CRASH DETECTED! ({crash_reason}). Saving...", file=sys.stderr)
 
             # Process the log (truncate/compress) using the crash-specific limit

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -613,7 +613,12 @@ class ScoringManager:
             parent_id=parent_id,
             mutation_info=mutation_info,
         ):
-            return {"status": "CRASH"}
+            return {
+                "status": "CRASH",
+                "mutation_info": mutation_info or {},
+                "parent_id": parent_id,
+                "fingerprint": self.artifact_manager.last_crash_fingerprint,
+            }
 
         child_coverage = parse_log_for_edge_coverage(exec_result.log_path, self.coverage_manager)
 


### PR DESCRIPTION
## Summary
- Add two-tier crash attribution to the learning system: **direct reward** (5x) for the crashing mutation and **lineage reward** (2x) for every ancestor in the corpus chain
- Walk corpus ancestry via `_walk_crash_lineage()` with safety bound of 20 steps
- Thread crash fingerprint, mutation_info, and parent_id through `analyze_run` CRASH return
- Log all attribution events to `logs/crash_attribution.jsonl` for post-campaign analysis
- Filter hygiene mutators from both direct and lineage rewards

## Test plan
- [x] All 1638 tests pass
- [x] ruff check clean
- [x] mypy clean
- [x] `TestRecordCrashAttribution` (5 tests): direct/lineage rewards, stacking, empty strategy, JSONL logging
- [x] `TestWalkCrashLineage` (6 tests): simple chain, None parent, pruned files, max depth, missing mutation info
- [x] `TestHandleAnalysisDataCrashAttribution` (3 tests): attribution triggered, skipped on empty info, stat increment

Follow-up: #651 (crash-productive mutators section in campaign report)

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)