### PR TITLE
refactor: CorpusFileMetadata TypedDict for per_file_coverage entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project should be documented in this file.
 - Added `compile(result, "<test>", "exec")` validation to 93 test methods across all mutator test files, catching scope violations (`return`/`yield` outside function, `break`/`continue` outside loop, `nonlocal` misuse) that `ast.parse()` alone misses, by @devdanzin.
 - `JitStats` and `MutationInfo` TypedDicts in `lafleur/types.py` for structural typing of the two most widely shared dict schemas, enabling mypy to catch key typos and missing fields across scoring, orchestrator, corpus manager, mutation controller, and corpus analysis modules, by @devdanzin.
 - `AnalysisResult` frozen dataclass hierarchy (`NewCoverageResult`, `CrashResult`, `NoChangeResult`, `DivergenceResult`) replacing the untyped `analysis_data` dict returned by `analyze_run()`, enabling `isinstance()` dispatch and compile-time verification of variant-specific field access, by @devdanzin.
+- `CorpusFileMetadata` and `LineageHarnessData` TypedDicts in `lafleur/types.py` for structural typing of `per_file_coverage` entries — the most widely accessed data structure in the codebase (~15 fields, 8 consuming modules), enabling mypy to catch key typos and type mismatches across corpus manager, orchestrator, scoring, corpus analysis, and state tool, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/corpus_analysis.py
+++ b/lafleur/corpus_analysis.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from lafleur.corpus_manager import CorpusManager
-    from lafleur.types import MutationInfo
+    from lafleur.types import CorpusFileMetadata, MutationInfo
 
 
 def calculate_distribution(values: Sequence[int | float]) -> dict[str, float | None]:
@@ -57,7 +57,9 @@ def generate_corpus_stats(corpus_manager: CorpusManager) -> dict[str, Any]:
         - Mutation intelligence (successful mutation histogram)
     """
     # Access the per-file coverage metadata
-    per_file_coverage = corpus_manager.coverage_state.state.get("per_file_coverage", {})
+    per_file_coverage: dict[str, CorpusFileMetadata] = corpus_manager.coverage_state.state.get(
+        "per_file_coverage", {}
+    )
 
     total_files = len(per_file_coverage)
 

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -23,6 +23,7 @@ from lafleur.coverage import (
 )
 from lafleur.types import (
     AnalysisResult,
+    CorpusFileMetadata,
     CrashResult,
     DivergenceResult,
     JitStats,
@@ -636,7 +637,9 @@ class ScoringManager:
         # Retrieve parent JIT stats from metadata
         parent_jit_stats: JitStats = {}
         if parent_id:
-            parent_metadata = self.coverage_manager.state["per_file_coverage"].get(parent_id, {})
+            parent_metadata: CorpusFileMetadata = self.coverage_manager.state[
+                "per_file_coverage"
+            ].get(parent_id, {})
             parent_jit_stats = parent_metadata.get("discovery_mutation", {}).get("jit_stats", {})
 
         is_interesting = self.score_and_decide_interestingness(

--- a/lafleur/state_tool.py
+++ b/lafleur/state_tool.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
+from lafleur.types import CorpusFileMetadata
+
 
 def migrate_state_to_integers(old_state: dict[str, Any]) -> dict[str, Any]:
     """
@@ -50,7 +52,7 @@ def migrate_state_to_integers(old_state: dict[str, Any]) -> dict[str, Any]:
     # 2. Migrate per_file_coverage
     per_file_cov = cast(dict[str, Any], new_state["per_file_coverage"])
     for filename, metadata in old_state.get("per_file_coverage", {}).items():
-        new_metadata = metadata.copy()
+        new_metadata: CorpusFileMetadata = metadata.copy()
 
         # a. Migrate baseline_coverage
         new_baseline = {}


### PR DESCRIPTION
## Summary
- Add `CorpusFileMetadata` and `LineageHarnessData` TypedDicts to `lafleur/types.py`
- Annotate all producers and consumers across corpus_manager, orchestrator, scoring, corpus_analysis, and state_tool
- Type the most widely accessed data structure in the codebase (~15 fields, 8 consuming modules) so mypy can catch key typos and type mismatches

## Test plan
- [x] `ruff check lafleur/ tests/` passes
- [x] `ruff format --check lafleur/ tests/` passes
- [x] `mypy lafleur/` passes clean (0 errors)
- [x] All 1839 tests pass — no behavioral changes
- [x] Verified no remaining untyped `metadata: dict` for per_file_coverage entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)