### PR TITLE
refactor: TypedDict for jit_stats and mutation_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project should be documented in this file.
 - A directory column in the campaign instance leaderboard for identifying instance paths, by @devdanzin.
 - Strengthened mutator test assertions: `exec()` verification for all evil object generators, safety wrapper assertions for `SliceMutator` and `StringInterpolationMutator`, and brittleness comments on tests with rigid `side_effect` sequences, by @devdanzin.
 - Added `compile(result, "<test>", "exec")` validation to 93 test methods across all mutator test files, catching scope violations (`return`/`yield` outside function, `break`/`continue` outside loop, `nonlocal` misuse) that `ast.parse()` alone misses, by @devdanzin.
+- `JitStats` and `MutationInfo` TypedDicts in `lafleur/types.py` for structural typing of the two most widely shared dict schemas, enabling mypy to catch key typos and missing fields across scoring, orchestrator, corpus manager, mutation controller, and corpus analysis modules, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -6,6 +6,8 @@ This module provides:
 - TelemetryManager: run statistics persistence and time-series logging
 """
 
+from __future__ import annotations
+
 import difflib
 import json
 import random
@@ -31,6 +33,7 @@ if TYPE_CHECKING:
     from lafleur.coverage import CoverageManager
     from lafleur.health import HealthMonitor
     from lafleur.learning import MutatorScoreTracker
+    from lafleur.types import MutationInfo
 
 # Log processing constants
 TIMEOUT_LOG_COMPRESSION_THRESHOLD = 1_048_576  # 1 MB
@@ -472,7 +475,7 @@ class ArtifactManager:
         session_files: list[Path] | None = None,
         *,
         parent_id: str | None = None,
-        mutation_info: dict | None = None,
+        mutation_info: MutationInfo | None = None,
     ) -> bool:
         """
         Check for crashes, determine the cause (Signal/Retcode/Keyword), and save artifacts.

--- a/lafleur/corpus_analysis.py
+++ b/lafleur/corpus_analysis.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from lafleur.corpus_manager import CorpusManager
+    from lafleur.types import MutationInfo
 
 
 def calculate_distribution(values: Sequence[int | float]) -> dict[str, float | None]:
@@ -117,7 +118,7 @@ def generate_corpus_stats(corpus_manager: CorpusManager) -> dict[str, Any]:
             parent_ids.add(parent_id)
 
         # Count successful mutations by strategy and individual mutators
-        discovery_mutation = metadata.get("discovery_mutation", {})
+        discovery_mutation: MutationInfo = metadata.get("discovery_mutation", {})
         if discovery_mutation:
             strategy = discovery_mutation.get("strategy", "unknown")
             mutation_counter[strategy] += 1

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from lafleur.coverage import save_coverage_state, CoverageManager
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
+from lafleur.types import MutationInfo
 from lafleur.utils import ExecutionResult, FUZZING_ENV
 
 if TYPE_CHECKING:
@@ -348,7 +349,7 @@ class CorpusManager:
         baseline_coverage: dict[str, Any],
         execution_time_ms: int,
         parent_id: str | None,
-        mutation_info: dict[str, Any],
+        mutation_info: MutationInfo,
         mutation_seed: int,
         content_hash: str,
         coverage_hash: str,

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -516,7 +516,7 @@ class LafleurOrchestrator:
             parent_id: Starting corpus filename to trace back from.
 
         Returns:
-            List of mutation info dicts, ordered parent -> grandparent -> ...
+            List of MutationInfo dicts, ordered parent -> grandparent -> ...
         """
         per_file = self.coverage_manager.state.get("per_file_coverage", {})
         lineage: list[dict] = []

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -21,6 +21,7 @@ from lafleur.coverage import (
     merge_coverage_into_global,
     parse_log_for_edge_coverage,
 )
+from lafleur.types import JitStats, MutationInfo
 from lafleur.utils import ExecutionResult
 
 if TYPE_CHECKING:
@@ -108,8 +109,8 @@ class InterestingnessScorer:
         jit_avg_time_ms: float | None,
         nojit_avg_time_ms: float | None,
         nojit_cv: float | None,
-        jit_stats: dict | None = None,
-        parent_jit_stats: dict | None = None,
+        jit_stats: JitStats | None = None,
+        parent_jit_stats: JitStats | None = None,
     ):
         self.info = coverage_info
         self.parent_file_size = parent_file_size
@@ -335,7 +336,7 @@ class ScoringManager:
         info.total_child_edges = total_edges
         return info
 
-    def parse_jit_stats(self, log_content: str) -> dict:
+    def parse_jit_stats(self, log_content: str) -> JitStats:
         """
         Parse JIT stats from the driver log output.
 
