### PR TITLE
fix: suppress blank lines from verbosity-filtered print() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- TeeLogger verbosity filtering leaving blank lines where suppressed lines were: `print()` sends two writes (content + `"\n"`) and the trailing newline was passing through after the content was suppressed, by @devdanzin.
 - Filter SyntaxError/IndentationError crashes from invalid mutations, by @devdanzin.
 - Delta tachycardia scoring applied an eternal reward because `parent_jit_stats` used a different key name than what `_prepare_new_coverage_result` stored, causing every child to appear to have higher density than its parent, by @devdanzin.
 - Delta tachycardia density threshold used a fixed minimum instead of a parent-relative calculation, making the bonus trivially easy to earn for any file above baseline, by @devdanzin.


### PR DESCRIPTION
## Summary
- Fix blank lines appearing in quiet mode output where suppressed lines used to be
- Root cause: `print()` sends two writes — content then `"\n"`. When the content was suppressed by the verbosity filter, the trailing `"\n"` still passed through
- Solution: track suppression state with `_last_was_suppressed` flag and swallow the next bare `"\n"` after a suppressed write

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] `mypy` passes on `lafleur/utils.py`
- [x] 4 new tests: `test_suppressed_print_no_blank_lines`, `test_suppressed_print_no_blank_lines_in_log_file`, `test_many_suppressed_prints_no_blank_lines`, `test_non_suppressed_newlines_still_pass_through`
- [x] Full test suite passes (1727 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)