### PR TITLE
test: strengthen mutator test assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project should be documented in this file.
 - A `SliceObjectChaosMutator` that attacks the JIT's slice type tracking (`_GUARD_TOS_SLICE` elimination, `_BINARY_OP_SUBSCR_LIST_SLICE` optimization) through six vectors: slice-to-int swaps in the same subscript, slice subclasses with dynamic indices, guard elimination violation via type substitution, mutating slice state between creation and use, cross-container-type slicing, and nested slice corruption, by @devdanzin.
 - CLI argument plumbing tests verifying that all CLI options are correctly threaded through to their respective manager classes, by @devdanzin.
 - A directory column in the campaign instance leaderboard for identifying instance paths, by @devdanzin.
+- Strengthened mutator test assertions: `exec()` verification for all evil object generators, safety wrapper assertions for `SliceMutator` and `StringInterpolationMutator`, and brittleness comments on tests with rigid `side_effect` sequences, by @devdanzin.
 
 
 ### Enhanced

--- a/tests/mutators/test_generic.py
+++ b/tests/mutators/test_generic.py
@@ -955,6 +955,9 @@ class TestSliceMutator(unittest.TestCase):
 
     def test_injects_slice_read_operation(self):
         """Test slice read operation injection is wrapped in try/except."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = [1, 2, 3, 4, 5]
@@ -976,6 +979,9 @@ class TestSliceMutator(unittest.TestCase):
 
     def test_injects_slice_write_operation(self):
         """Test slice write operation injection is wrapped in try/except."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = [1, 2, 3, 4, 5]
@@ -997,6 +1003,9 @@ class TestSliceMutator(unittest.TestCase):
 
     def test_injects_slice_delete_operation(self):
         """Test slice delete operation injection is wrapped in try/except."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = [1, 2, 3, 4, 5]
@@ -1018,6 +1027,9 @@ class TestSliceMutator(unittest.TestCase):
 
     def test_injects_slice_object_read(self):
         """Test slice object read operation injection."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = [1, 2, 3, 4, 5]
@@ -1034,9 +1046,15 @@ class TestSliceMutator(unittest.TestCase):
         # Should have slice object
         self.assertIn("slice_obj_8000", result)
         self.assertIn("slice(", result)
+        # Safety wrapper must be present — slice operations can raise
+        self.assertIn("try:", result)
+        self.assertIn("except Exception:", result)
 
     def test_slice_object_read_not_double_wrapped(self):
         """Test that read_slice_obj is not double-wrapped in try/except."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = [1, 2, 3, 4, 5]
@@ -1225,6 +1243,9 @@ class TestArithmeticSpamMutator(unittest.TestCase):
 
     def test_injects_float_add_spam(self):
         """Test float addition spam injection."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = 1.5
@@ -1243,6 +1264,9 @@ class TestArithmeticSpamMutator(unittest.TestCase):
 
     def test_injects_float_multiply_spam(self):
         """Test float multiplication spam injection."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = 0.25
@@ -1260,6 +1284,9 @@ class TestArithmeticSpamMutator(unittest.TestCase):
 
     def test_injects_string_spam(self):
         """Test string concatenation spam injection."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = "hello"
@@ -1335,6 +1362,9 @@ class TestStringInterpolationMutator(unittest.TestCase):
 
     def test_injects_fstring_with_int_format(self):
         """Test f-string with integer format spec injection."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = 42
@@ -1350,9 +1380,15 @@ class TestStringInterpolationMutator(unittest.TestCase):
         # Should have f-string with format spec
         self.assertIn("f'", result)
         self.assertIn(":04d", result)
+        # Safety wrapper must be present
+        self.assertIn("try:", result)
+        self.assertIn("except Exception:", result)
 
     def test_injects_fstring_with_float_format(self):
         """Test f-string with float format spec injection."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = 3.14
@@ -1369,9 +1405,15 @@ class TestStringInterpolationMutator(unittest.TestCase):
         # Should have f-string with float formatting
         self.assertIn("f'", result)
         self.assertIn(":.2f", result)
