### PR TITLE
feat: add diagnostic introspection CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project should be documented in this file.
 
 ### Added
 
+- Diagnostic introspection CLI options: `--keep-children` to retain all generated scripts, `--dry-run` for mutation-only mode, and `--list-mutators` to discover available mutators, by @devdanzin.
 - Diagnostic bounded-run CLI options: `--max-sessions`, `--max-mutations-per-session`, `--seed`, and `--workdir` for reproducible smoke tests and CI verification, by @devdanzin.
 - GitHub Actions CI/CD workflow with lint, format, and JIT test jobs, by @devdanzin.
 - An `UnpackingChaosMutator` that attacks JIT optimizations for `UNPACK_SEQUENCE` and `UNPACK_EX` by wrapping iterables in a chaotic iterator that lies about its length and changes behavior (grow, shrink, type_switch) after JIT warmup to trigger deoptimization bugs, by @devdanzin.

--- a/lafleur/metadata.py
+++ b/lafleur/metadata.py
@@ -434,6 +434,8 @@ def generate_run_metadata(output_dir: Path, args: argparse.Namespace) -> dict:
     metadata["workdir"] = (
         str(getattr(args, "workdir", None)) if getattr(args, "workdir", None) else None
     )
+    metadata["keep_children"] = getattr(args, "keep_children", False)
+    metadata["dry_run"] = getattr(args, "dry_run", False)
 
     with open(metadata_path, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=2, default=str)

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -410,5 +410,26 @@ class TestMinimizeMain(unittest.TestCase):
                 self.assertTrue(args[0][2])  # force_overwrite is third arg
 
 
+class TestListMutatorsFlag(unittest.TestCase):
+    """Test --list-mutators prints mutator list and exits."""
+
+    def test_list_mutators_prints_and_exits(self):
+        """--list-mutators prints all mutators and exits with code 0."""
+        with patch("sys.argv", ["lafleur", "--list-mutators"]):
+            from lafleur.orchestrator import main
+
+            captured = StringIO()
+            with patch("sys.stdout", captured):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
+
+            self.assertEqual(ctx.exception.code, 0)
+            output = captured.getvalue()
+            self.assertIn("OperatorSwapper", output)
+            self.assertIn("GCInjector", output)
+            self.assertIn("TypeInstabilityInjector", output)
+            self.assertIn("total", output)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `--keep-children` to retain all generated child scripts in `tmp_fuzz_run/` for inspection
- Add `--dry-run` for mutation-only mode (generates children but skips subprocess execution); implies `--keep-children`
- Add `--list-mutators` to print all available mutators with descriptions and exit
- Record `keep_children` and `dry_run` settings in run_metadata.json

Closes #704

## Test plan
- [x] CLI plumbing tests for `--keep-children`, `--dry-run`, and `--dry-run` implying `--keep-children`
- [x] Dry-run mode does not call `execute_child`
- [x] Dry-run mode writes child files to disk with `_dryrun` suffix
- [x] `--list-mutators` prints mutator names and exits with code 0
- [x] All existing test setups updated with `keep_children`/`dry_run` attributes
- [x] All 1803 tests pass
- [x] ruff check/format clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)