### PR TITLE
refactor: AnalysisResult dataclass hierarchy for analyze_run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project should be documented in this file.
 - Strengthened mutator test assertions: `exec()` verification for all evil object generators, safety wrapper assertions for `SliceMutator` and `StringInterpolationMutator`, and brittleness comments on tests with rigid `side_effect` sequences, by @devdanzin.
 - Added `compile(result, "<test>", "exec")` validation to 93 test methods across all mutator test files, catching scope violations (`return`/`yield` outside function, `break`/`continue` outside loop, `nonlocal` misuse) that `ast.parse()` alone misses, by @devdanzin.
 - `JitStats` and `MutationInfo` TypedDicts in `lafleur/types.py` for structural typing of the two most widely shared dict schemas, enabling mypy to catch key typos and missing fields across scoring, orchestrator, corpus manager, mutation controller, and corpus analysis modules, by @devdanzin.
+- `AnalysisResult` frozen dataclass hierarchy (`NewCoverageResult`, `CrashResult`, `NoChangeResult`, `DivergenceResult`) replacing the untyped `analysis_data` dict returned by `analyze_run()`, enabling `isinstance()` dispatch and compile-time verification of variant-specific field access, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from lafleur.coverage import save_coverage_state, CoverageManager
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
-from lafleur.types import MutationInfo
+from lafleur.types import MutationInfo, NewCoverageResult
 from lafleur.utils import ExecutionResult, FUZZING_ENV
 
 if TYPE_CHECKING:
@@ -257,16 +257,16 @@ class CorpusManager:
                     parent_file_size=0,
                     parent_lineage_edge_count=0,
                 )
-                if analysis_data["status"] == "NEW_COVERAGE":
+                if isinstance(analysis_data, NewCoverageResult):
                     self.add_new_file(
-                        core_code=analysis_data["core_code"],
-                        baseline_coverage=analysis_data["baseline_coverage"],
-                        content_hash=analysis_data["content_hash"],
-                        coverage_hash=analysis_data["coverage_hash"],
-                        execution_time_ms=analysis_data["execution_time_ms"],
-                        parent_id=analysis_data["parent_id"],
-                        mutation_info=analysis_data["mutation_info"],
-                        mutation_seed=analysis_data["mutation_seed"],
+                        core_code=analysis_data.core_code,
+                        baseline_coverage=analysis_data.baseline_coverage,
+                        content_hash=analysis_data.content_hash,
+                        coverage_hash=analysis_data.coverage_hash,
+                        execution_time_ms=analysis_data.execution_time_ms,
+                        parent_id=analysis_data.parent_id,
+                        mutation_info=analysis_data.mutation_info,
+                        mutation_seed=analysis_data.mutation_seed,
                         build_lineage_func=orchestrator_build_lineage_func,
                         filename_override=filename,
                     )
@@ -478,16 +478,16 @@ class CorpusManager:
             parent_file_size=0,
             parent_lineage_edge_count=0,
         )
-        if analysis_data["status"] == "NEW_COVERAGE":
+        if isinstance(analysis_data, NewCoverageResult):
             self.add_new_file(
-                core_code=analysis_data["core_code"],
-                baseline_coverage=analysis_data["baseline_coverage"],
-                content_hash=analysis_data["content_hash"],
-                coverage_hash=analysis_data["coverage_hash"],
-                execution_time_ms=analysis_data["execution_time_ms"],
-                parent_id=analysis_data["parent_id"],
-                mutation_info=analysis_data["mutation_info"],
-                mutation_seed=analysis_data["mutation_seed"],
+                core_code=analysis_data.core_code,
+                baseline_coverage=analysis_data.baseline_coverage,
+                content_hash=analysis_data.content_hash,
+                coverage_hash=analysis_data.coverage_hash,
+                execution_time_ms=analysis_data.execution_time_ms,
+                parent_id=analysis_data.parent_id,
+                mutation_info=analysis_data.mutation_info,
+                mutation_seed=analysis_data.mutation_seed,
                 build_lineage_func=orchestrator_build_lineage_func,
             )
 

--- a/tests/orchestrator/test_mutation_strategies.py
+++ b/tests/orchestrator/test_mutation_strategies.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
 from lafleur.mutation_controller import MutationController
+from lafleur.types import DivergenceResult
 
 
 class TestApplyMutationStrategy(unittest.TestCase):
@@ -1002,9 +1003,9 @@ class TestRecordSuccessHygieneFiltering(unittest.TestCase):
         orch.mutations_since_last_find = 0
         orch.score_tracker = MagicMock()
 
-        analysis_data = {
-            "status": "DIVERGENCE",
-            "mutation_info": {
+        analysis_data = DivergenceResult(
+            status="DIVERGENCE",
+            mutation_info={
                 "strategy": "havoc",
                 "transformers": [
                     "OperatorSwapper",
@@ -1014,7 +1015,7 @@ class TestRecordSuccessHygieneFiltering(unittest.TestCase):
                     "RedundantStatementSanitizer",
                 ],
             },
-        }
+        )
 
         orch._handle_analysis_data(analysis_data, i=0, parent_metadata={}, nojit_cv=None)
 


### PR DESCRIPTION
## Summary
- Add frozen dataclass hierarchy (`AnalysisResult`, `NewCoverageResult`, `CrashResult`, `NoChangeResult`, `DivergenceResult`) to `lafleur/types.py`
- Replace untyped `analysis_data` dict returns from `analyze_run()` with dataclass instances
- Consumers use `isinstance()` dispatch instead of string-based status checks
- All field access converted from dict lookups to attribute access
- No behavioral changes

## Test plan
- [x] `ruff check lafleur/ tests/` passes
- [x] `ruff format --check lafleur/ tests/` passes
- [x] `mypy lafleur/` passes (0 errors)
- [x] All 1839 tests pass
- [x] No remaining `analysis_data["` or `analysis_data.get(` in `lafleur/` production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)