### PR TITLE
test: strengthen env variable assertions in verify_target_capabilities test

### DIFF
--- a/tests/orchestrator/test_execution.py
+++ b/tests/orchestrator/test_execution.py
@@ -726,6 +726,11 @@ class TestVerifyTargetCapabilities(unittest.TestCase):
                 # Check environment variables
                 call_kwargs = mock_run.call_args[1]
                 self.assertIn("env", call_kwargs)
+                env = call_kwargs["env"]
+                self.assertEqual(env["PYTHON_JIT"], "1")
+                self.assertEqual(env["PYTHON_LLTRACE"], "2")
+                self.assertEqual(env["PYTHON_OPT_DEBUG"], "4")
+                self.assertEqual(env["ASAN_OPTIONS"], "detect_leaks=0")
 
 
 class TestMakeDivergenceResult(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Validate actual `FUZZING_ENV` values (`PYTHON_JIT=1`, `PYTHON_LLTRACE=2`, `PYTHON_OPT_DEBUG=4`, `ASAN_OPTIONS=detect_leaks=0`) in `test_uses_correct_environment` instead of only asserting the `env` dict exists
- Scanned for other weak `assertIn("env", ...)` patterns in the file — none found

## Test plan
- [x] All 55 tests in `tests/orchestrator/test_execution.py` pass
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)