### PR TITLE
feat: add diagnostic bounded-run CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project should be documented in this file.
 
 ### Added
 
+- Diagnostic bounded-run CLI options: `--max-sessions`, `--max-mutations-per-session`, `--seed`, and `--workdir` for reproducible smoke tests and CI verification, by @devdanzin.
 - GitHub Actions CI/CD workflow with lint, format, and JIT test jobs, by @devdanzin.
 - An `UnpackingChaosMutator` that attacks JIT optimizations for `UNPACK_SEQUENCE` and `UNPACK_EX` by wrapping iterables in a chaotic iterator that lies about its length and changes behavior (grow, shrink, type_switch) after JIT warmup to trigger deoptimization bugs, by @devdanzin.
 - A `PatternMatchingChaosMutator` that attacks JIT optimizations for structural pattern matching (`MATCH_MAPPING`, `MATCH_SEQUENCE`, `MATCH_CLASS`) by injecting classes with dynamic `__match_args__`, guards with side effects, type-switching subjects, walrus operators in guards, and converting `isinstance` checks and for-loop unpacking to match statements, by @devdanzin.

--- a/lafleur/metadata.py
+++ b/lafleur/metadata.py
@@ -428,7 +428,13 @@ def generate_run_metadata(output_dir: Path, args: argparse.Namespace) -> dict:
         },
     }
 
-    # Save metadata to file
+    metadata["max_sessions"] = getattr(args, "max_sessions", None)
+    metadata["max_mutations_per_session"] = getattr(args, "max_mutations_per_session", None)
+    metadata["global_seed"] = getattr(args, "seed", None)
+    metadata["workdir"] = (
+        str(getattr(args, "workdir", None)) if getattr(args, "workdir", None) else None
+    )
+
     with open(metadata_path, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=2, default=str)
 


### PR DESCRIPTION
## Summary
- Add `--max-sessions` to stop after N fuzzing sessions
- Add `--max-mutations-per-session` to override dynamic mutation count calculation
- Add `--seed` for global random seed (reproducible corpus selection)
- Add `--workdir` to redirect all outputs to a specified directory
- Diagnostic settings recorded in run_metadata.json

Closes #702

## Test plan
- [x] CLI plumbing tests for all 4 new flags
- [x] `run_evolutionary_loop` stops after `max_sessions` limit
- [x] `max_sessions=None` runs indefinitely (no regression)
- [x] `max_mutations_per_session` overrides dynamic calculation
- [x] Integration tests for bounded runs
- [x] All 1795 existing tests pass
- [x] ruff check/format clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)