### PR TITLE
fix: campaign weighted averages, timeseries I/O, and metadata package resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ All notable changes to this project should be documented in this file.
 - `_concatenate_scripts()`: Removed `rename_harnesses()` call that changed function names (e.g. `uop_harness_f1` → `uop_harness_f1_0`), breaking crash reproduction by altering the global dict keys the JIT watches, by @devdanzin.
 - `_generate_bash_scripts()`: `target_python` and script paths are now shell-escaped with `shlex.quote()` to handle paths containing spaces, by @devdanzin.
 - `upsert_reported_issues()`: Replaced `INSERT OR REPLACE` (which deletes entire rows on conflict, wiping existing fields) with `INSERT ... ON CONFLICT DO UPDATE SET ... COALESCE` to preserve existing values when incoming data has NULL/missing fields, by @devdanzin.
+- `_aggregate_corpus()`: Truthiness check `if depth_dist.get("mean"):` silently dropped instances whose mean depth was `0.0` from weighted averages, skewing campaign statistics upward. Now uses `is not None` for both depth and size checks, by @devdanzin.
+- `load_latest_timeseries_entry()`: Byte-by-byte backward seek caused excessive syscalls on large files due to `BufferedReader` invalidation. Replaced with `collections.deque(f, maxlen=1)` for a single-pass O(n) read, by @devdanzin.
+- `get_installed_packages()` and `get_target_python_info()`: A single corrupted `dist-info` entry would crash the entire package listing. Now uses per-package try/except to skip broken entries, by @devdanzin.
 
 
 ### Documentation

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -510,11 +510,11 @@ class CampaignAggregator:
             depth_dist = corpus.get("lineage_depth_distribution", {})
             size_dist = corpus.get("file_size_distribution", {})
 
-            if depth_dist.get("mean"):
+            if depth_dist.get("mean") is not None:
                 self.global_corpus["sum_depth"] += depth_dist["mean"] * total_files
                 self.global_corpus["file_count_for_avg"] += total_files
 
-            if size_dist.get("mean"):
+            if size_dist.get("mean") is not None:
                 self.global_corpus["sum_size"] += size_dist["mean"] * total_files
 
         # Aggregate mutation strategies (with backwards compatibility)

--- a/lafleur/metadata.py
+++ b/lafleur/metadata.py
@@ -246,7 +246,10 @@ def get_installed_packages() -> list[dict[str, str]]:
     """Get list of installed packages with their versions from the current interpreter."""
     packages = []
     for dist in distributions():
-        packages.append({"name": dist.metadata["Name"], "version": dist.metadata["Version"]})
+        try:
+            packages.append({"name": dist.metadata["Name"], "version": dist.metadata["Version"]})
+        except Exception:
+            pass
     # Sort by name for consistent output
     return sorted(packages, key=lambda p: p["name"].lower())
 
@@ -273,7 +276,12 @@ import json
 import sysconfig
 try:
     from importlib.metadata import distributions
-    packages = [{"name": d.metadata["Name"], "version": d.metadata["Version"]} for d in distributions()]
+    packages = []
+    for d in distributions():
+        try:
+            packages.append({"name": d.metadata["Name"], "version": d.metadata["Version"]})
+        except Exception:
+            pass
     packages = sorted(packages, key=lambda p: p["name"].lower())
 except Exception:
     packages = []

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -138,6 +138,22 @@ class TestGetInstalledPackages(unittest.TestCase):
 
         self.assertEqual(packages, [])
 
+    @patch("lafleur.metadata.distributions")
+    def test_skips_corrupted_packages(self, mock_distributions):
+        """Test that corrupted dist-info entries are skipped without crashing."""
+        good_dist = MagicMock()
+        good_dist.metadata = {"Name": "good-pkg", "Version": "1.0"}
+
+        bad_dist = MagicMock()
+        bad_dist.metadata.__getitem__ = MagicMock(side_effect=KeyError("Name"))
+
+        mock_distributions.return_value = [good_dist, bad_dist]
+
+        packages = get_installed_packages()
+
+        self.assertEqual(len(packages), 1)
+        self.assertEqual(packages[0]["name"], "good-pkg")
+
 
 class TestGetTargetPythonInfo(unittest.TestCase):
     """Tests for target Python interpreter info retrieval."""


### PR DESCRIPTION
## Summary
- Fix `_aggregate_corpus()` truthiness check that silently dropped instances with mean depth `0.0` from weighted averages — now uses `is not None`
- Replace byte-by-byte backward seek in `load_latest_timeseries_entry()` with `collections.deque(f, maxlen=1)` for efficient O(n) single-pass reading
- Add per-package try/except in `get_installed_packages()` and `get_target_python_info()` injected script to skip corrupted `dist-info` entries

Closes #686

## Test plan
- [x] Two new campaign tests verify zero-mean depth is included in weighted averages
- [x] Five new timeseries tests cover no-logs, no-files, last-line, empty-file, single-line scenarios
- [x] One new metadata test verifies corrupted packages are skipped
- [x] All 143 tests pass across test_campaign, test_report, test_metadata
- [x] mypy passes, ruff format/check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)