### PR TITLE
Fix five mutator sterility bugs: scope leaks, narrow excepts, missing dunders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ All notable changes to this project should be documented in this file.
 - Numerous mutator bugs across all modules found during systematic code review campaign: `TypeInstabilityInjector` scoping issues, `NumericMutator` `visit_Call` scoping bug, hardcoded variable names in three `scenarios_data` mutators, `ContainerChanger` probability distribution imbalance, `GuardInjector` over-wrapping, and others, by @devdanzin.
 - Unparseable corpus files could poison the corpus and waste mutation cycles; now validated with `ast.parse()` before saving and unparseable parents are marked sterile so the scheduler deprioritizes them, by @devdanzin.
 - Six mutator bugs causing sterile mutations and runtime errors: `PatternMatchingChaosMutator` referencing undefined `_chaos_side_effect`, `StressPatternInjector` injecting operations without try/except, `WeakRefCallbackChaos` local/global scope confusion, and `SideEffectInjector`/`FrameManipulator`/`ReentrantSideEffectMutator` catching only `TypeError` instead of also `NameError` for code injected before variable definitions, by @devdanzin.
+- `RecursionWrappingMutator`: Remainder of function body after the wrapped block is now protected by try/except to handle `UnboundLocalError` from variables that moved into the nested scope, by @devdanzin.
+- `_mutate_for_loop_iter`: Replaced for loop is now wrapped in try/except to handle tuple-unpacking and type mismatch errors from the stateful iterator replacement, by @devdanzin.
+- `TypeInstabilityInjector`: Widened except clause from `TypeError` to `(TypeError, AttributeError)` to handle method calls on corrupted string values, by @devdanzin.
+- `LatticeSurfingMutator`: Added `__radd__`, `__sub__`, `__rsub__`, `__mul__`, `__rmul__`, `__mod__`, `__lt__`, `__le__`, `__gt__`, `__ge__`, `__eq__`, `__ne__`, `__hash__`, and `__repr__` to both `_SurferA` and `_SurferB` classes. Each method performs the class-flip before delegating, increasing the attack surface, by @devdanzin.
+- `SuperResolutionAttacker`: Widened Phase 3 stress loop from `except AttributeError` to `except Exception`, by @devdanzin.
+- `CodeObjectSwapper`: Widened post-swap stress loop from `except TypeError` to `except Exception`, by @devdanzin.
 
 
 ### Documentation

--- a/tests/mutators/test_scenarios_data.py
+++ b/tests/mutators/test_scenarios_data.py
@@ -803,7 +803,7 @@ class TestMutateForLoopIter(unittest.TestCase):
     """Test the shared _mutate_for_loop_iter helper."""
 
     def test_mutate_for_loop_iter_shared_function(self):
-        """Test the shared _mutate_for_loop_iter helper."""
+        """Test the shared _mutate_for_loop_iter helper wraps in try/except."""
         code = dedent("""
             def uop_harness_test():
                 for i in range(10):
@@ -818,6 +818,9 @@ class TestMutateForLoopIter(unittest.TestCase):
         self.assertTrue(result)
         code_str = ast.unparse(func_node)
         self.assertIn("StatefulIter_iter_4242", code_str)
+        # The for loop should be wrapped in try/except
+        try_nodes = [n for n in func_node.body if isinstance(n, ast.Try)]
+        self.assertGreater(len(try_nodes), 0, "For loop should be wrapped in try/except")
 
     def test_mutate_for_loop_iter_no_loop(self):
         """Test that _mutate_for_loop_iter returns False with no for loop."""
@@ -1197,6 +1200,12 @@ class TestLatticeSurfingMutator(unittest.TestCase):
         self.assertIn("self.__class__ = _SurferB", result)
         # _SurferB should flip to _SurferA in magic methods
         self.assertIn("self.__class__ = _SurferA", result)
+        # Should have comparison and arithmetic dunder methods
+        self.assertIn("__lt__", result)
+        self.assertIn("__eq__", result)
+        self.assertIn("__sub__", result)
+        self.assertIn("__mul__", result)
+        self.assertIn("__hash__", result)
 
     def test_limits_mutation_to_1_or_2_variables(self):
         """Test that only 1-2 variables are mutated."""

--- a/tests/mutators/test_scenarios_types.py
+++ b/tests/mutators/test_scenarios_types.py
@@ -40,7 +40,7 @@ class TestTypeInstabilityInjector(unittest.TestCase):
         random.seed(42)
 
     def test_type_instability_injector(self):
-        """Test TypeInstabilityInjector mutator."""
+        """Test TypeInstabilityInjector mutator catches TypeError and AttributeError."""
         code = dedent("""
             def uop_harness_test():
                 for i in range(100):
@@ -58,6 +58,7 @@ class TestTypeInstabilityInjector(unittest.TestCase):
         result = ast.unparse(mutated)
         self.assertIn("try:", result)
         self.assertIn("TypeError", result)
+        self.assertIn("AttributeError", result)
 
     def test_type_instability_with_no_loop_var(self):
         """Test TypeInstabilityInjector with tuple target."""
@@ -863,7 +864,7 @@ class TestSuperResolutionAttacker(unittest.TestCase):
         self.assertGreaterEqual(result.count("super()"), 2)
 
     def test_includes_stress_loop(self):
-        """Test that stress loop repeatedly calls method."""
+        """Test that stress loop repeatedly calls method with broad exception handling."""
         code = dedent("""
             def uop_harness_test():
                 x = 1
@@ -879,6 +880,8 @@ class TestSuperResolutionAttacker(unittest.TestCase):
         # Should have stress loop calling method
         self.assertIn("for _ in range(100):", result)
         self.assertIn("instance_super_5000.f()", result)
+        # Phase 3 stress loop should catch Exception (not just AttributeError)
+        self.assertIn("except Exception", result)
 
     def test_wraps_in_try_except(self):
         """Test that scenario is wrapped in try/except."""


### PR DESCRIPTION
## Summary

- Fix `RecursionWrappingMutator` scope leak: remainder of function body after the wrapped block is now protected by try/except to handle `UnboundLocalError` from variables that moved into the nested scope
- Fix `_mutate_for_loop_iter` unprotected replacement: replaced for loop is now wrapped in try/except to handle tuple-unpacking and type mismatch errors
- Fix `TypeInstabilityInjector` narrow except: widened from `TypeError` to `(TypeError, AttributeError)` to handle method calls on corrupted string values
- Fix `LatticeSurfingMutator` missing dunders: added 14 dunder methods (`__radd__`, `__sub__`, `__rsub__`, `__mul__`, `__rmul__`, `__mod__`, `__lt__`, `__le__`, `__gt__`, `__ge__`, `__eq__`, `__ne__`, `__hash__`, `__repr__`) to both Surfer classes so the class-flip fires on common operations
- Fix `SuperResolutionAttacker` and `CodeObjectSwapper` narrow excepts: widened stress loop handlers to `except Exception`

Closes #676

## Test plan

- [x] Updated `test_wraps_block_in_recursive_function` to verify remainder protection
- [x] Added `test_remainder_wrapped_in_try_except` for scope error protection
- [x] Added `test_no_remainder_wrapper_when_block_at_end` for no-remainder case
- [x] Updated `test_mutate_for_loop_iter_shared_function` to verify try/except wrapping
- [x] Updated `test_surfer_class_flip_flop` to verify new dunder methods
- [x] Updated `test_type_instability_injector` to verify AttributeError in except
- [x] Updated `test_includes_stress_loop` to verify broad exception handling
- [x] All 392 mutator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)