### PR TITLE
fix: driver stats serialization safety and log parser false matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- `parse_jit_stats()` matched Python traceback source lines containing `[DRIVER:STATS]` as a substring, producing false parse warnings. Now filters out lines with leading whitespace (traceback source is always indented), by @devdanzin.
+- `driver.py` had no safety wrapper around `json.dumps(stats)` — if `get_jit_stats()` returned non-serializable values (ctypes pointers, etc.), the success path fell into the exception handler, silently reclassifying successful runs as errors and losing all JIT statistics, by @devdanzin.
 - TeeLogger verbosity filtering leaving blank lines where suppressed lines were: `print()` sends two writes (content + `"\n"`) and the trailing newline was passing through after the content was suppressed, by @devdanzin.
 - TeeLogger verbosity filtering missing suppression prefixes for `Mutating`, `Transposing`, `Normalizing`, `Sanitizing`, `Decorating`, `Variable`, `Failed`, `SyntaxError`, `Targeting` mutator verbs, `    [!] SyntaxError` mutator warnings, and `[NEW RELATIVE RARE_EVENT]` coverage lines, by @devdanzin.
 - Filter SyntaxError/IndentationError crashes from invalid mutations, by @devdanzin.

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -367,7 +367,7 @@ class ScoringManager:
         watched_dependencies: set[str] = set()
 
         for line in log_content.splitlines():
-            if "[DRIVER:STATS]" in line:
+            if "[DRIVER:STATS]" in line and line[:1] not in (" ", "\t"):
                 try:
                     json_str = line.split("[DRIVER:STATS]", 1)[1].strip()
                     stats = json.loads(json_str)
@@ -417,7 +417,7 @@ class ScoringManager:
                         f"Line content: {line[:200]}",
                         file=sys.stderr,
                     )
-            elif line.startswith("[EKG] WATCHED:"):
+            elif "[EKG] WATCHED:" in line and line[:1] not in (" ", "\t"):
                 try:
                     variables = line.split("[EKG] WATCHED:", 1)[1].strip()
                     if variables:


### PR DESCRIPTION
## Summary
- Add `_emit_stats()` safety wrapper in `driver.py` that catches `json.dumps()` failures (ctypes pointers, non-serializable values) and emits sanitized fallback JSON with `_serialization_fallback` flag, preventing successful runs from being silently reclassified as errors
- Fix `parse_jit_stats()` in `scoring.py` to filter out indented lines (traceback source) that false-match the `[DRIVER:STATS]` and `[EKG] WATCHED:` markers
- Replace all 5 bare `print(f"[DRIVER:STATS] {json.dumps(...)}")` call sites with `_emit_stats()` calls
- Update `[EKG] WATCHED:` matching from `startswith` to substring match with leading-whitespace filter for consistency

## Test plan
- [x] `TestEmitStats` (5 tests): normal dict, ctypes fallback, NaN passthrough, empty dict, mixed values
- [x] `TestRunSessionSerializationFailure` (1 test): end-to-end with non-serializable get_jit_stats return
- [x] `TestJITParsing` new tests (6 tests): indented stats/EKG lines skipped, interleaved lines parsed, fallback stats parsed
- [x] Updated `test_parse_jit_stats_malformed_json` for new indentation filter
- [x] Full test suite passes (1839 tests)
- [x] Zero remaining bare `print.*DRIVER:STATS` in driver.py (only inside `_emit_stats`)

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)