### PR TITLE
fix: fix ShrinkRay exit code matching, concatenation renaming, path escaping, registry upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ All notable changes to this project should be documented in this file.
 - `verify_target_capabilities()`: Fixed typo in error message — `PYTHON_LLTRACE=4` corrected to `PYTHON_LLTRACE=2`, by @devdanzin.
 - `_find_subsumer_candidates()`: Changed `>` to `>=` so files with equal coverage are considered as subsumption candidates. Previously, a minimized file with identical coverage but smaller size and faster execution could never replace the original because the strict greater-than excluded equal-sized edge sets from the candidate pool, by @devdanzin.
 - `merge_coverage_into_global()`: Discovery log entries now resolve integer IDs to human-readable names (e.g. `LOAD_FAST` instead of `42`) by building reverse maps from the forward ID tables, with fallback to `str(id)` for unmapped IDs, by @devdanzin.
+- `check_crash.sh`: Exit code matching now mirrors the Python `check_reproduction()` logic — signal crashes check for `128+N` (not raw Python `-N`), ASAN accepts any non-zero, others do exact match. Previously any non-zero exit (including `SyntaxError=1`) was treated as crash reproduction, by @devdanzin.
+- `_concatenate_scripts()`: Removed `rename_harnesses()` call that changed function names (e.g. `uop_harness_f1` → `uop_harness_f1_0`), breaking crash reproduction by altering the global dict keys the JIT watches, by @devdanzin.
+- `_generate_bash_scripts()`: `target_python` and script paths are now shell-escaped with `shlex.quote()` to handle paths containing spaces, by @devdanzin.
+- `upsert_reported_issues()`: Replaced `INSERT OR REPLACE` (which deletes entire rows on conflict, wiping existing fields) with `INSERT ... ON CONFLICT DO UPDATE SET ... COALESCE` to preserve existing values when incoming data has NULL/missing fields, by @devdanzin.
 
 
 ### Documentation

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -95,3 +95,80 @@ class TestCrashRegistry(unittest.TestCase):
         fetched = self.registry.get_all_reported_issues()
         self.assertEqual(len(fetched), 1)
         self.assertEqual(fetched[0]["issue_number"], 999)
+
+    def test_upsert_partial_preserves_existing(self):
+        """Test that partial upsert preserves existing fields."""
+        # Insert a complete issue first
+        full_issue = {
+            "issue_number": 100,
+            "title": "Original Title",
+            "url": "https://github.com/issue/100",
+            "description": "Original description",
+            "issue_status": "Open",
+            "crash_status": "NEW",
+        }
+        self.registry.upsert_reported_issues([full_issue])
+
+        # Now upsert with only a partial update
+        partial_update = {
+            "issue_number": 100,
+            "issue_status": "Closed",
+        }
+        self.registry.upsert_reported_issues([partial_update])
+
+        # Verify that existing fields were preserved
+        issues = self.registry.get_all_reported_issues()
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue["issue_number"], 100)
+        self.assertEqual(issue["title"], "Original Title")  # PRESERVED
+        self.assertEqual(issue["url"], "https://github.com/issue/100")  # PRESERVED
+        self.assertEqual(issue["description"], "Original description")  # PRESERVED
+        self.assertEqual(issue["issue_status"], "Closed")  # UPDATED
+        self.assertEqual(issue["crash_status"], "NEW")  # PRESERVED
+
+    def test_upsert_new_issue_works(self):
+        """Test that upserting a brand new issue still inserts correctly."""
+        new_issue = {
+            "issue_number": 200,
+            "title": "New Bug",
+            "url": "https://github.com/issue/200",
+        }
+        count = self.registry.upsert_reported_issues([new_issue])
+        self.assertEqual(count, 1)
+
+        issues = self.registry.get_all_reported_issues()
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0]["title"], "New Bug")
+
+    def test_upsert_multiple_mixed(self):
+        """Test upserting a mix of new and existing issues."""
+        # Insert initial issue
+        self.registry.upsert_reported_issues(
+            [
+                {
+                    "issue_number": 300,
+                    "title": "Existing",
+                    "description": "Keep this",
+                }
+            ]
+        )
+
+        # Upsert: update existing + insert new
+        batch = [
+            {"issue_number": 300, "issue_status": "Closed"},  # Partial update
+            {"issue_number": 301, "title": "Brand New"},  # New issue
+        ]
+        count = self.registry.upsert_reported_issues(batch)
+        self.assertEqual(count, 2)
+
+        issues = self.registry.get_all_reported_issues()
+        self.assertEqual(len(issues), 2)
+
+        issue_300 = next(i for i in issues if i["issue_number"] == 300)
+        self.assertEqual(issue_300["title"], "Existing")  # Preserved
+        self.assertEqual(issue_300["description"], "Keep this")  # Preserved
+        self.assertEqual(issue_300["issue_status"], "Closed")  # Updated
+
+        issue_301 = next(i for i in issues if i["issue_number"] == 301)
+        self.assertEqual(issue_301["title"], "Brand New")


### PR DESCRIPTION
## Summary
- `check_crash.sh` exit code matching now mirrors `check_reproduction()`: signal crashes check `128+N`, ASAN accepts any non-zero, others do exact match
- Removed `rename_harnesses()` call from `_concatenate_scripts()` that broke crash reproduction by altering JIT-watched global dict keys
- Shell-escaped `target_python` and script paths in generated bash scripts with `shlex.quote()`
- Replaced `INSERT OR REPLACE` in `upsert_reported_issues()` with `ON CONFLICT DO UPDATE SET ... COALESCE` to preserve existing fields on partial updates

## Test plan
- [x] `test_check_crash_sh_signal_exit_code` — signal crash checks for bash code 139 (128+11)
- [x] `test_check_crash_sh_asan_any_nonzero` — ASAN accepts any non-zero exit
- [x] `test_concatenation_preserves_original_names` — no harness renaming in concatenation
- [x] `test_check_crash_sh_quoted_paths` — paths with spaces are shell-escaped
- [x] `test_upsert_partial_preserves_existing` — partial update preserves existing fields
- [x] `test_upsert_new_issue_works` — new issue inserts correctly
- [x] `test_upsert_multiple_mixed` — mixed new/update batch works
- [x] All 39 tests in test_minimize.py and test_registry.py pass
- [x] mypy passes on both source files

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)