### PR TITLE
feat: add rich diagnostic capture for ast.unparse() failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- **ast.unparse() diagnostic capture** with rich output: pickle dump of failing AST for exact reproduction, full traceback, transformer list, source hint, `ast.dump()` text, and a standalone `reproduce.py` script for CPython bug reporting. Replaces the previous text-only `_dump_failing_ast` approach and is now used in both `ASTMutator.mutate()` and `MutationController.prepare_child_script()`, by @devdanzin.
 - **TeeLogger** with repeat collapsing (consecutive identical lines collapsed to `(×N)` suffix), verbosity filtering (`--verbose` flag controls detail-level messages vs quiet mode showing only important events), and configurable log path (`--log-path` flag), by @devdanzin.
 - `BuiltinNamespaceCorruptor` with test_optimizer.py-inspired attacks: direct `__builtins__["KEY"]` style modifications, `ModuleType` vs dict representation handling, and high-frequency builtin corruption (corrupting `len`, `isinstance`, and `type` simultaneously), by @devdanzin.
 - `BloomFilterSaturator` with probe-based saturation detection, strategic global modifications, and multi-phase attacks (warmup, saturation, exploitation, verification) to better exploit the JIT's global variable tracking bloom filter, by @devdanzin.

--- a/lafleur/mutators/__init__.py
+++ b/lafleur/mutators/__init__.py
@@ -7,7 +7,7 @@ essential utility transformers like `FuzzerSetupNormalizer` and `EmptyBodySaniti
 for easy access by the orchestrator.
 """
 
-from lafleur.mutators.engine import ASTMutator, SlicingMutator
+from lafleur.mutators.engine import ASTMutator, SlicingMutator, _dump_unparse_diagnostics
 from lafleur.mutators.utils import (
     FuzzerSetupNormalizer,
     EmptyBodySanitizer,
@@ -19,6 +19,7 @@ from lafleur.mutators.generic import ImportPrunerMutator, StatementDuplicator, V
 __all__ = [
     "ASTMutator",
     "SlicingMutator",
+    "_dump_unparse_diagnostics",
     "FuzzerSetupNormalizer",
     "EmptyBodySanitizer",
     "HarnessInstrumentor",

--- a/tests/orchestrator/test_execution.py
+++ b/tests/orchestrator/test_execution.py
@@ -14,7 +14,7 @@ import subprocess
 import unittest
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 from lafleur.execution import ExecutionManager
 from lafleur.mutation_controller import MutationController
@@ -138,13 +138,18 @@ class TestPrepareChildScript(unittest.TestCase):
             side_effect=AttributeError("_Precedence has no attribute '_indent'"),
         ):
             with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
-                with patch.object(self.controller, "_dump_failing_ast"):
+                with patch("lafleur.mutation_controller._dump_unparse_diagnostics") as mock_dump:
                     result = self.controller.prepare_child_script(
                         parent_tree, mutated_harness, runtime_seed=42
                     )
 
         self.assertIsNone(result)
         self.assertIn("AttributeError", mock_stderr.getvalue())
+        mock_dump.assert_called_once()
+        self.assertEqual(
+            mock_dump.call_args[1]["source_hint"],
+            "MutationController.prepare_child_script",
+        )
 
     def test_returns_none_on_type_error_during_unparse(self):
         """TypeError during ast.unparse returns None."""
@@ -153,43 +158,14 @@ class TestPrepareChildScript(unittest.TestCase):
 
         with patch("ast.unparse", side_effect=TypeError("unexpected type")):
             with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
-                with patch.object(self.controller, "_dump_failing_ast"):
+                with patch("lafleur.mutation_controller._dump_unparse_diagnostics") as mock_dump:
                     result = self.controller.prepare_child_script(
                         parent_tree, mutated_harness, runtime_seed=42
                     )
 
         self.assertIsNone(result)
         self.assertIn("TypeError", mock_stderr.getvalue())
-
-    def test_dump_failing_ast_creates_file(self):
-        """_dump_failing_ast creates a diagnostic file in crashes/unparse_errors/."""
-        tree = ast.parse("x = 1")
-        error = AttributeError("test error")
-
-        with patch("builtins.open", mock_open()) as mock_file:
-            with patch("pathlib.Path.mkdir"):
-                self.controller._dump_failing_ast(tree, error)
-
-            mock_file.assert_called_once()
-            written = "".join(call.args[0] for call in mock_file().write.call_args_list)
-            self.assertIn("AttributeError", written)
-            self.assertIn("test error", written)
-            self.assertIn("AST Dump", written)
-
-    def test_dump_failing_ast_handles_dump_failure(self):
-        """_dump_failing_ast handles ast.dump failure gracefully."""
-        tree = MagicMock()
-        error = AttributeError("test error")
-
-        with patch("ast.dump", side_effect=Exception("dump also broken")):
-            with patch("pathlib.Path.mkdir"):
-                with patch("builtins.open", mock_open()) as mock_file:
-                    with patch("sys.stderr", new_callable=io.StringIO):
-                        # Should not raise
-                        self.controller._dump_failing_ast(tree, error)
-
-                    written = "".join(call.args[0] for call in mock_file().write.call_args_list)
-                    self.assertIn("ast.dump also failed", written)
+        mock_dump.assert_called_once()
 
     def test_runtime_seed_in_rng_setup(self):
         """Test that runtime seed is correctly embedded."""


### PR DESCRIPTION
## Summary
- Add `_dump_unparse_diagnostics()` helper in `engine.py` that captures pickle dump, full traceback, transformer list, source hint, `ast.dump()` text, and `reproduce.py` script when `ast.unparse()` fails
- Replace the old `_dump_failing_ast` method in `mutation_controller.py` with the new richer helper
- Wire diagnostics into `ASTMutator.mutate()` as well, capturing transformer list for debugging
- Add 10 new tests in `TestUnparseDiagnostics` covering all diagnostic outputs and error handling
- Update existing tests to use `_dump_unparse_diagnostics` mocking

## Test plan
- [x] All 1737 tests pass
- [x] ruff format/check clean
- [x] New `TestUnparseDiagnostics` tests cover: directory creation, pickle file, info.txt content, reproduce.py, transformer recording, source hint, unpicklable tree handling, ast.dump failure fallback, total failure returns None, stderr output

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)