### PR TITLE
fix: add missing mutator log prefixes to TeeLogger verbosity suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project should be documented in this file.
 ### Fixed
 
 - TeeLogger verbosity filtering leaving blank lines where suppressed lines were: `print()` sends two writes (content + `"\n"`) and the trailing newline was passing through after the content was suppressed, by @devdanzin.
+- TeeLogger verbosity filtering missing suppression prefixes for `Mutating`, `Transposing`, `Normalizing`, `Sanitizing`, `Decorating`, `Variable`, `Failed`, `SyntaxError`, `Targeting` mutator verbs, `    [!] SyntaxError` mutator warnings, and `[NEW RELATIVE RARE_EVENT]` coverage lines, by @devdanzin.
 - Filter SyntaxError/IndentationError crashes from invalid mutations, by @devdanzin.
 - Delta tachycardia scoring applied an eternal reward because `parent_jit_stats` used a different key name than what `_prepare_new_coverage_result` stored, causing every child to appear to have higher density than its parent, by @devdanzin.
 - Delta tachycardia density threshold used a fixed minimum instead of a parent-relative calculation, making the bonus trivially easy to earn for any file above baseline, by @devdanzin.

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -117,7 +117,18 @@ class TeeLogger:
         "    -> Corrupting",
         "    -> Patching",
         "    -> Polluting",
+        "    -> Mutating",
+        "    -> Transposing",
+        "    -> Normalizing",
+        "    -> Sanitizing",
+        "    -> Decorating",
+        "    -> Variable",
+        "    -> Failed",
+        "    -> SyntaxError",
+        "    -> Targeting",
         "    -> Run #",
+        # Mutator error/warning lines (4-space indent + bracket)
+        "    [!] SyntaxError",
         # Stage notifications
         "  [~] Large AST detected",
         "  [~] Running HAVOC",
@@ -134,6 +145,7 @@ class TeeLogger:
         # Individual relative discoveries (globals are important, relatives are noisy)
         "[NEW RELATIVE EDGE]",
         "[NEW RELATIVE UOP]",
+        "[NEW RELATIVE RARE_EVENT]",
         # Non-interesting child results
         "  [+] Child IS NOT interesting",
         # Corpus score calculation (happens twice per mutation cycle)


### PR DESCRIPTION
## Summary
- Audit all mutator `print()` calls across `generic.py`, `scenarios_data.py`, `scenarios_types.py`, `scenarios_control.py`, `scenarios_runtime.py`, `utils.py`, and `engine.py`
- Add 9 missing `    -> ` verb prefixes: `Mutating`, `Transposing`, `Normalizing`, `Sanitizing`, `Decorating`, `Variable`, `Failed`, `SyntaxError`, `Targeting`
- Add `    [!] SyntaxError` for mutator warning lines (t-string parse fallback)
- Add `[NEW RELATIVE RARE_EVENT]` for individual relative rare event discoveries

Closes #670

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] New test `test_quiet_mode_suppresses_all_mutator_verbs` covers all 9 new verb prefixes
- [x] New test `test_quiet_mode_suppresses_mutator_warning_lines` covers `    [!] SyntaxError`
- [x] Existing `test_quiet_mode_suppresses_relative_coverage` extended with `[NEW RELATIVE RARE_EVENT]`
- [x] Full test suite passes (1729 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)