### PR TITLE
fix: fix corpus subsumption operator and coverage log readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ All notable changes to this project should be documented in this file.
 - `run_session()`: `sys.path` and `sys.modules` are now snapshotted and restored between scripts. This prevents `ImportChaosMutator` pollution from leaking across session scripts and causing false-positive divergences, by @devdanzin.
 - `get_jit_stats()`, `snapshot_executor_state()`, `scan_watched_variables()`: Dictionary iteration now uses `list(dict.items())` to prevent `RuntimeError: dictionary changed size during iteration` when chaotic harness code triggers namespace-modifying side effects, by @devdanzin.
 - `verify_target_capabilities()`: Fixed typo in error message — `PYTHON_LLTRACE=4` corrected to `PYTHON_LLTRACE=2`, by @devdanzin.
+- `_find_subsumer_candidates()`: Changed `>` to `>=` so files with equal coverage are considered as subsumption candidates. Previously, a minimized file with identical coverage but smaller size and faster execution could never replace the original because the strict greater-than excluded equal-sized edge sets from the candidate pool, by @devdanzin.
+- `merge_coverage_into_global()`: Discovery log entries now resolve integer IDs to human-readable names (e.g. `LOAD_FAST` instead of `42`) by building reverse maps from the forward ID tables, with fallback to `str(id)` for unmapped IDs, by @devdanzin.
 
 
 ### Documentation

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -536,7 +536,7 @@ class CorpusManager:
 
         A valid subsumer candidate must:
         1. Contain ALL of A's edges (found via index intersection)
-        2. Have strictly MORE edges than A (proper superset requirement)
+        2. Have at least as many edges as A (superset-or-equal requirement)
         3. Not be A itself
         4. Not already be marked for pruning
 
@@ -569,10 +569,10 @@ class CorpusManager:
                 # At most self remains — no subsumers possible
                 break
 
-        # Remove self, already-pruned files, and files without strictly more edges
+        # Remove self, already-pruned files, and files without at least as many edges
         candidates.discard(filename_a)
         candidates -= files_to_prune
-        candidates = {c for c in candidates if len(file_edges.get(c, set())) > len(edges_a)}
+        candidates = {c for c in candidates if len(file_edges.get(c, set())) >= len(edges_a)}
 
         return candidates
 
@@ -621,7 +621,7 @@ class CorpusManager:
             if not edges_a or filename_a in files_to_prune:
                 continue
 
-            # Find files that contain all of A's edges and have strictly more
+            # Find files that contain all of A's edges (superset or equal)
             candidates = self._find_subsumer_candidates(
                 filename_a, edges_a, file_edges, edge_to_files, files_to_prune
             )


### PR DESCRIPTION
## Summary
- Changed `>` to `>=` in `_find_subsumer_candidates()` so files with equal coverage are considered as subsumption candidates, enabling minimized files to replace originals when they have better size/time metrics
- Added reverse map lookup in `merge_coverage_into_global()` so discovery log entries show human-readable names (e.g. `LOAD_FAST`) instead of raw integer IDs
- Updated docstrings and comments to reflect the relaxed subsumption semantics

## Test plan
- [x] Renamed `test_returns_proper_supersets` → `test_returns_supersets_and_equal_coverage` to verify equal-coverage files are now candidates
- [x] Added `test_prune_minimized_file_replaces_original` to verify end-to-end pruning of equal-coverage files with better metrics
- [x] Added `test_prune_equal_coverage_equal_metrics_not_subsumed` to verify equal metrics prevent pruning
- [x] Added `test_merge_coverage_resolves_display_names` to verify reverse map lookup
- [x] Added `test_merge_coverage_falls_back_to_id_string` to verify fallback for unmapped IDs
- [x] All 77 tests in test_corpus_manager.py and test_coverage.py pass

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)