+        # Safety wrapper must be present
+        self.assertIn("try:", result)
+        self.assertIn("except Exception:", result)
 
     def test_creates_variables_when_none_exist(self):
         """Test that variables are created when none exist."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 pass
@@ -1425,6 +1467,9 @@ class TestStringInterpolationMutator(unittest.TestCase):
     @unittest.skipIf(sys.version_info < (3, 14), "t-strings require Python 3.14+")
     def test_injects_tstring(self):
         """Test t-string template injection (Python 3.14+)."""
+        # NOTE: side_effect sequence is coupled to internal random call order.
+        # If this breaks after a refactor, update the sequence or rely on
+        # test_produces_valid_code for behavioral coverage.
         code = dedent("""
             def uop_harness_test():
                 x = 42

--- a/tests/mutators/test_utils.py
+++ b/tests/mutators/test_utils.py
@@ -44,6 +44,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genStatefulLenObject(self):
         """Test stateful len object generation."""
@@ -55,6 +57,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genUnstableHashObject(self):
         """Test unstable hash object generation."""
@@ -66,6 +70,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genSimpleObject(self):
         """Test simple object generation."""
@@ -74,6 +80,12 @@ class TestEvilObjectGenerators(unittest.TestCase):
         self.assertIn("self.x = 1", code)
         self.assertIn("self.y = 'y'", code)
         self.assertIn("def get_value", code)
+
+        # Test it's valid Python
+        tree = ast.parse(code)
+        self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genStatefulStrReprObject(self):
         """Test stateful str/repr object generation."""
@@ -87,6 +99,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genStatefulGetitemObject(self):
         """Test stateful getitem object generation."""
@@ -100,6 +114,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genStatefulGetattrObject(self):
         """Test stateful getattr object generation."""
@@ -113,6 +129,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genStatefulBoolObject(self):
         """Test stateful bool object generation."""
@@ -126,6 +144,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genStatefulIterObject(self):
         """Test stateful iter object generation."""
@@ -139,6 +159,8 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
 
     def test_genStatefulIndexObject(self):
         """Test stateful index object generation."""
@@ -152,6 +174,33 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Test it's valid Python
         tree = ast.parse(code)
         self.assertIsInstance(tree, ast.Module)
+        # Verify it actually runs — catches runtime issues ast.parse misses
+        exec(code, {})
+
+    def test_all_evil_objects_are_executable(self):
+        """Verify every evil object generator produces code that runs cleanly."""
+        generators = [
+            (genLyingEqualityObject, "obj_eq"),
+            (genStatefulLenObject, "obj_len"),
+            (genUnstableHashObject, "obj_hash"),
+            (genSimpleObject, "obj_simple"),
+            (genStatefulStrReprObject, "obj_str"),
+            (genStatefulGetitemObject, "obj_getitem"),
+            (genStatefulGetattrObject, "obj_getattr"),
+            (genStatefulBoolObject, "obj_bool"),
+            (genStatefulIterObject, "obj_iter"),
+            (genStatefulIndexObject, "obj_index"),
+        ]
+        for gen_func, var_name in generators:
+            with self.subTest(generator=gen_func.__name__):
+                code = gen_func(var_name)
+                # Must parse
+                ast.parse(code)
+                # Must execute and instantiate
+                namespace = {}
+                exec(code, namespace)
+                # Variable should exist in namespace after exec
+                self.assertIn(var_name, namespace)
 
 
 class TestFuzzerSetupNormalizer(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `exec()` verification to all 10 evil object generator tests, catching runtime issues that `ast.parse()` alone misses
- Add comprehensive `test_all_evil_objects_are_executable` with subtests as a safety net for future generators
- Assert `try/except` safety wrappers exist in `SliceMutator` and `StringInterpolationMutator` tests
- Add brittleness comments to 12 tests with rigid `side_effect` sequences

Closes #688

## Test plan
- [x] All 175 tests in test_utils.py + test_generic.py pass (plus 10 subtests)
- [x] Full suite: 1768 passed, 78 subtests passed
- [x] ruff format/check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)