@@ -349,7 +350,7 @@ class ScoringManager:
         Returns:
             Dictionary of aggregated JIT statistics
         """
-        aggregated_stats: dict = {
+        aggregated_stats: JitStats = {
             "max_exit_count": 0,
             "max_chain_depth": 0,
             "zombie_traces": 0,
@@ -443,15 +444,15 @@ class ScoringManager:
         self,
         coverage_info: NewCoverageInfo,
         parent_id: str | None,
-        mutation_info: dict,
+        mutation_info: MutationInfo,
         parent_file_size: int,
         parent_lineage_edge_count: int,
         child_file_size: int,
         jit_avg_time_ms: float | None,
         nojit_avg_time_ms: float | None,
         nojit_cv: float | None,
-        jit_stats: dict | None = None,
-        parent_jit_stats: dict | None = None,
+        jit_stats: JitStats | None = None,
+        parent_jit_stats: JitStats | None = None,
     ) -> bool:
         """
         Use the scorer to decide if a child is interesting.
@@ -573,7 +574,7 @@ class ScoringManager:
         exec_result: ExecutionResult,
         parent_lineage_profile: dict,
         parent_id: str | None,
-        mutation_info: dict,
+        mutation_info: MutationInfo,
         mutation_seed: int,
         parent_file_size: int,
         parent_lineage_edge_count: int,
@@ -625,7 +626,7 @@ class ScoringManager:
         jit_stats = self.parse_jit_stats(log_content)
 
         # Retrieve parent JIT stats from metadata
-        parent_jit_stats = {}
+        parent_jit_stats: JitStats = {}
         if parent_id:
             parent_metadata = self.coverage_manager.state["per_file_coverage"].get(parent_id, {})
             parent_jit_stats = parent_metadata.get("discovery_mutation", {}).get("jit_stats", {})
@@ -661,10 +662,10 @@ class ScoringManager:
         self,
         exec_result: ExecutionResult,
         child_coverage: dict,
-        jit_stats: dict,
-        parent_jit_stats: dict,
+        jit_stats: JitStats,
+        parent_jit_stats: JitStats,
         parent_id: str | None,
-        mutation_info: dict,
+        mutation_info: MutationInfo,
         mutation_seed: int,
     ) -> dict:
         """Deduplicate, commit coverage, apply density decay, and build the result dict."""

--- a/lafleur/types.py
+++ b/lafleur/types.py
@@ -1,0 +1,63 @@
+"""Shared type definitions for lafleur.
+
+This module defines TypedDict types for the major dict schemas that flow
+between modules. Using a dedicated types module avoids circular imports.
+
+These are TypedDict (not dataclass) because they are persisted inside
+coverage_state.pkl — TypedDict is a plain dict at runtime, so existing
+pickle files load without migration.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class JitStats(TypedDict, total=False):
+    """JIT vitals parsed from driver log output and stored in discovery_mutation.
+
+    Uses total=False because:
+    - Delta metrics are only present in session mode.
+    - Older pickled states may lack fields added after their creation.
+    - Some fields (watched_dependencies) are conditionally populated.
+
+    See doc/dev/03_coverage_and_feedback.md for field semantics.
+    """
+
+    # Absolute metrics (always present in new data, may be missing in old pickles)
+    max_exit_count: int
+    max_chain_depth: int
+    zombie_traces: int
+    min_code_size: int
+    max_exit_density: float
+    watched_dependencies: list[str]
+
+    # Delta metrics (session mode only — isolate child script's contribution)
+    child_delta_max_exit_density: float
+    child_delta_max_exit_count: int
+    child_delta_total_exits: int | float
+    child_delta_new_executors: int
+    child_delta_new_zombies: int
+
+
+class MutationInfo(TypedDict, total=False):
+    """Metadata describing the mutation that created a corpus file.
+
+    Stored as discovery_mutation in per_file_coverage entries.
+    Uses total=False because:
+    - Seed files have only {"strategy": "generative_seed"} or {"strategy": "seed"}.
+    - jit_stats is injected by scoring.py after initial creation.
+    - watched_dependencies moved into jit_stats but may exist at top level in old data.
+
+    See doc/dev/05_state_and_data_formats.md for field semantics.
+    """
+
+    strategy: str
+    transformers: list[str]
+    jit_stats: JitStats
+    watched_dependencies: list[str]  # Legacy location; newer data stores this in jit_stats
+    # Fields set by specific mutation stages
+    sliced: bool
+    targets: list[str]
+    seed: int
+    runtime_seed: int


### PR DESCRIPTION
## Summary
- Add `JitStats` and `MutationInfo` TypedDicts in new `lafleur/types.py` module
- Update type annotations across scoring, orchestrator, corpus manager, mutation controller, artifacts, and corpus analysis modules
- No behavioral changes — TypedDict is a plain dict at runtime, so pickle backward compatibility is preserved

## Test plan
- [x] `ruff check lafleur/ tests/` passes
- [x] `ruff format --check lafleur/ tests/` passes
- [x] `mypy lafleur/` passes (0 errors)
- [x] All 1839 tests pass
- [x] No remaining `jit_stats: dict` or `mutation_info: dict` in `lafleur/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)