### PR TITLE
Fix HelperFunctionInjector unprotected calls, SniperMutator zero-warmup, SliceMutator unprotected ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ All notable changes to this project should be documented in this file.
 - `LatticeSurfingMutator`: Added `__radd__`, `__sub__`, `__rsub__`, `__mul__`, `__rmul__`, `__mod__`, `__lt__`, `__le__`, `__gt__`, `__ge__`, `__eq__`, `__ne__`, `__hash__`, and `__repr__` to both `_SurferA` and `_SurferB` classes. Each method performs the class-flip before delegating, increasing the attack surface, by @devdanzin.
 - `SuperResolutionAttacker`: Widened Phase 3 stress loop from `except AttributeError` to `except Exception`, by @devdanzin.
 - `CodeObjectSwapper`: Widened post-swap stress loop from `except TypeError` to `except Exception`, by @devdanzin.
+- `HelperFunctionInjector`: Wrapped injected helper calls in `visit_For` and `visit_While` in try/except to handle type mismatches when loop variables are non-int types, by @devdanzin.
+- `SniperMutator`: Gated invalidation behind an iteration counter (trigger at 50–100 iterations) so the JIT has time to compile the hot path before the sniper fires — previously fired on iteration 0, never triggering deoptimization, by @devdanzin.
+- `SliceMutator`: Wrapped read, write, and delete slice operations in try/except to handle cross-mutator type changes and out-of-bounds errors, by @devdanzin.
 
 
 ### Documentation

--- a/lafleur/mutators/helper_injection.py
+++ b/lafleur/mutators/helper_injection.py
@@ -223,8 +223,23 @@ class HelperFunctionInjector(ast.NodeTransformer):
             ),
         )
 
+        # Wrap in try/except to handle type mismatches when loop_var
+        # is not a compatible type (e.g., string in `for name in names:`)
+        wrapped_call = ast.Try(
+            body=[call_stmt],
+            handlers=[
+                ast.ExceptHandler(
+                    type=ast.Name(id="Exception", ctx=ast.Load()),
+                    name=None,
+                    body=[ast.Pass()],
+                )
+            ],
+            orelse=[],
+            finalbody=[],
+        )
+
         # Insert the call at the start of the loop body
-        node.body = [call_stmt] + node.body
+        node.body = [wrapped_call] + node.body
         ast.fix_missing_locations(node)
 
         return node
@@ -254,8 +269,23 @@ class HelperFunctionInjector(ast.NodeTransformer):
             ),
         )
 
+        # Wrap in try/except in case the helper has been sniped or
+        # is otherwise unavailable
+        wrapped_call = ast.Try(
+            body=[call_stmt],
+            handlers=[
+                ast.ExceptHandler(
+                    type=ast.Name(id="Exception", ctx=ast.Load()),
+                    name=None,
+                    body=[ast.Pass()],
+                )
+            ],
+            orelse=[],
+            finalbody=[],
+        )
+
         # Insert the call at the start of the loop body
-        node.body = [call_stmt] + node.body
+        node.body = [wrapped_call] + node.body
         ast.fix_missing_locations(node)
 
         return node


### PR DESCRIPTION
## Summary

- Fix `HelperFunctionInjector` injecting unprotected helper calls that crash on non-int loop variables (e.g., `_jit_helper_add("alice", 10)` → TypeError)
- Fix `SniperMutator` firing invalidation on iteration 0 before JIT compilation — the entire sniper strategy was ineffective. Now gated behind an iteration counter (trigger at 50–100 iterations)
- Fix `SliceMutator` injecting raw slice read/write/delete operations without try/except — cross-mutator type changes and out-of-bounds crash the harness

Closes #678

## Test plan

- [x] Updated `test_injects_calls_into_existing_loops` to verify try/except wrapping of helper calls
- [x] Added `test_helper_call_handles_non_int_loop_var` for string loop variable protection
- [x] Replaced `test_injection_into_for_loop` with `test_injection_into_for_loop_with_warmup_delay` verifying counter, guard, and NameError lazy-init
- [x] Replaced `test_injection_into_while_loop` with `test_injection_into_while_loop_with_warmup_delay`
- [x] Added `test_trigger_iteration_in_warmup_range` verifying trigger is in 50–100 range
- [x] Updated `test_syntax_validity` for new sniper structure
- [x] Updated `test_injects_slice_read_operation`, `test_injects_slice_write_operation`, `test_injects_slice_delete_operation` to verify try/except wrapping
- [x] Added `test_slice_object_read_not_double_wrapped` to verify read_slice_obj is not double-wrapped
- [x] All 139 tests pass across the three modified test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)