### PR TITLE
feat: add targeted testing CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project should be documented in this file.
 
 ### Added
 
+- Targeted testing CLI options: `--mutators` to filter the mutator pool and `--strategy` to force a specific mutation strategy, by @devdanzin.
 - Diagnostic introspection CLI options: `--keep-children` to retain all generated scripts, `--dry-run` for mutation-only mode, and `--list-mutators` to discover available mutators, by @devdanzin.
 - Diagnostic bounded-run CLI options: `--max-sessions`, `--max-mutations-per-session`, `--seed`, and `--workdir` for reproducible smoke tests and CI verification, by @devdanzin.
 - GitHub Actions CI/CD workflow with lint, format, and JIT test jobs, by @devdanzin.

--- a/lafleur/metadata.py
+++ b/lafleur/metadata.py
@@ -436,6 +436,8 @@ def generate_run_metadata(output_dir: Path, args: argparse.Namespace) -> dict:
     )
     metadata["keep_children"] = getattr(args, "keep_children", False)
     metadata["dry_run"] = getattr(args, "dry_run", False)
+    metadata["mutator_filter"] = getattr(args, "mutators", None)
+    metadata["forced_strategy"] = getattr(args, "strategy", None)
 
     with open(metadata_path, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=2, default=str)

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -2168,6 +2168,30 @@ class TestMainCLIPlumbing(unittest.TestCase):
         _, kwargs = self._run_main(["--fusil-path", "/fake", "--dry-run"])
         self.assertTrue(kwargs["keep_children"])
 
+    # --- Targeted testing flags ---
+
+    def test_mutators_default_none(self):
+        """--mutators defaults to None (no filtering)."""
+        _, kwargs = self._run_main(["--fusil-path", "/fake"])
+        self.assertIsNone(kwargs["mutator_filter"])
+
+    def test_mutators_passed_as_list(self):
+        """--mutators value is parsed into a list and reaches constructor."""
+        _, kwargs = self._run_main(
+            ["--fusil-path", "/fake", "--mutators", "OperatorSwapper,GCInjector"]
+        )
+        self.assertEqual(kwargs["mutator_filter"], ["OperatorSwapper", "GCInjector"])
+
+    def test_strategy_default_none(self):
+        """--strategy defaults to None."""
+        _, kwargs = self._run_main(["--fusil-path", "/fake"])
+        self.assertIsNone(kwargs["forced_strategy"])
+
+    def test_strategy_custom(self):
+        """--strategy value reaches constructor."""
+        _, kwargs = self._run_main(["--fusil-path", "/fake", "--strategy", "spam"])
+        self.assertEqual(kwargs["forced_strategy"], "spam")
+
     # --- Value flags ---
 
     def test_fusil_path_passed(self):
@@ -2284,6 +2308,10 @@ class TestMainCLIPlumbing(unittest.TestCase):
                 "5",
                 "--keep-children",
                 "--dry-run",
+                "--mutators",
+                "OperatorSwapper,GCInjector",
+                "--strategy",
+                "spam",
             ]
         )
         self.assertEqual(kwargs["fusil_path"], "/my/fusil")
@@ -2304,6 +2332,8 @@ class TestMainCLIPlumbing(unittest.TestCase):
         self.assertEqual(kwargs["max_mutations_per_session"], 5)
         self.assertTrue(kwargs["keep_children"])
         self.assertTrue(kwargs["dry_run"])
+        self.assertEqual(kwargs["mutator_filter"], ["OperatorSwapper", "GCInjector"])
+        self.assertEqual(kwargs["forced_strategy"], "spam")
 
     # --- run_stats deep copy ---
 


### PR DESCRIPTION
## Summary
- Add `--mutators` to filter the mutator pool to specific transformer class names (comma-separated)
- Add `--strategy` to force a specific mutation strategy (deterministic, havoc, spam, sniper, helper_sniper), bypassing adaptive selection
- Unknown mutator names raise `ValueError` at construction time with helpful error message
- Forced strategy still records attempts for score tracking
- Record `mutator_filter` and `forced_strategy` in run_metadata.json

Closes #706

## Test plan
- [x] CLI plumbing tests for `--mutators` and `--strategy` (defaults and custom values)
- [x] `test_all_flags_combined` updated with both new flags
- [x] Forced strategy bypasses `RANDOM.choices` (havoc, spam, deterministic tested)
- [x] Forced strategy still records attempt
- [x] `forced_strategy=None` falls through to normal adaptive selection
- [x] Mutator pool filtering: single, multiple, and filtered-still-works tests
- [x] Integration: unknown mutator raises ValueError, valid filter accepted
- [x] All 1816 tests pass
- [x] ruff check/format clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)