### PR TITLE
Fix six mutator bugs causing sterile mutations and runtime errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to this project should be documented in this file.
 - `ConstantPerturbator` crash when encountering certain constant node types during mutation, found during code review, by @devdanzin.
 - Numerous mutator bugs across all modules found during systematic code review campaign: `TypeInstabilityInjector` scoping issues, `NumericMutator` `visit_Call` scoping bug, hardcoded variable names in three `scenarios_data` mutators, `ContainerChanger` probability distribution imbalance, `GuardInjector` over-wrapping, and others, by @devdanzin.
 - Unparseable corpus files could poison the corpus and waste mutation cycles; now validated with `ast.parse()` before saving and unparseable parents are marked sterile so the scheduler deprioritizes them, by @devdanzin.
+- Six mutator bugs causing sterile mutations and runtime errors: `PatternMatchingChaosMutator` referencing undefined `_chaos_side_effect`, `StressPatternInjector` injecting operations without try/except, `WeakRefCallbackChaos` local/global scope confusion, and `SideEffectInjector`/`FrameManipulator`/`ReentrantSideEffectMutator` catching only `TypeError` instead of also `NameError` for code injected before variable definitions, by @devdanzin.
 
 
 ### Documentation

--- a/lafleur/mutators/scenarios_control.py
+++ b/lafleur/mutators/scenarios_control.py
@@ -1128,7 +1128,7 @@ class PatternMatchingChaosMutator(ast.NodeTransformer):
                     values=[
                         ast.Call(
                             func=ast.Attribute(
-                                value=ast.Name(id="_chaos_side_effect", ctx=ast.Load()),
+                                value=ast.List(elts=[], ctx=ast.Load()),
                                 attr="append",
                                 ctx=ast.Load(),
                             ),

--- a/lafleur/mutators/scenarios_data.py
+++ b/lafleur/mutators/scenarios_data.py
@@ -932,16 +932,16 @@ class ReentrantSideEffectMutator(ast.NodeTransformer):
             trigger_code = dedent(f"""
                 try:
                     _ = {class_name}() in {var_name}
-                except (IndexError, KeyError, RuntimeError, ValueError):
-                    pass  # Expected errors from rug pull
+                except (IndexError, KeyError, RuntimeError, ValueError, NameError):
+                    pass  # Expected errors from rug pull or insertion before definition
             """)
         else:
             # For sequences and dicts, use [] operator
             trigger_code = dedent(f"""
                 try:
                     _ = {var_name}[{class_name}()]
-                except (IndexError, KeyError, RuntimeError, ValueError):
-                    pass  # Expected errors from rug pull
+                except (IndexError, KeyError, RuntimeError, ValueError, NameError):
+                    pass  # Expected errors from rug pull or insertion before definition
             """)
 
         return ast.parse(trigger_code).body

--- a/tests/mutators/test_scenarios_control.py
+++ b/tests/mutators/test_scenarios_control.py
@@ -1725,6 +1725,8 @@ class TestPatternMatchingChaosMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         # Should still be valid Python with match
         self.assertIn("match x:", result)
+        # Should NOT reference the undefined _chaos_side_effect
+        self.assertNotIn("_chaos_side_effect", result)
         ast.parse(result)  # Ensure valid
 
     def test_transforms_existing_match_with_nested(self):

--- a/tests/mutators/test_scenarios_data.py
+++ b/tests/mutators/test_scenarios_data.py
@@ -996,9 +996,10 @@ class TestReentrantSideEffectMutator(unittest.TestCase):
         # Should clear the target list
         self.assertIn("my_list.clear()", code_str)
 
-        # Should have try/except wrapper
+        # Should have try/except wrapper catching NameError
         self.assertIn("try:", code_str)
         self.assertIn("except", code_str)
+        self.assertIn("NameError", code_str)
 
         # Should have trigger statement using []
         self.assertIn("my_list[RugPuller_1234()]", code_str)
@@ -1033,9 +1034,10 @@ class TestReentrantSideEffectMutator(unittest.TestCase):
         # Should clear the target set
         self.assertIn("my_set.clear()", code_str)
 
-        # Should have try/except wrapper
+        # Should have try/except wrapper catching NameError
         self.assertIn("try:", code_str)
         self.assertIn("except", code_str)
+        self.assertIn("NameError", code_str)
 
         # Should use 'in' operator for sets
         self.assertIn("in my_set", code_str)


### PR DESCRIPTION
## Summary

- Fix `PatternMatchingChaosMutator` referencing undefined `_chaos_side_effect` → NameError at runtime
- Fix `StressPatternInjector` injecting operations without try/except → immediate crash on simple types
- Fix `WeakRefCallbackChaos` local/global scope confusion → completely sterile mutation
- Fix `SideEffectInjector`, `FrameManipulator`, and `ReentrantSideEffectMutator` catching only `TypeError` instead of also `NameError` for code injected before variable definitions

Closes #674

## Test plan

- [x] Updated `test_transforms_existing_match_with_guard` to verify no `_chaos_side_effect` reference
- [x] Updated `test_stress_pattern_injector` to verify try/except wrapping via `ast.Try` nodes
- [x] Updated `test_creates_global_variable_and_weakref` to verify `global` declaration
- [x] Added `test_side_effect_injector_catches_name_error` test
- [x] Added `test_frame_manipulator_catches_name_error` test
- [x] Updated `test_includes_guarded_usage_after_corruption` assertion for NameError
- [x] Updated `test_rug_pull_attack_on_list` and `test_rug_pull_attack_on_set` for NameError
- [x] All 349 mutator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)