### PR TITLE
docs: add changelog update instructions to CLAUDE.md and skills

### DIFF
--- a/.claude/skills/new-mutator/SKILL.md
+++ b/.claude/skills/new-mutator/SKILL.md
@@ -73,7 +73,15 @@ class MyMutator(ast.NodeTransformer):
 1. Add the import to `lafleur/mutators/engine.py` in the appropriate import block (sorted alphabetically within the block for the source module)
 2. Add the class to the `self.transformers` list in `ASTMutator.__init__()`, placed near related mutators
 
-## Step 4: Write tests
+## Step 4: Update CHANGELOG.md
+
+Add an entry under `## [0.1.x] - Unreleased` → `### Added` describing what the mutator does and what JIT weakness it targets. Follow the existing format:
+
+```
+- A `MyMutator` that <what it does> to <JIT weakness targeted>, by @devdanzin.
+```
+
+## Step 5: Write tests
 
 Add tests to the matching test file under `tests/mutators/`:
 
@@ -119,7 +127,7 @@ class TestMyMutator(unittest.TestCase):
         self.assertEqual(ast.dump(mutated), original)
 ```
 
-## Step 5: Verify
+## Step 6: Verify
 
 Run these commands:
 

--- a/.claude/skills/task-workflow/SKILL.md
+++ b/.claude/skills/task-workflow/SKILL.md
@@ -42,6 +42,7 @@ Read existing code before modifying it. Follow patterns already established in t
 - Double quotes for strings
 - Complete type hints on all functions
 - Docstrings on classes and public methods
+- Add an entry to `CHANGELOG.md` under `## [0.1.x] - Unreleased` in the appropriate section (Added/Enhanced/Fixed/Documentation). Format: `- Description, by @devdanzin.`
 
 ## Step 4: Verify
 
@@ -107,3 +108,4 @@ Tell the user:
 - PR URL (merged)
 - Summary of changes made
 - Test results (pass count)
+- Changelog entry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,15 @@ The mutators are organized into several submodules under `lafleur/mutators/`:
 - Line length: 100 characters
 - Python 3.14+ features are acceptable
 
+### Changelog
+Every user-visible change (new feature, enhancement, bug fix, documentation update) must have a corresponding entry in `CHANGELOG.md` under `## [0.1.x] - Unreleased`. Place the entry in the appropriate section:
+- **Added** — new features, mutators, CLI flags, report sections
+- **Enhanced** — improvements to existing features
+- **Fixed** — bug fixes
+- **Documentation** — documentation-only changes
+
+Format: `- Description of the change, by @devdanzin.`
+
 ### Commit Messages
 Follow Conventional Commits specification:
 - `feat: Add new SideEffectInjector mutator`
@@ -325,7 +334,8 @@ When reviewing AI-generated code:
 2. Create a class inheriting from `ast.NodeTransformer`
 3. Implement visitor methods (`visit_*`) for target AST node types
 4. Import and register in `lafleur/mutators/engine.py`
-5. The learning system will automatically track its effectiveness
+5. Add a CHANGELOG.md entry under Added
+6. The learning system will automatically track its effectiveness
 
 ### Pattern 1: Scenario Injection (preferred for complex mutations)
 ```python


### PR DESCRIPTION
## Summary

- Adds a **Changelog** subsection to CLAUDE.md under Code Style, documenting the section names (Added/Enhanced/Fixed/Documentation) and entry format
- Adds step 5 ("Add a CHANGELOG.md entry under Added") to the Adding New Mutators checklist in CLAUDE.md
- Improves task-workflow skill Step 3 with specific changelog section/format guidance
- Expands new-mutator skill Step 4 with a format template showing how to describe the mutator and its JIT target

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)