### PR TITLE
Fix driver session robustness: SystemExit, dict iteration, sys.modules/sys.path leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to this project should be documented in this file.
 - `HelperFunctionInjector`: Wrapped injected helper calls in `visit_For` and `visit_While` in try/except to handle type mismatches when loop variables are non-int types, by @devdanzin.
 - `SniperMutator`: Gated invalidation behind an iteration counter (trigger at 50–100 iterations) so the JIT has time to compile the hot path before the sniper fires — previously fired on iteration 0, never triggering deoptimization, by @devdanzin.
 - `SliceMutator`: Wrapped read, write, and delete slice operations in try/except to handle cross-mutator type changes and out-of-bounds errors, by @devdanzin.
+- `run_session()`: `SystemExit` is now caught and logged instead of propagating. If a mutator injects `sys.exit()` into a warmup or polluter script, the session continues to the attack script instead of killing the driver process, by @devdanzin.
+- `run_session()`: `sys.path` and `sys.modules` are now snapshotted and restored between scripts. This prevents `ImportChaosMutator` pollution from leaking across session scripts and causing false-positive divergences, by @devdanzin.
+- `get_jit_stats()`, `snapshot_executor_state()`, `scan_watched_variables()`: Dictionary iteration now uses `list(dict.items())` to prevent `RuntimeError: dictionary changed size during iteration` when chaotic harness code triggers namespace-modifying side effects, by @devdanzin.
+- `verify_target_capabilities()`: Fixed typo in error message — `PYTHON_LLTRACE=4` corrected to `PYTHON_LLTRACE=2`, by @devdanzin.
 
 
 ### Documentation

--- a/lafleur/execution.py
+++ b/lafleur/execution.py
@@ -634,7 +634,7 @@ class ExecutionManager:
                     Troubleshooting:
                     1. Ensure you built CPython with: ./configure --with-pydebug --enable-experimental-jit
                     2. Ensure you ran: make -j$(nproc)
-                    3. Ensure the environment variables PYTHON_JIT=1, PYTHON_LLTRACE=4, and PYTHON_OPT_DEBUG=4 are respected.
+                    3. Ensure the environment variables PYTHON_JIT=1, PYTHON_LLTRACE=2, and PYTHON_OPT_DEBUG=4 are respected.
 
                     Output received from target (stderr +  stdout):
                     {output}


### PR DESCRIPTION
## Summary

- Fix `run_session()` catching `SystemExit` then re-raising it, killing the driver process when mutators inject `sys.exit()` into warmup/polluter scripts
- Fix `get_jit_stats()`, `snapshot_executor_state()`, `scan_watched_variables()` iterating `namespace.items()` directly — chaotic harness code can modify the namespace during iteration
- Fix `run_session()` not snapshotting/restoring `sys.modules` and `sys.path` between scripts — `ImportChaosMutator` pollution leaked across session scripts
- Fix typo in `verify_target_capabilities()` error message: `PYTHON_LLTRACE=4` → `PYTHON_LLTRACE=2`

Closes #680

## Test plan

- [x] Replaced `test_run_session_propagates_system_exit` with `test_run_session_catches_system_exit_and_continues` verifying catch + continue behavior
- [x] Added `test_run_session_system_exit_zero` verifying `sys.exit(0)` is also caught
- [x] Added `TestRunSessionStateIsolation` with `test_sys_path_restored_between_scripts`, `test_sys_modules_cleaned_between_scripts`, `test_sys_argv_restored_between_scripts`
- [x] All 54 driver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)