### PR TITLE
test: add compile() validation to mutator test_produces_valid_code methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project should be documented in this file.
 - CLI argument plumbing tests verifying that all CLI options are correctly threaded through to their respective manager classes, by @devdanzin.
 - A directory column in the campaign instance leaderboard for identifying instance paths, by @devdanzin.
 - Strengthened mutator test assertions: `exec()` verification for all evil object generators, safety wrapper assertions for `SliceMutator` and `StringInterpolationMutator`, and brittleness comments on tests with rigid `side_effect` sequences, by @devdanzin.
+- Added `compile(result, "<test>", "exec")` validation to 93 test methods across all mutator test files, catching scope violations (`return`/`yield` outside function, `break`/`continue` outside loop, `nonlocal` misuse) that `ast.parse()` alone misses, by @devdanzin.
 
 
 ### Enhanced

--- a/tests/mutators/test_engine.py
+++ b/tests/mutators/test_engine.py
@@ -215,6 +215,7 @@ class TestASTMutator(unittest.TestCase):
         # Should produce valid code
         tree = ast.parse(result)
         self.assertIsInstance(tree, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_seed_determinism(self):
         """Test that using the same seed produces identical results."""
@@ -290,6 +291,7 @@ class TestASTMutator(unittest.TestCase):
                 try:
                     tree = ast.parse(result)
                     self.assertIsInstance(tree, ast.Module)
+                    compile(result, "<test>", "exec")
                 except SyntaxError as e:
                     self.fail(f"Mutated code failed to parse: {result}\nError: {e}")
 
@@ -662,6 +664,7 @@ class TestSlicingMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_exactly_100_statements(self):
         """Test edge case with exactly 100 statements."""
@@ -696,6 +699,7 @@ class TestSlicingMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_random_slice_selection(self):
         """Test that random slice selection works correctly."""

--- a/tests/mutators/test_generic.py
+++ b/tests/mutators/test_generic.py
@@ -132,6 +132,7 @@ class TestBoundaryValuesMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestLiteralTypeSwapMutator(unittest.TestCase):
@@ -282,6 +283,7 @@ class TestLiteralTypeSwapMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_literal_swap_fstring_safety(self):
         """
@@ -308,6 +310,7 @@ class TestLiteralTypeSwapMutator(unittest.TestCase):
         # Verify it's still valid Python
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
         # Verify the f-string literal parts are still strings (not bytes)
         # The literal parts "Value: " and ".2f" should remain as strings
@@ -344,6 +347,7 @@ class TestLiteralTypeSwapMutator(unittest.TestCase):
         # Verify it's still valid Python
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
         # Verify the t-string literal parts are still strings (not bytes)
         # The literal parts "Hello " and " World" should remain as strings
@@ -510,6 +514,7 @@ class TestImportChaosMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_handles_empty_module(self):
         """Test handling of module with no statements."""
@@ -650,6 +655,7 @@ class TestBlockTransposerMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_preserves_all_statements(self):
         """Test that all original statements are preserved after transposition."""
@@ -738,6 +744,7 @@ class TestUnpackingMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_creates_valid_unpacking_target(self):
         """Test that the unpacking target has valid structure."""
@@ -848,6 +855,7 @@ class TestNewUnpackingMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestDecoratorMutator(unittest.TestCase):
@@ -944,6 +952,7 @@ class TestDecoratorMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestSliceMutator(unittest.TestCase):
@@ -1121,6 +1130,7 @@ class TestSliceMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestPatternMatchingMutator(unittest.TestCase):
@@ -1232,6 +1242,7 @@ class TestPatternMatchingMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestArithmeticSpamMutator(unittest.TestCase):
@@ -1351,6 +1362,7 @@ class TestArithmeticSpamMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestStringInterpolationMutator(unittest.TestCase):
@@ -1463,6 +1475,7 @@ class TestStringInterpolationMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     @unittest.skipIf(sys.version_info < (3, 14), "t-strings require Python 3.14+")
     def test_injects_tstring(self):
@@ -1560,6 +1573,7 @@ class TestExceptionGroupMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_creates_nested_exception_groups(self):
         """Test that nested ExceptionGroups are created."""
@@ -1671,6 +1685,7 @@ class TestAsyncConstructMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_creates_coroutine_driver(self):
         """Test that coroutine driver code is created."""
@@ -1801,6 +1816,7 @@ class TestSysMonitoringMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_creates_monitored_gymnasium_function(self):
         """Test that a monitored 'gymnasium' function is created."""

--- a/tests/mutators/test_helper_injection.py
+++ b/tests/mutators/test_helper_injection.py
@@ -147,6 +147,7 @@ class TestHelperFunctionInjector(unittest.TestCase):
         self.assertIn("_helper_result", result)
         # Code should be valid Python
         ast.parse(result)
+        compile(result, "<test>", "exec")
 
     def test_probability_controls_injection(self):
         """Test that probability parameter controls whether mutation is applied."""

--- a/tests/mutators/test_scenarios_control.py
+++ b/tests/mutators/test_scenarios_control.py
@@ -213,6 +213,7 @@ class TestRecursionWrappingMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_skips_functions_with_too_few_statements(self):
         """Test that functions with < 5 statements are not mutated."""
@@ -302,6 +303,7 @@ class TestRecursionWrappingMutator(unittest.TestCase):
         self.assertIn("except Exception", result)
         # Verify the code is valid Python
         ast.parse(result)
+        compile(result, "<test>", "exec")
 
     def test_no_remainder_wrapper_when_block_at_end(self):
         """Test that no remainder wrapper is added when the block is at the end."""
@@ -496,6 +498,7 @@ class TestExceptionHandlerMaze(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_class_names(self):
         """Test that unique class names are generated."""
@@ -554,6 +557,7 @@ class TestExceptionHandlerMaze(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestCoroutineStateCorruptor(unittest.TestCase):
@@ -755,6 +759,7 @@ class TestCoroutineStateCorruptor(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_function_names(self):
         """Test that unique function names are generated."""
@@ -813,6 +818,7 @@ class TestCoroutineStateCorruptor(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestStressPatternMutators(unittest.TestCase):
@@ -1188,6 +1194,7 @@ class TestContextManagerInjector(unittest.TestCase):
         # Should be valid Python
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestYieldFromInjector(unittest.TestCase):
@@ -1334,6 +1341,7 @@ class TestYieldFromInjector(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_produces_valid_code_recursive(self):
         """Test that recursive generator produces valid, parseable Python."""
@@ -1353,6 +1361,7 @@ class TestYieldFromInjector(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_naming(self):
         """Test that generated names use unique suffixes."""
@@ -1522,6 +1531,7 @@ class TestMaxOperandMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestExitStresser(unittest.TestCase):
@@ -1549,6 +1559,7 @@ class TestExitStresser(unittest.TestCase):
         self.assertIn("res_es_5", result)
         # Check that it produces valid python
         ast.parse(result)
+        compile(result, "<test>", "exec")
 
 
 class TestPatternMatchingChaosMutator(unittest.TestCase):
@@ -1781,6 +1792,7 @@ class TestPatternMatchingChaosMutator(unittest.TestCase):
         # Should NOT reference the undefined _chaos_side_effect
         self.assertNotIn("_chaos_side_effect", result)
         ast.parse(result)  # Ensure valid
+        compile(result, "<test>", "exec")
 
     def test_transforms_existing_match_with_nested(self):
         """Test that existing match statements get nested match."""
@@ -1858,6 +1870,7 @@ class TestPatternMatchingChaosMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_skips_existing_helper_class(self):
         """Test that helper is not re-injected if already present."""

--- a/tests/mutators/test_scenarios_data.py
+++ b/tests/mutators/test_scenarios_data.py
@@ -205,6 +205,7 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_preserves_original_function_body(self):
         """Test that original function statements are preserved."""
@@ -242,6 +243,7 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_variable_names(self):
         """Test that unique variable names are generated."""
@@ -326,6 +328,7 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_enhanced_attack_builtins_type_toggle(self):
         """Test that builtins_type_toggle attack is injected correctly."""
@@ -356,6 +359,7 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_enhanced_attack_highfreq_builtin_corruption(self):
         """Test that highfreq_builtin_corruption attack is injected correctly."""
@@ -388,6 +392,7 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_enhanced_attack_restores_builtins(self):
         """Test that enhanced attacks restore builtins in finally block."""
@@ -614,6 +619,7 @@ class TestComprehensionBomb(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_class_and_variable_names(self):
         """Test that unique names are generated for class and variables."""
@@ -670,6 +676,7 @@ class TestComprehensionBomb(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_injects_at_random_position(self):
         """Test that injection occurs at random position in function body."""
@@ -1269,6 +1276,7 @@ class TestLatticeSurfingMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestBloomFilterSaturator(unittest.TestCase):
@@ -1418,6 +1426,7 @@ class TestBloomFilterSaturator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_has_enhanced_attacks_list(self):
         """Test that ENHANCED_ATTACKS list is defined."""
@@ -1463,6 +1472,7 @@ class TestBloomFilterSaturator(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_enhanced_attack_strategic_global_mod(self):
         """Test that strategic_global_mod attack is injected correctly."""
@@ -1494,6 +1504,7 @@ class TestBloomFilterSaturator(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_enhanced_attack_multi_phase(self):
         """Test that multi_phase_attack is injected correctly."""
@@ -1526,6 +1537,7 @@ class TestBloomFilterSaturator(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_enhanced_attacks_produce_valid_code(self):
         """Test that all enhanced attack types produce valid, parseable code."""
@@ -1733,6 +1745,7 @@ class TestStackCacheThrasher(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestBoundaryComparisonMutator(unittest.TestCase):
@@ -1880,6 +1893,7 @@ class TestBoundaryComparisonMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestAbstractInterpreterConfusionMutator(unittest.TestCase):
@@ -2027,6 +2041,7 @@ class TestAbstractInterpreterConfusionMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestGlobalOptimizationInvalidator(unittest.TestCase):
@@ -2178,6 +2193,7 @@ class TestGlobalOptimizationInvalidator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestCodeObjectHotSwapper(unittest.TestCase):
@@ -2325,6 +2341,7 @@ class TestCodeObjectHotSwapper(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestTypeShadowingMutator(unittest.TestCase):
@@ -2490,6 +2507,7 @@ class TestTypeShadowingMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestZombieTraceMutator(unittest.TestCase):
@@ -2652,6 +2670,7 @@ class TestZombieTraceMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestUnpackingChaosMutator(unittest.TestCase):
@@ -2896,6 +2915,7 @@ class TestUnpackingChaosMutator(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_mode_and_trigger_are_configurable(self):
         """Test that mode and trigger_count are passed to the wrapper."""
@@ -3017,6 +3037,7 @@ class TestConstantNarrowingPoisonMutator(unittest.TestCase):
                             mutated = mutator.visit(tree)
                 result = ast.unparse(mutated)
                 ast.parse(result)
+                compile(result, "<test>", "exec")
 
     def test_skips_non_harness(self):
         code = dedent("""
@@ -3110,6 +3131,7 @@ class TestStarCallMutator(unittest.TestCase):
                             mutated = mutator.visit(tree)
                 result = ast.unparse(mutated)
                 ast.parse(result)
+                compile(result, "<test>", "exec")
 
     def test_skips_non_harness(self):
         code = dedent("""
@@ -3201,6 +3223,7 @@ class TestSliceObjectChaosMutator(unittest.TestCase):
                             mutated = mutator.visit(tree)
                 result = ast.unparse(mutated)
                 ast.parse(result)
+                compile(result, "<test>", "exec")
 
     def test_skips_non_harness(self):
         code = dedent("""

--- a/tests/mutators/test_scenarios_runtime.py
+++ b/tests/mutators/test_scenarios_runtime.py
@@ -462,6 +462,7 @@ class TestFrameManipulator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_function_names(self):
         """Test that unique function names are generated."""
@@ -729,6 +730,7 @@ class TestWeakRefCallbackChaos(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_variable_and_class_names(self):
         """Test that unique names are generated."""
@@ -786,6 +788,7 @@ class TestWeakRefCallbackChaos(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_callback_uses_lambda_wrapper(self):
         """Test that callback is wrapped in lambda for var_name closure."""
@@ -869,6 +872,7 @@ class TestClosureStompMutator(unittest.TestCase):
 
         result = ast.unparse(mutated)
         ast.parse(result)  # Should not raise SyntaxError
+        compile(result, "<test>", "exec")
 
     def test_closure_stomp_multiple_functions(self):
         """Test injection for multiple functions."""
@@ -1133,6 +1137,7 @@ class TestEvalFrameHookMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_prefixes(self):
         """Test that unique prefixes are generated."""
@@ -1187,6 +1192,7 @@ class TestEvalFrameHookMutator(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_different_attack_types(self):
         """Test that all three attack types can be generated."""
@@ -1266,6 +1272,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_single_event_set_bases(self):
         """Test single event attack: set_bases."""
@@ -1291,6 +1298,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_single_event_set_eval_frame(self):
         """Test single event attack: set_eval_frame."""
@@ -1315,6 +1323,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_single_event_builtin_dict(self):
         """Test single event attack: builtin_dict."""
@@ -1339,6 +1348,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_single_event_func_modification(self):
         """Test single event attack: func_modification."""
@@ -1363,6 +1373,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_combination_attack(self):
         """Test combination attack with multiple events."""
@@ -1389,6 +1400,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_combination_attack_three_events(self):
         """Test combination attack with three events."""
@@ -1415,6 +1427,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # Verify code is valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_no_mutation_when_random_fails(self):
         """Test that no mutation occurs when random check fails."""
@@ -1549,6 +1562,7 @@ class TestRareEventStressTester(unittest.TestCase):
         self.assertIn("_cleanup_key_rarestress_4444", result)
         # Verify code is valid
         ast.parse(result)
+        compile(result, "<test>", "exec")
 
     def test_combination_no_unnecessary_cleanup(self):
         """Test that combinations without persistent events skip cleanup."""
@@ -1571,6 +1585,7 @@ class TestRareEventStressTester(unittest.TestCase):
         # (it may appear inside event code, but not as a standalone cleanup)
         # Verify code is valid
         ast.parse(result)
+        compile(result, "<test>", "exec")
 
 
 class TestRefcountEscapeHatchMutator(unittest.TestCase):

--- a/tests/mutators/test_scenarios_types.py
+++ b/tests/mutators/test_scenarios_types.py
@@ -482,6 +482,7 @@ class TestDescriptorChaosGenerator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_class_names(self):
         """Test that unique class names are generated."""
@@ -538,6 +539,7 @@ class TestDescriptorChaosGenerator(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestMROShuffler(unittest.TestCase):
@@ -721,6 +723,7 @@ class TestMROShuffler(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_class_names(self):
         """Test that unique class names are generated."""
@@ -778,6 +781,7 @@ class TestMROShuffler(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestSuperResolutionAttacker(unittest.TestCase):
@@ -949,6 +953,7 @@ class TestSuperResolutionAttacker(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_class_names(self):
         """Test that unique class names are generated."""
@@ -1005,6 +1010,7 @@ class TestSuperResolutionAttacker(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestCodeObjectSwapper(unittest.TestCase):
@@ -1156,6 +1162,7 @@ class TestCodeObjectSwapper(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_function_names(self):
         """Test that unique function names are generated."""
@@ -1212,6 +1219,7 @@ class TestCodeObjectSwapper(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 class TestComprehensiveFunctionMutator(unittest.TestCase):
@@ -1413,6 +1421,7 @@ class TestComprehensiveFunctionMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_prefixes(self):
         """Test that unique prefixes are generated."""
@@ -1467,6 +1476,7 @@ class TestComprehensiveFunctionMutator(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_all_attack_types(self):
         """Test that all attack types can be generated."""
@@ -1736,6 +1746,7 @@ class TestDynamicClassSwapper(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_prefixes(self):
         """Test that unique prefixes are generated."""
@@ -1790,6 +1801,7 @@ class TestDynamicClassSwapper(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_all_attack_types(self):
         """Test that all attack types can be generated."""
@@ -2021,6 +2033,7 @@ class TestBasesRewriteMutator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_prefixes(self):
         """Test that unique prefixes are generated."""
@@ -2075,6 +2088,7 @@ class TestBasesRewriteMutator(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_all_attack_types(self):
         """Test that all attack types can be generated."""
@@ -2339,6 +2353,7 @@ class TestTypeVersionInvalidator(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_unique_prefixes(self):
         """Test that unique prefixes are generated."""
@@ -2393,6 +2408,7 @@ class TestTypeVersionInvalidator(unittest.TestCase):
         # Should still be valid
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_all_attack_types(self):
         """Test that all attack types can be generated."""
@@ -2525,6 +2541,7 @@ class TestInlinedFrameCorruptionMutator(unittest.TestCase):
                             mutated = mutator.visit(tree)
                 result = ast.unparse(mutated)
                 ast.parse(result)
+                compile(result, "<test>", "exec")
 
     def test_skips_non_harness(self):
         code = dedent("""

--- a/tests/mutators/test_sniper.py
+++ b/tests/mutators/test_sniper.py
@@ -137,6 +137,7 @@ class TestSniperMutator(unittest.TestCase):
         generated = ast.unparse(mutated)
         # Must be parseable
         ast.parse(generated)
+        compile(generated, "<test>", "exec")
 
 
 if __name__ == "__main__":

--- a/tests/mutators/test_utils.py
+++ b/tests/mutators/test_utils.py
@@ -434,6 +434,7 @@ class TestHarnessInstrumentor(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_produces_valid_code(self):
         """Test that output is valid, parseable Python."""
@@ -457,6 +458,7 @@ class TestHarnessInstrumentor(unittest.TestCase):
         result = ast.unparse(mutated)
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
     def test_handles_multiple_harness_functions(self):
         """Test handling of multiple harness functions."""
@@ -794,6 +796,7 @@ class TestRedundantStatementSanitizer(unittest.TestCase):
         # Should be parseable
         reparsed = ast.parse(result)
         self.assertIsInstance(reparsed, ast.Module)
+        compile(result, "<test>", "exec")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `compile(result, "<test>", "exec")` after `ast.parse()` in 93 test methods across all 9 mutator test files
- Catches scope violations (`return`/`yield` outside function, `break`/`continue` outside loop, `nonlocal` misuse) that `ast.parse()` alone misses
- Covers three pattern categories: standard `reparsed` pattern, `tree` variant in test_engine.py, and standalone `ast.parse()` validity checks

Closes #690

## Test plan
- [x] All 727 mutator tests pass (plus 78 subtests) — no false positives from compile()
- [x] ruff check clean across all mutator test files
- [x] Verified compile() added consistently: 16 in test_generic, 17 in test_scenarios_types, 23 in test_scenarios_data, 13 in test_scenarios_control, 15 in test_scenarios_runtime, 4 in test_engine, 3 in test_utils, 1 in test_helper_injection, 1 in test_sniper

🤖 Generated with [Claude Code](https://claude.com/claude-code)