### PR TITLE
feat: lineage tool prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to this project should be documented in this file.
 - `JitStats` and `MutationInfo` TypedDicts in `lafleur/types.py` for structural typing of the two most widely shared dict schemas, enabling mypy to catch key typos and missing fields across scoring, orchestrator, corpus manager, mutation controller, and corpus analysis modules, by @devdanzin.
 - `AnalysisResult` frozen dataclass hierarchy (`NewCoverageResult`, `CrashResult`, `NoChangeResult`, `DivergenceResult`) replacing the untyped `analysis_data` dict returned by `analyze_run()`, enabling `isinstance()` dispatch and compile-time verification of variant-specific field access, by @devdanzin.
 - `CorpusFileMetadata` and `LineageHarnessData` TypedDicts in `lafleur/types.py` for structural typing of `per_file_coverage` entries — the most widely accessed data structure in the codebase (~15 fields, 8 consuming modules), enabling mypy to catch key typos and type mismatches across corpus manager, orchestrator, scoring, corpus analysis, and state tool, by @devdanzin.
+- A `total_mutations_against` lifetime counter on corpus file metadata, enabling accurate success rate calculation (`total_finds / total_mutations_against`) for the lineage tool, by @devdanzin.
+- **Tombstone metadata** for pruned corpus files: pruning now retains a minimal metadata entry (`parent_id`, `discovery_mutation`, `lineage_depth`, `discovery_time`, `is_pruned: True`) instead of deleting entirely, preserving lineage graph connectivity for the lineage tool, by @devdanzin.
+- **Session corpus filenames** in crash metadata: session crash bundles now record the parent corpus filename and polluter IDs in `metadata.json` under `session_corpus_files`, enabling direct lineage-to-crash mapping without content-hash searching, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/corpus_analysis.py
+++ b/lafleur/corpus_analysis.py
@@ -94,6 +94,8 @@ def generate_corpus_stats(corpus_manager: CorpusManager) -> dict[str, Any]:
     mutator_counter: Counter[str] = Counter()  # Individual transformers
 
     for filename, metadata in per_file_coverage.items():
+        if metadata.get("is_pruned", False):
+            continue
         all_file_ids.add(filename)
 
         # Count sterile files
@@ -132,7 +134,9 @@ def generate_corpus_stats(corpus_manager: CorpusManager) -> dict[str, Any]:
 
     # Calculate tree topology
     root_count = sum(
-        1 for metadata in per_file_coverage.values() if metadata.get("parent_id") is None
+        1
+        for metadata in per_file_coverage.values()
+        if metadata.get("parent_id") is None and not metadata.get("is_pruned", False)
     )
 
     # Leaf files are those that never appear as a parent

--- a/lafleur/execution.py
+++ b/lafleur/execution.py
@@ -476,6 +476,7 @@ class ExecutionManager:
 
             # Build the command based on session fuzzing mode
             session_files: list[Path] | None = None
+            polluter_ids: list[str] | None = None
             if self.session_fuzz:
                 if random.random() < SOLO_SESSION_PROBABILITY:
                     # Solo session: child only, cold JIT
@@ -508,6 +509,7 @@ class ExecutionManager:
                             pass
 
                         if polluters:
+                            polluter_ids = [p.name for p in polluters]
                             session_files = polluters + [parent_path, child_source_path]
                             print(
                                 f"  [MIXER] Active: Added {len(polluters)} polluter(s) to session.",
@@ -554,6 +556,7 @@ class ExecutionManager:
                 nojit_cv=nojit_cv,
                 parent_path=parent_path,
                 session_files=session_files if self.session_fuzz else None,
+                polluter_ids=polluter_ids,
             ), None
         except subprocess.TimeoutExpired:
             self.artifact_manager.handle_timeout(child_source_path, child_log_path, parent_path)

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -423,6 +423,11 @@ class LafleurOrchestrator:
             A tuple of (flow_control, new_filename). new_filename is set for
             NEW_COVERAGE and DIVERGENCE statuses, None otherwise.
         """
+        # Lifetime mutation attempt counter — fires on every outcome
+        parent_metadata["total_mutations_against"] = (
+            parent_metadata.get("total_mutations_against", 0) + 1
+        )
+
         if isinstance(analysis_data, (DivergenceResult, NewCoverageResult)):
             mutation_info = analysis_data.mutation_info
             strategy = mutation_info.get("strategy")

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -621,6 +621,7 @@ class ScoringManager:
             exec_result.session_files,
             parent_id=parent_id,
             mutation_info=mutation_info,
+            polluter_ids=exec_result.polluter_ids,
         ):
             return CrashResult(
                 status="CRASH",

--- a/lafleur/types.py
+++ b/lafleur/types.py
@@ -124,7 +124,9 @@ class CorpusFileMetadata(TypedDict, total=False):
     # --- Mutable runtime state ---
     mutations_since_last_find: int
     total_finds: int
+    total_mutations_against: int
     is_sterile: bool
+    is_pruned: bool  # Tombstone marker for pruned files
 
     # --- Post-hoc additions (may be absent on most entries) ---
     subsumed_children_count: int  # Set by prune_corpus only

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -317,3 +317,4 @@ class ExecutionResult:
     nojit_cv: float | None = None
     parent_path: Path | None = None
     session_files: list[Path] | None = None
+    polluter_ids: list[str] | None = None


### PR DESCRIPTION
## Summary
- Add `total_mutations_against` lifetime counter to per_file_coverage metadata for accurate success rate calculation
- Retain tombstone metadata for pruned corpus files, preserving lineage graph connectivity
- Record session corpus filenames (`parent_id`, `polluter_ids`) in crash `metadata.json`

All three changes are backward-compatible — they add optional fields only. Existing `.get()` patterns handle missing fields gracefully.

## Test plan
- [x] `total_mutations_against` increments on every outcome (NO_CHANGE, CRASH, NEW_COVERAGE)
- [x] `add_new_file()` initializes `total_mutations_against: 0`
- [x] Backward compat: missing field defaults to 0 via `.get()`
- [x] Tombstones preserve `parent_id`, `discovery_mutation`, `lineage_depth`, `discovery_time`
- [x] Tombstones exclude bulk fields (`baseline_coverage`, `content_hash`, etc.)
- [x] `CorpusScheduler` skips tombstones in scoring and parent selection
- [x] Lineage chain A→B→C survives pruning of B
- [x] Session crash metadata includes `session_corpus_files` with warmup and polluters
- [x] `ruff check`, `ruff format`, `mypy` all pass clean
- [x] All 1850 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)