### PR TITLE
feat: enhance TeeLogger with repeat collapsing, verbosity filtering, and --log-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- **TeeLogger** with repeat collapsing (consecutive identical lines collapsed to `(×N)` suffix), verbosity filtering (`--verbose` flag controls detail-level messages vs quiet mode showing only important events), and configurable log path (`--log-path` flag), by @devdanzin.
 - `BuiltinNamespaceCorruptor` with test_optimizer.py-inspired attacks: direct `__builtins__["KEY"]` style modifications, `ModuleType` vs dict representation handling, and high-frequency builtin corruption (corrupting `len`, `isinstance`, and `type` simultaneously), by @devdanzin.
 - `BloomFilterSaturator` with probe-based saturation detection, strategic global modifications, and multi-phase attacks (warmup, saturation, exploitation, verification) to better exploit the JIT's global variable tracking bloom filter, by @devdanzin.
 - Legacy mode (non-session) crash handling now generates proper directory structure and `metadata.json` files, making legacy crashes visible to `lafleur-campaign` and `lafleur-triage` tools, by @devdanzin.


### PR DESCRIPTION
## Summary
- **Repeat collapsing**: consecutive identical lines collapsed into a single line with `(×N)` suffix, active for both console and log file output
- **Verbosity filtering**: `--verbose` / `-v` flag controls detail-level messages; default is quiet mode showing only important events (successes, crashes, errors, mutation headers, tachycardia, rewards)
- **`--log-path`**: configurable log file location, defaulting to the current auto-generated `logs/deep_fuzzer_run_{timestamp}.log` pattern

Closes #667

## Test plan
- [x] `ruff format` passes
- [x] `ruff check` passes
- [x] `mypy` passes on `lafleur/utils.py` and `lafleur/orchestrator.py`
- [x] 47 utils tests pass (20 new: 9 repeat collapsing, 10 verbosity filtering, 1 log path)
- [x] 3 new CLI plumbing tests pass (verbose flag, quiet default, custom log path)
- [x] Full test suite passes (1723 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)