### PR TITLE
feat: lafleur-lineage core (ancestry + descendants)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project should be documented in this file.
 - A `total_mutations_against` lifetime counter on corpus file metadata, enabling accurate success rate calculation (`total_finds / total_mutations_against`) for the lineage tool, by @devdanzin.
 - **Tombstone metadata** for pruned corpus files: pruning now retains a minimal metadata entry (`parent_id`, `discovery_mutation`, `lineage_depth`, `discovery_time`, `is_pruned: True`) instead of deleting entirely, preserving lineage graph connectivity for the lineage tool, by @devdanzin.
 - **Session corpus filenames** in crash metadata: session crash bundles now record the parent corpus filename and polluter IDs in `metadata.json` under `session_corpus_files`, enabling direct lineage-to-crash mapping without content-hash searching, by @devdanzin.
+- A `lafleur-lineage` CLI tool for corpus lineage visualization with ancestry mode (trace a file back to its seed) and descendants mode (show what a file produced), DOT/JSON output, optional Graphviz rendering, strategy-colored edges, ghost nodes for pruned intermediates, sterile leaf collapsing, and statistics summary, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/lineage.py
+++ b/lafleur/lineage.py
@@ -1,0 +1,962 @@
+"""Corpus lineage visualization tool for lafleur.
+
+Builds and renders lineage trees from coverage_state.pkl, showing how corpus
+files descend from seeds through mutation chains. Supports ancestry (trace a
+file back to its seed) and descendants (show what a file produced) modes.
+
+Output formats: Graphviz DOT (default), JSON, or rendered images (PNG/SVG/PDF).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pickle
+import shutil
+import subprocess
+import sys
+from collections import defaultdict, deque
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LineageGraph:
+    """Full adjacency graph built from per_file_coverage."""
+
+    children: dict[str, list[str]]  # parent_id → list of child filenames
+    parent: dict[str, str | None]  # filename → parent_id (None for seeds)
+    roots: list[str]  # files with parent_id is None (seeds)
+    metadata: dict[str, dict]  # filename → full per_file_coverage entry
+
+
+@dataclass
+class Subgraph:
+    """A subset of the lineage graph for rendering."""
+
+    nodes: set[str]  # filenames in this subgraph
+    edges: list[tuple[str, str]]  # (parent, child) pairs
+    collapsed: dict[str, int] = field(default_factory=dict)  # summary_node_id → count
+    special_nodes: dict[str, str] = field(
+        default_factory=dict
+    )  # node_id → role (crash, ghost, mrca)
+
+
+@dataclass
+class NodeStyle:
+    """Visual properties for a single node."""
+
+    shape: str = "box"
+    fillcolor: str = "#d4edda"
+    fontcolor: str = "black"
+    style: str = "filled"
+    color: str = ""  # border color (empty = default)
+    penwidth: float = 1.0
+    label: str = ""
+    tooltip: str = ""
+
+
+@dataclass
+class EdgeStyle:
+    """Visual properties for a single edge."""
+
+    color: str = "#000000"
+    style: str = "solid"
+    penwidth: float = 1.0
+    label: str = ""
+
+
+@dataclass
+class DecoratedGraph:
+    """Subgraph with visual properties assigned."""
+
+    nodes: dict[str, NodeStyle]  # node_id → style
+    edges: list[tuple[str, str, EdgeStyle]]  # (parent, child, style)
+    graph_attrs: dict[str, str] = field(default_factory=dict)  # rankdir, fontname, etc.
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Node colors
+COLOR_SEED = "#e8e8e8"
+COLOR_NORMAL = "#d4edda"
+COLOR_FERTILE = "#28a745"
+COLOR_STERILE = "#f5f5f5"
+COLOR_CRASH = "#dc3545"
+COLOR_TIMEOUT = "#fd7e14"
+COLOR_GHOST = "#f0f0f0"
+COLOR_COLLAPSED = "#f0f0f0"
+BORDER_ZOMBIE = "#dc3545"
+BORDER_TACHYCARDIA = "#fd7e14"
+
+# Edge colors by strategy
+STRATEGY_COLORS: dict[str, str] = {
+    "deterministic": "#6c757d",
+    "havoc": "#007bff",
+    "spam": "#6f42c1",
+    "sniper": "#dc3545",
+    "helper_sniper": "#e83e8c",
+    "generative_seed": "#6c757d",
+}
+STRATEGY_STYLES: dict[str, str] = {
+    "sniper": "bold",
+    "helper_sniper": "bold",
+    "generative_seed": "dashed",
+}
+
+FERTILE_THRESHOLD = 5  # total_finds >= this → fertile styling
+ANCESTRY_DEPTH_LIMIT = 200
+
+# ---------------------------------------------------------------------------
+# Graph construction
+# ---------------------------------------------------------------------------
+
+
+def load_coverage_state(state_path: Path) -> dict:
+    """Load coverage_state.pkl and return the full state dict."""
+    with open(state_path, "rb") as f:
+        return pickle.load(f)
+
+
+def build_adjacency_graph(per_file_coverage: dict[str, dict]) -> LineageGraph:
+    """Build the full adjacency graph from per_file_coverage metadata."""
+    children: dict[str, list[str]] = defaultdict(list)
+    parent: dict[str, str | None] = {}
+    roots: list[str] = []
+
+    for filename, metadata in per_file_coverage.items():
+        parent_id = metadata.get("parent_id")
+        parent[filename] = parent_id
+
+        if parent_id is not None:
+            children[parent_id].append(filename)
+        elif not metadata.get("is_pruned", False):
+            roots.append(filename)
+
+    # Sort children lists for deterministic output
+    for parent_id in children:
+        children[parent_id].sort()
+
+    roots.sort()
+    return LineageGraph(
+        children=dict(children),
+        parent=parent,
+        roots=roots,
+        metadata=per_file_coverage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subgraph extraction: ancestry
+# ---------------------------------------------------------------------------
+
+
+def extract_ancestry(graph: LineageGraph, target: str) -> Subgraph:
+    """Walk parent_id backward from target to seed, producing a linear chain."""
+    nodes_ordered: list[str] = []
+    edges: list[tuple[str, str]] = []
+    special_nodes: dict[str, str] = {}
+
+    current = target
+    visited: set[str] = set()
+
+    for _ in range(ANCESTRY_DEPTH_LIMIT):
+        if current in visited:
+            break
+        visited.add(current)
+        nodes_ordered.append(current)
+
+        # Check if this node is a ghost (not in metadata)
+        if current not in graph.metadata:
+            special_nodes[current] = "ghost"
+            # Ghost may still have tombstone parent_id
+            break
+
+        parent_id = graph.parent.get(current)
+        if parent_id is None:
+            break  # Reached seed
+
+        edges.append((parent_id, current))
+
+        # Check if parent is a ghost
+        if parent_id not in graph.metadata:
+            # Insert ghost node
+            special_nodes[parent_id] = "ghost"
+            nodes_ordered.append(parent_id)
+            # Check tombstone for further ancestry — tombstones are IN metadata
+            break
+
+        current = parent_id
+
+    # Reverse to get seed-first order
+    nodes_ordered.reverse()
+    edges.reverse()
+    return Subgraph(nodes=set(nodes_ordered), edges=edges, special_nodes=special_nodes)
+
+
+# ---------------------------------------------------------------------------
+# Subgraph extraction: descendants
+# ---------------------------------------------------------------------------
+
+
+def extract_descendants(
+    graph: LineageGraph,
+    root: str,
+    max_depth: int | None = None,
+    collapse_sterile: bool = True,
+) -> Subgraph:
+    """BFS from root through children, producing a tree."""
+    nodes: set[str] = set()
+    edges: list[tuple[str, str]] = []
+    collapsed: dict[str, int] = {}
+    special_nodes: dict[str, str] = {}
+
+    # BFS
+    queue: deque[tuple[str, int]] = deque([(root, 0)])
+    nodes.add(root)
+
+    # Track children per parent for sterile collapsing
+    parent_children: dict[str, list[str]] = defaultdict(list)
+
+    while queue:
+        current, depth = queue.popleft()
+
+        if max_depth is not None and depth >= max_depth:
+            continue
+
+        # Sort children by total_finds descending for consistent layout
+        child_list = graph.children.get(current, [])
+        sorted_children = sorted(
+            child_list,
+            key=lambda c: graph.metadata.get(c, {}).get("total_finds", 0),
+            reverse=True,
+        )
+
+        for child in sorted_children:
+            meta = graph.metadata.get(child, {})
+            # Skip pruned nodes as BFS starting points
+            if meta.get("is_pruned", False):
+                continue
+
+            if child not in nodes:
+                nodes.add(child)
+                edges.append((current, child))
+                parent_children[current].append(child)
+                queue.append((child, depth + 1))
+
+    # Sterile collapsing
+    if collapse_sterile:
+        for parent_node, children_list in parent_children.items():
+            # Find sterile childless siblings
+            sterile_childless = [
+                c
+                for c in children_list
+                if graph.metadata.get(c, {}).get("is_sterile", False)
+                and not graph.children.get(c, [])
+            ]
+
+            if len(sterile_childless) >= 3 and len(sterile_childless) == len(children_list):
+                # ALL children are sterile+childless — collapse all
+                summary_id = f"__collapsed_{parent_node}_{len(sterile_childless)}"
+                collapsed[summary_id] = len(sterile_childless)
+                special_nodes[summary_id] = "collapsed"
+
+                # Remove individual sterile nodes, add summary
+                for c in sterile_childless:
+                    nodes.discard(c)
+                    edges = [(p, ch) for p, ch in edges if ch != c]
+                nodes.add(summary_id)
+                edges.append((parent_node, summary_id))
+
+            elif len(sterile_childless) >= 3:
+                # Some children are non-sterile — collapse only the sterile ones
+                summary_id = f"__collapsed_{parent_node}_{len(sterile_childless)}"
+                collapsed[summary_id] = len(sterile_childless)
+                special_nodes[summary_id] = "collapsed"
+
+                for c in sterile_childless:
+                    nodes.discard(c)
+                    edges = [(p, ch) for p, ch in edges if ch != c]
+                nodes.add(summary_id)
+                edges.append((parent_node, summary_id))
+
+    return Subgraph(nodes=nodes, edges=edges, collapsed=collapsed, special_nodes=special_nodes)
+
+
+# ---------------------------------------------------------------------------
+# Decoration
+# ---------------------------------------------------------------------------
+
+
+def _build_node_label(
+    node: str,
+    metadata: dict,
+    label_style: str,
+) -> str:
+    """Build a node label based on the label style."""
+    if label_style == "minimal":
+        return node
+
+    dm = metadata.get("discovery_mutation", {})
+    strategy = dm.get("strategy", "?")
+    transformers = dm.get("transformers", [])
+    jit_stats = dm.get("jit_stats", {})
+    depth = metadata.get("lineage_depth", 0)
+    finds = metadata.get("total_finds", 0)
+    density = jit_stats.get("max_exit_density", 0.0)
+    edges_count = len(metadata.get("baseline_coverage", {}).get("h1", {}).get("edges", []))
+
+    parts = [node]
+    parts.append(f"{strategy} ({len(transformers)} transformers)")
+    parts.append(f"depth={depth} finds={finds}")
+    parts.append(f"density={density:.3f} edges={edges_count}")
+
+    if label_style == "verbose":
+        exec_time = metadata.get("execution_time_ms", 0)
+        file_size = metadata.get("file_size_bytes", 0)
+        disc_time = metadata.get("discovery_time", "?")
+        parts.append(f"exec={exec_time}ms size={file_size}B")
+        parts.append(f"discovered={disc_time}")
+        if transformers:
+            parts.append("transformers: " + ", ".join(transformers))
+        for key, val in sorted(jit_stats.items()):
+            parts.append(f"  {key}={val}")
+
+    return "\\n".join(parts)
+
+
+def _build_tooltip(metadata: dict) -> str:
+    """Build a tooltip with full metadata dump."""
+    dm = metadata.get("discovery_mutation", {})
+    jit_stats = dm.get("jit_stats", {})
+    transformers = dm.get("transformers", [])
+    watched_deps = jit_stats.get("watched_dependencies", dm.get("watched_dependencies", []))
+
+    lines = [
+        f"strategy: {dm.get('strategy', '?')}",
+        f"transformers: {transformers}",
+        f"depth: {metadata.get('lineage_depth', 0)}",
+        f"total_finds: {metadata.get('total_finds', 0)}",
+        f"total_mutations_against: {metadata.get('total_mutations_against', 0)}",
+        f"execution_time_ms: {metadata.get('execution_time_ms', 0)}",
+        f"file_size_bytes: {metadata.get('file_size_bytes', 0)}",
+        f"content_hash: {metadata.get('content_hash', '?')}",
+        f"coverage_hash: {metadata.get('coverage_hash', '?')}",
+        f"discovery_time: {metadata.get('discovery_time', '?')}",
+        f"watched_dependencies: {watched_deps}",
+    ]
+    for key, val in sorted(jit_stats.items()):
+        lines.append(f"jit.{key}: {val}")
+    return "\\n".join(lines)
+
+
+def decorate(
+    subgraph: Subgraph,
+    graph: LineageGraph,
+    label_style: str = "standard",
+    no_color: bool = False,
+) -> DecoratedGraph:
+    """Assign visual properties to nodes and edges."""
+    node_styles: dict[str, NodeStyle] = {}
+    edge_list: list[tuple[str, str, EdgeStyle]] = []
+
+    for node in subgraph.nodes:
+        ns = NodeStyle()
+
+        # Priority 1: special nodes
+        if node in subgraph.special_nodes:
+            role = subgraph.special_nodes[node]
+            if role == "ghost":
+                ns.shape = "box"
+                ns.style = "dotted"
+                ns.fillcolor = COLOR_GHOST
+                ns.fontcolor = "gray"
+                ns.label = f"{node}\\n[pruned]"
+                ns.tooltip = ""
+            elif role == "crash":
+                ns.shape = "octagon"
+                ns.fillcolor = COLOR_CRASH
+                ns.fontcolor = "white"
+                ns.label = node
+                ns.tooltip = ""
+            elif role == "collapsed":
+                count = subgraph.collapsed.get(node, 0)
+                ns.shape = "note"
+                ns.fillcolor = COLOR_COLLAPSED
+                ns.label = f"{count} sterile leaves"
+                ns.tooltip = ""
+            node_styles[node] = ns
+            continue
+
+        # Priority 2: normal corpus nodes
+        metadata = graph.metadata.get(node, {})
+        parent_id = metadata.get("parent_id")
+        is_pruned = metadata.get("is_pruned", False)
+        is_sterile = metadata.get("is_sterile", False)
+        total_finds = metadata.get("total_finds", 0)
+
+        if parent_id is None and not is_pruned:
+            # Seed
+            ns.shape = "doubleoctagon"
+            ns.fillcolor = COLOR_SEED
+        elif is_sterile:
+            ns.fillcolor = COLOR_STERILE
+            ns.style = "filled,dashed"
+        elif total_finds >= FERTILE_THRESHOLD:
+            ns.fillcolor = COLOR_FERTILE
+            ns.fontcolor = "white"
+        else:
+            ns.fillcolor = COLOR_NORMAL
+
+        # Priority 3: border overlays
+        dm = metadata.get("discovery_mutation", {})
+        jit_stats = dm.get("jit_stats", {})
+
+        if jit_stats.get("zombie_traces", 0) > 0:
+            ns.color = BORDER_ZOMBIE
+            ns.penwidth = 3.0
+
+        if jit_stats.get("max_exit_density", 0.0) > 0.1:
+            ns.color = BORDER_TACHYCARDIA
+            ns.penwidth = 2.0
+
+        # Label and tooltip
+        ns.label = _build_node_label(node, metadata, label_style)
+        ns.tooltip = _build_tooltip(metadata)
+
+        node_styles[node] = ns
+
+    # Edge decoration
+    for parent_node, child_node in subgraph.edges:
+        es = EdgeStyle()
+        child_meta = graph.metadata.get(child_node, {})
+        dm = child_meta.get("discovery_mutation", {})
+        strategy = dm.get("strategy", "")
+        transformers = dm.get("transformers", [])
+
+        es.color = STRATEGY_COLORS.get(strategy, "#000000")
+        es.style = STRATEGY_STYLES.get(strategy, "solid")
+
+        if label_style == "minimal":
+            es.label = strategy
+        elif label_style == "verbose":
+            es.label = f"{strategy}\\n{', '.join(transformers)}" if transformers else strategy
+        else:
+            es.label = f"{strategy} ({len(transformers)})" if transformers else strategy
+
+        # Make fertile edges more prominent
+        if child_meta.get("total_finds", 0) >= FERTILE_THRESHOLD:
+            es.penwidth = 2.0
+
+        edge_list.append((parent_node, child_node, es))
+
+    # no_color override
+    if no_color:
+        for ns in node_styles.values():
+            ns.fillcolor = "white"
+            ns.fontcolor = "black"
+            if ns.color:
+                ns.color = "black"
+        for _, _, es in edge_list:
+            es.color = "black"
+
+    graph_attrs = {
+        "rankdir": "LR",
+        "fontname": "Helvetica",
+    }
+
+    return DecoratedGraph(nodes=node_styles, edges=edge_list, graph_attrs=graph_attrs)
+
+
+# ---------------------------------------------------------------------------
+# DOT emission
+# ---------------------------------------------------------------------------
+
+
+def _escape_dot(text: str) -> str:
+    """Escape special characters for DOT labels/tooltips."""
+    return text.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def emit_dot(decorated: DecoratedGraph) -> str:
+    """Generate a Graphviz DOT string from a decorated graph."""
+    lines: list[str] = []
+    lines.append("digraph lineage {")
+
+    # Graph-level attributes
+    for key, val in decorated.graph_attrs.items():
+        lines.append(f"  {key}={_quote(val)};")
+
+    lines.append('  node [fontname="Helvetica", fontsize=10];')
+    lines.append('  edge [fontname="Helvetica", fontsize=8];')
+    lines.append("")
+
+    # Nodes
+    for node_id, ns in decorated.nodes.items():
+        attrs: list[str] = []
+        attrs.append(f'label="{_escape_dot(ns.label)}"')
+        attrs.append(f"shape={ns.shape}")
+        attrs.append(f'fillcolor="{ns.fillcolor}"')
+        attrs.append(f'fontcolor="{ns.fontcolor}"')
+        attrs.append(f'style="{ns.style}"')
+        if ns.color:
+            attrs.append(f'color="{ns.color}"')
+        if ns.penwidth != 1.0:
+            attrs.append(f"penwidth={ns.penwidth}")
+        if ns.tooltip:
+            attrs.append(f'tooltip="{_escape_dot(ns.tooltip)}"')
+        attrs_str = ", ".join(attrs)
+        lines.append(f"  {_quote(node_id)} [{attrs_str}];")
+
+    lines.append("")
+
+    # Edges
+    for parent_node, child_node, es in decorated.edges:
+        attrs = []
+        attrs.append(f'label="{_escape_dot(es.label)}"')
+        attrs.append(f'color="{es.color}"')
+        if es.style != "solid":
+            attrs.append(f'style="{es.style}"')
+        if es.penwidth != 1.0:
+            attrs.append(f"penwidth={es.penwidth}")
+        attrs_str = ", ".join(attrs)
+        lines.append(f"  {_quote(parent_node)} -> {_quote(child_node)} [{attrs_str}];")
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _quote(text: str) -> str:
+    """Quote a DOT identifier."""
+    return f'"{_escape_dot(text)}"'
+
+
+# ---------------------------------------------------------------------------
+# JSON emission
+# ---------------------------------------------------------------------------
+
+
+def emit_json(decorated: DecoratedGraph, graph: LineageGraph, subgraph: Subgraph) -> str:
+    """Emit the decorated graph as JSON."""
+    nodes_list = []
+    for node_id, ns in decorated.nodes.items():
+        meta = graph.metadata.get(node_id, {})
+        nodes_list.append(
+            {
+                "id": node_id,
+                "metadata": meta,
+                "style": asdict(ns),
+            }
+        )
+
+    edges_list = []
+    for parent_node, child_node, es in decorated.edges:
+        edges_list.append(
+            {
+                "source": parent_node,
+                "target": child_node,
+                "style": asdict(es),
+            }
+        )
+
+    result = {
+        "nodes": nodes_list,
+        "edges": edges_list,
+        "statistics": {
+            "node_count": len(subgraph.nodes),
+            "edge_count": len(subgraph.edges),
+            "collapsed_count": len(subgraph.collapsed),
+        },
+    }
+    return json.dumps(result, indent=2, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Graphviz rendering
+# ---------------------------------------------------------------------------
+
+
+def render_graphviz(dot_string: str, output_path: Path, fmt: str = "png") -> bool:
+    """Invoke Graphviz dot to render the DOT string to an image file.
+
+    Returns True on success, False on failure.
+    """
+    if shutil.which("dot") is None:
+        print(
+            "Error: Graphviz 'dot' command not found. "
+            "Install Graphviz (e.g. 'apt install graphviz') to use --render.",
+            file=sys.stderr,
+        )
+        return False
+
+    try:
+        result = subprocess.run(
+            ["dot", f"-T{fmt}", "-o", str(output_path)],
+            input=dot_string,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            print(f"Graphviz error: {result.stderr}", file=sys.stderr)
+            return False
+        return True
+    except subprocess.TimeoutExpired:
+        print("Error: Graphviz rendering timed out after 60 seconds.", file=sys.stderr)
+        return False
+    except OSError as e:
+        print(f"Error running Graphviz: {e}", file=sys.stderr)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Statistics summary
+# ---------------------------------------------------------------------------
+
+
+def print_ancestry_stats(chain: list[str], graph: LineageGraph) -> None:
+    """Print ancestry-mode statistics to stderr."""
+    if not chain:
+        return
+
+    seed = chain[0]
+    target = chain[-1]
+    depth = len(chain) - 1
+
+    strategies: list[str] = []
+    total_edges = 0
+    first_zombie: str | None = None
+    first_zombie_depth: int | None = None
+
+    for i, node in enumerate(chain):
+        meta = graph.metadata.get(node, {})
+        dm = meta.get("discovery_mutation", {})
+        strategy = dm.get("strategy", "?")
+        strategies.append(strategy)
+
+        # Count edges from baseline coverage
+        bc = meta.get("baseline_coverage", {})
+        for harness_data in bc.values():
+            if isinstance(harness_data, dict):
+                total_edges += len(harness_data.get("edges", []))
+
+        # Check for zombie traces
+        jit_stats = dm.get("jit_stats", {})
+        if first_zombie is None and jit_stats.get("zombie_traces", 0) > 0:
+            first_zombie = node
+            first_zombie_depth = i
+
+    strategy_path = " → ".join(strategies)
+
+    print(f"Lineage for {target} (depth={depth}):", file=sys.stderr)
+    print(f"  Seed: {seed}", file=sys.stderr)
+    print(f"  Path: {' → '.join(chain)}", file=sys.stderr)
+    print(f"  Strategies: {strategy_path}", file=sys.stderr)
+    print(f"  Total edges discovered along path: {total_edges}", file=sys.stderr)
+    if first_zombie is not None:
+        print(
+            f"  Zombie traces first appeared at: {first_zombie} (depth={first_zombie_depth})",
+            file=sys.stderr,
+        )
+
+
+def print_descendants_stats(subgraph: Subgraph, graph: LineageGraph) -> None:
+    """Print descendants-mode statistics to stderr."""
+    seed_count = 0
+    mutation_count = 0
+    depths: list[int] = []
+    strategy_counts: dict[str, int] = defaultdict(int)
+    fertile_count = 0
+    sterile_count = 0
+    zombie_count = 0
+    tachycardia_count = 0
+
+    real_nodes = [n for n in subgraph.nodes if not n.startswith("__collapsed_")]
+    for node in real_nodes:
+        meta = graph.metadata.get(node, {})
+        if not meta:
+            continue
+
+        parent_id = meta.get("parent_id")
+        if parent_id is None:
+            seed_count += 1
+        else:
+            mutation_count += 1
+
+        depths.append(meta.get("lineage_depth", 0))
+
+        dm = meta.get("discovery_mutation", {})
+        strategy = dm.get("strategy", "unknown")
+        strategy_counts[strategy] += 1
+
+        total_finds = meta.get("total_finds", 0)
+        if total_finds >= FERTILE_THRESHOLD:
+            fertile_count += 1
+        if meta.get("is_sterile", False):
+            sterile_count += 1
+
+        jit_stats = dm.get("jit_stats", {})
+        if jit_stats.get("zombie_traces", 0) > 0:
+            zombie_count += 1
+        if jit_stats.get("max_exit_density", 0.0) > 0.1:
+            tachycardia_count += 1
+
+    # Add collapsed counts to sterile
+    for count in subgraph.collapsed.values():
+        sterile_count += count
+
+    total_nodes = len(real_nodes) + sum(subgraph.collapsed.values())
+    max_depth = max(depths) if depths else 0
+    mean_depth = sum(depths) / len(depths) if depths else 0.0
+
+    fertile_pct = (fertile_count / total_nodes * 100) if total_nodes else 0.0
+    sterile_pct = (sterile_count / total_nodes * 100) if total_nodes else 0.0
+
+    strategy_str = ", ".join(f"{k}={v}" for k, v in sorted(strategy_counts.items()))
+
+    print("Lineage Statistics:", file=sys.stderr)
+    print(
+        f"  Nodes: {total_nodes} ({seed_count} seeds, {mutation_count} mutations)", file=sys.stderr
+    )
+    print(f"  Depth: max={max_depth}, mean={mean_depth:.1f}", file=sys.stderr)
+    print(f"  Strategies: {strategy_str}", file=sys.stderr)
+    print(f"  Fertile nodes: {fertile_count} ({fertile_pct:.0f}%)", file=sys.stderr)
+    print(f"  Sterile nodes: {sterile_count} ({sterile_pct:.0f}%)", file=sys.stderr)
+    print(f"  Zombie traces: {zombie_count} nodes", file=sys.stderr)
+    print(f"  Tachycardia events: {tachycardia_count} nodes", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Target resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_target(target_str: str, per_file_coverage: dict[str, dict]) -> tuple[str, str]:
+    """Resolve a CLI target argument to a corpus filename and mode hint.
+
+    Handles:
+    - Plain corpus filenames: "1234.py" → ("1234.py", "file")
+    - Corpus file paths: "corpus/jit_interesting_tests/1234.py" → ("1234.py", "file")
+    - Crash directory paths: "crashes/session_crash_..." → resolved from metadata
+
+    Returns (corpus_filename, target_type) where target_type is "file" or "crash_dir".
+    """
+    target_path = Path(target_str)
+
+    # Check if it's a crash directory
+    metadata_json = target_path / "metadata.json"
+    if target_path.is_dir() and metadata_json.exists():
+        with open(metadata_json) as f:
+            crash_meta = json.load(f)
+        # Try session_corpus_files first, then parent_id
+        session_files = crash_meta.get("session_corpus_files", {})
+        warmup = session_files.get("warmup")
+        if warmup:
+            if warmup not in per_file_coverage:
+                print(
+                    f"Error: crash warmup file '{warmup}' not found in coverage state.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            return warmup, "crash_dir"
+        parent_id = crash_meta.get("parent_id")
+        if parent_id:
+            if parent_id not in per_file_coverage:
+                print(
+                    f"Error: crash parent '{parent_id}' not found in coverage state.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            return parent_id, "crash_dir"
+        print(
+            f"Error: crash metadata in '{target_str}' has no parent_id or session_corpus_files.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Extract basename from file path
+    filename = target_path.name if target_path.suffix else target_str
+
+    if filename not in per_file_coverage:
+        print(f"Error: '{filename}' not found in coverage state.", file=sys.stderr)
+        sys.exit(1)
+
+    return filename, "file"
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Main entry point for lafleur-lineage."""
+    parser = argparse.ArgumentParser(
+        description="Visualize corpus lineage trees from coverage_state.pkl.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s ancestry 1234.py                      # Trace a file back to its seed
+  %(prog)s ancestry crashes/session_crash_XXX/    # Trace a crash's lineage
+  %(prog)s descendants 0001.py                    # Show a seed's family tree
+  %(prog)s descendants 0001.py --max-depth 5      # Limit depth
+  %(prog)s descendants 0001.py --render -o tree.png  # Render to PNG
+        """,
+    )
+
+    # Common options
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=Path("coverage/coverage_state.pkl"),
+        help="Path to coverage_state.pkl",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--render",
+        action="store_true",
+        help="Render to image via Graphviz (requires dot)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Image format for --render (default: png)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of DOT")
+    parser.add_argument("--no-color", action="store_true", help="Monochrome output")
+    parser.add_argument(
+        "--label-style",
+        choices=["minimal", "standard", "verbose"],
+        default="standard",
+        help="Node label detail level",
+    )
+    parser.add_argument(
+        "--highlight",
+        type=str,
+        default=None,
+        help="Highlight a specific file and its path to root",
+    )
+    parser.add_argument(
+        "--layout",
+        choices=["LR", "TB"],
+        default="LR",
+        help="Graph direction (default: LR)",
+    )
+
+    subparsers = parser.add_subparsers(dest="mode", help="Visualization mode")
+
+    # Ancestry subcommand
+    ancestry_parser = subparsers.add_parser(
+        "ancestry", help="Trace a file's lineage back to its seed"
+    )
+    ancestry_parser.add_argument("target", help="Corpus filename, file path, or crash directory")
+
+    # Descendants subcommand
+    desc_parser = subparsers.add_parser("descendants", help="Show what a file produced")
+    desc_parser.add_argument("root", help="Corpus filename or file path")
+    desc_parser.add_argument("--max-depth", type=int, default=None, help="Maximum tree depth")
+    desc_parser.add_argument(
+        "--no-collapse-sterile",
+        action="store_true",
+        help="Don't collapse sterile leaf clusters",
+    )
+
+    args = parser.parse_args()
+
+    if args.mode is None:
+        parser.print_help()
+        sys.exit(0)
+
+    # Load state
+    state = load_coverage_state(args.state_path)
+    per_file_coverage = state.get("per_file_coverage", {})
+
+    # Build graph
+    graph = build_adjacency_graph(per_file_coverage)
+
+    # Extract subgraph based on mode
+    if args.mode == "ancestry":
+        target, _ = resolve_target(args.target, per_file_coverage)
+        subgraph = extract_ancestry(graph, target)
+        # Build ordered chain for stats
+        chain = _extract_ancestry_chain(graph, target)
+    elif args.mode == "descendants":
+        root, _ = resolve_target(args.root, per_file_coverage)
+        subgraph = extract_descendants(
+            graph,
+            root,
+            max_depth=args.max_depth,
+            collapse_sterile=not args.no_collapse_sterile,
+        )
+        chain = None
+    else:
+        parser.print_help()
+        sys.exit(0)
+
+    # Decorate
+    decorated = decorate(subgraph, graph, label_style=args.label_style, no_color=args.no_color)
+    decorated.graph_attrs["rankdir"] = args.layout
+
+    # Emit
+    if args.json:
+        output = emit_json(decorated, graph, subgraph)
+    else:
+        output = emit_dot(decorated)
+
+    # Render or write
+    if args.render:
+        output_path = args.output or Path(f"lineage.{args.format}")
+        # Always render from DOT, even if --json was requested
+        dot_output = emit_dot(decorated)
+        success = render_graphviz(dot_output, output_path, fmt=args.format)
+        if success:
+            print(f"Rendered to {output_path}", file=sys.stderr)
+        else:
+            sys.exit(1)
+    elif args.output:
+        args.output.write_text(output)
+    else:
+        print(output)
+
+    # Print statistics to stderr
+    if args.mode == "ancestry" and chain is not None:
+        print_ancestry_stats(chain, graph)
+    elif args.mode == "descendants":
+        print_descendants_stats(subgraph, graph)
+
+
+def _extract_ancestry_chain(graph: LineageGraph, target: str) -> list[str]:
+    """Extract ordered ancestry chain (seed first, target last) for stats."""
+    chain: list[str] = []
+    current = target
+    visited: set[str] = set()
+
+    for _ in range(ANCESTRY_DEPTH_LIMIT):
+        if current in visited:
+            break
+        visited.add(current)
+        chain.append(current)
+
+        if current not in graph.metadata:
+            break
+
+        parent_id = graph.parent.get(current)
+        if parent_id is None:
+            break
+        current = parent_id
+
+    chain.reverse()
+    return chain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ lafleur-report = "lafleur.report:main"
 lafleur-campaign = "lafleur.campaign:main"
 lafleur-triage = "lafleur.triage:main"
 lafleur-driver = "lafleur.driver:main"
+lafleur-lineage = "lafleur.lineage:main"
 
 
 [tool.mypy]

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,860 @@
+"""Tests for lafleur.lineage — corpus lineage visualization tool."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lafleur.lineage import (
+    COLOR_COLLAPSED,
+    COLOR_GHOST,
+    COLOR_SEED,
+    BORDER_TACHYCARDIA,
+    BORDER_ZOMBIE,
+    STRATEGY_COLORS,
+    build_adjacency_graph,
+    decorate,
+    emit_dot,
+    emit_json,
+    extract_ancestry,
+    extract_descendants,
+    print_ancestry_stats,
+    print_descendants_stats,
+    render_graphviz,
+    resolve_target,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_simple_chain() -> dict:
+    """Create a 3-node chain: seed → middle → leaf."""
+    return {
+        "seed.py": {
+            "parent_id": None,
+            "lineage_depth": 0,
+            "total_finds": 2,
+            "mutations_since_last_find": 10,
+            "total_mutations_against": 50,
+            "is_sterile": False,
+            "is_pruned": False,
+            "discovery_mutation": {
+                "strategy": "generative_seed",
+                "transformers": [],
+                "jit_stats": {},
+            },
+            "discovery_time": "2025-01-01T00:00:00Z",
+            "execution_time_ms": 100,
+            "file_size_bytes": 500,
+            "baseline_coverage": {"h1": {"edges": [1, 2], "uops": [10], "rare_events": []}},
+        },
+        "middle.py": {
+            "parent_id": "seed.py",
+            "lineage_depth": 1,
+            "total_finds": 1,
+            "mutations_since_last_find": 5,
+            "total_mutations_against": 20,
+            "is_sterile": False,
+            "is_pruned": False,
+            "discovery_mutation": {
+                "strategy": "havoc",
+                "transformers": ["OperatorSwapMutator", "GuardInjector"],
+                "jit_stats": {"max_exit_density": 0.05, "zombie_traces": 0},
+            },
+            "discovery_time": "2025-01-01T01:00:00Z",
+            "execution_time_ms": 150,
+            "file_size_bytes": 800,
+            "baseline_coverage": {"h1": {"edges": [1, 2, 3], "uops": [10, 11], "rare_events": []}},
+        },
+        "leaf.py": {
+            "parent_id": "middle.py",
+            "lineage_depth": 2,
+            "total_finds": 0,
+            "mutations_since_last_find": 100,
+            "total_mutations_against": 100,
+            "is_sterile": True,
+            "is_pruned": False,
+            "discovery_mutation": {
+                "strategy": "sniper",
+                "transformers": ["SniperMutator"],
+                "jit_stats": {"max_exit_density": 0.3, "zombie_traces": 2},
+            },
+            "discovery_time": "2025-01-01T02:00:00Z",
+            "execution_time_ms": 200,
+            "file_size_bytes": 1200,
+            "baseline_coverage": {
+                "h1": {
+                    "edges": [1, 2, 3, 4],
+                    "uops": [10, 11, 12],
+                    "rare_events": [100],
+                }
+            },
+        },
+    }
+
+
+def make_branching_tree() -> dict:
+    """Create a tree: seed → [child_a, child_b, child_c, child_d, child_e]
+    where child_c, child_d, child_e are sterile leaves.
+    child_a has two children of its own.
+    """
+    base = {
+        "strategy": "havoc",
+        "transformers": ["OpSwap"],
+        "jit_stats": {"max_exit_density": 0.01, "zombie_traces": 0},
+    }
+    return {
+        "seed.py": {
+            "parent_id": None,
+            "lineage_depth": 0,
+            "total_finds": 10,
+            "total_mutations_against": 200,
+            "is_sterile": False,
+            "is_pruned": False,
+            "discovery_mutation": {
+                "strategy": "generative_seed",
+                "transformers": [],
+                "jit_stats": {},
+            },
+            "discovery_time": "2025-01-01T00:00:00Z",
+            "execution_time_ms": 100,
+            "file_size_bytes": 500,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 0,
+        },
+        "child_a.py": {
+            "parent_id": "seed.py",
+            "lineage_depth": 1,
+            "total_finds": 3,
+            "total_mutations_against": 50,
+            "is_sterile": False,
+            "is_pruned": False,
+            "discovery_mutation": base,
+            "discovery_time": "2025-01-01T01:00:00Z",
+            "execution_time_ms": 120,
+            "file_size_bytes": 600,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 0,
+        },
+        "child_b.py": {
+            "parent_id": "seed.py",
+            "lineage_depth": 1,
+            "total_finds": 1,
+            "total_mutations_against": 30,
+            "is_sterile": False,
+            "is_pruned": False,
+            "discovery_mutation": base,
+            "discovery_time": "2025-01-01T01:01:00Z",
+            "execution_time_ms": 110,
+            "file_size_bytes": 550,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 0,
+        },
+        "child_c.py": {
+            "parent_id": "seed.py",
+            "lineage_depth": 1,
+            "total_finds": 0,
+            "total_mutations_against": 100,
+            "is_sterile": True,
+            "is_pruned": False,
+            "discovery_mutation": base,
+            "discovery_time": "2025-01-01T01:02:00Z",
+            "execution_time_ms": 90,
+            "file_size_bytes": 400,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 100,
+        },
+        "child_d.py": {
+            "parent_id": "seed.py",
+            "lineage_depth": 1,
+            "total_finds": 0,
+            "total_mutations_against": 80,
+            "is_sterile": True,
+            "is_pruned": False,
+            "discovery_mutation": base,
+            "discovery_time": "2025-01-01T01:03:00Z",
+            "execution_time_ms": 85,
+            "file_size_bytes": 380,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 80,
+        },
+        "child_e.py": {
+            "parent_id": "seed.py",
+            "lineage_depth": 1,
+            "total_finds": 0,
+            "total_mutations_against": 90,
+            "is_sterile": True,
+            "is_pruned": False,
+            "discovery_mutation": base,
+            "discovery_time": "2025-01-01T01:04:00Z",
+            "execution_time_ms": 95,
+            "file_size_bytes": 420,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 90,
+        },
+        "grandchild_1.py": {
+            "parent_id": "child_a.py",
+            "lineage_depth": 2,
+            "total_finds": 0,
+            "total_mutations_against": 10,
+            "is_sterile": True,
+            "is_pruned": False,
+            "discovery_mutation": {
+                "strategy": "sniper",
+                "transformers": ["SniperMutator"],
+                "jit_stats": {"max_exit_density": 0.02, "zombie_traces": 0},
+            },
+            "discovery_time": "2025-01-01T02:00:00Z",
+            "execution_time_ms": 200,
+            "file_size_bytes": 1000,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 10,
+        },
+        "grandchild_2.py": {
+            "parent_id": "child_a.py",
+            "lineage_depth": 2,
+            "total_finds": 0,
+            "total_mutations_against": 15,
+            "is_sterile": False,
+            "is_pruned": False,
+            "discovery_mutation": {
+                "strategy": "spam",
+                "transformers": ["SpamMutator"],
+                "jit_stats": {"max_exit_density": 0.01, "zombie_traces": 0},
+            },
+            "discovery_time": "2025-01-01T02:01:00Z",
+            "execution_time_ms": 180,
+            "file_size_bytes": 900,
+            "baseline_coverage": {},
+            "mutations_since_last_find": 5,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# TestBuildAdjacencyGraph
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAdjacencyGraph(unittest.TestCase):
+    def test_basic_chain(self):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+
+        self.assertEqual(graph.parent["seed.py"], None)
+        self.assertEqual(graph.parent["middle.py"], "seed.py")
+        self.assertEqual(graph.parent["leaf.py"], "middle.py")
+        self.assertIn("middle.py", graph.children["seed.py"])
+        self.assertIn("leaf.py", graph.children["middle.py"])
+        self.assertEqual(graph.roots, ["seed.py"])
+        self.assertEqual(graph.metadata, pfc)
+
+    def test_branching_tree(self):
+        pfc = make_branching_tree()
+        graph = build_adjacency_graph(pfc)
+
+        children_of_seed = graph.children["seed.py"]
+        self.assertEqual(len(children_of_seed), 5)
+        children_of_a = graph.children["child_a.py"]
+        self.assertEqual(len(children_of_a), 2)
+
+    def test_with_tombstone(self):
+        pfc = make_simple_chain()
+        # Make middle a tombstone
+        pfc["middle.py"]["is_pruned"] = True
+        graph = build_adjacency_graph(pfc)
+
+        # Tombstones participate in parent/children but not roots
+        self.assertIn("middle.py", graph.parent)
+        self.assertIn("leaf.py", graph.children["middle.py"])
+        self.assertNotIn("middle.py", graph.roots)
+
+    def test_empty_corpus(self):
+        graph = build_adjacency_graph({})
+
+        self.assertEqual(graph.children, {})
+        self.assertEqual(graph.parent, {})
+        self.assertEqual(graph.roots, [])
+
+    def test_orphaned_file(self):
+        """File with parent_id referencing nonexistent file doesn't crash."""
+        pfc = {
+            "orphan.py": {
+                "parent_id": "nonexistent.py",
+                "lineage_depth": 1,
+                "is_pruned": False,
+                "discovery_mutation": {"strategy": "havoc", "transformers": [], "jit_stats": {}},
+            }
+        }
+        graph = build_adjacency_graph(pfc)
+        self.assertEqual(graph.parent["orphan.py"], "nonexistent.py")
+        self.assertIn("orphan.py", graph.children["nonexistent.py"])
+        self.assertEqual(graph.roots, [])
+
+    def test_children_sorted(self):
+        """Children lists are sorted by filename for determinism."""
+        pfc = {
+            "seed.py": {
+                "parent_id": None,
+                "is_pruned": False,
+                "discovery_mutation": {},
+            },
+            "z.py": {
+                "parent_id": "seed.py",
+                "is_pruned": False,
+                "discovery_mutation": {},
+            },
+            "a.py": {
+                "parent_id": "seed.py",
+                "is_pruned": False,
+                "discovery_mutation": {},
+            },
+            "m.py": {
+                "parent_id": "seed.py",
+                "is_pruned": False,
+                "discovery_mutation": {},
+            },
+        }
+        graph = build_adjacency_graph(pfc)
+        self.assertEqual(graph.children["seed.py"], ["a.py", "m.py", "z.py"])
+
+
+# ---------------------------------------------------------------------------
+# TestExtractAncestry
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAncestry(unittest.TestCase):
+    def test_simple_chain(self):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_ancestry(graph, "leaf.py")
+
+        self.assertEqual(sub.nodes, {"seed.py", "middle.py", "leaf.py"})
+        self.assertEqual(sub.edges, [("seed.py", "middle.py"), ("middle.py", "leaf.py")])
+
+    def test_seed_only(self):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_ancestry(graph, "seed.py")
+
+        self.assertEqual(sub.nodes, {"seed.py"})
+        self.assertEqual(sub.edges, [])
+
+    def test_ghost_node_with_tombstone(self):
+        """Ghost node inserted for missing parent that has tombstone metadata."""
+        pfc = make_simple_chain()
+        # Remove middle from metadata but keep its parent_id reference in leaf
+        del pfc["middle.py"]
+        graph = build_adjacency_graph(pfc)
+
+        sub = extract_ancestry(graph, "leaf.py")
+        self.assertIn("middle.py", sub.nodes)
+        self.assertEqual(sub.special_nodes["middle.py"], "ghost")
+
+    def test_ghost_node_no_tombstone(self):
+        """Ghost node for completely missing file terminates the chain."""
+        pfc = {
+            "leaf.py": {
+                "parent_id": "ghost.py",
+                "lineage_depth": 1,
+                "is_pruned": False,
+                "discovery_mutation": {"strategy": "havoc", "transformers": [], "jit_stats": {}},
+            }
+        }
+        graph = build_adjacency_graph(pfc)
+        sub = extract_ancestry(graph, "leaf.py")
+
+        self.assertIn("ghost.py", sub.nodes)
+        self.assertEqual(sub.special_nodes["ghost.py"], "ghost")
+        # Chain terminates at ghost
+        self.assertEqual(len(sub.nodes), 2)
+
+    def test_depth_limit(self):
+        """Chain of 250 nodes — ancestry walk is capped at ANCESTRY_DEPTH_LIMIT."""
+        pfc = {}
+        for i in range(250):
+            name = f"{i:04d}.py"
+            parent = f"{i - 1:04d}.py" if i > 0 else None
+            pfc[name] = {
+                "parent_id": parent,
+                "lineage_depth": i,
+                "is_pruned": False,
+                "discovery_mutation": {"strategy": "havoc", "transformers": [], "jit_stats": {}},
+            }
+        graph = build_adjacency_graph(pfc)
+        sub = extract_ancestry(graph, "0249.py")
+
+        # Should be capped at ~200 nodes (ANCESTRY_DEPTH_LIMIT)
+        self.assertLessEqual(len(sub.nodes), 201)
+
+
+# ---------------------------------------------------------------------------
+# TestExtractDescendants
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDescendants(unittest.TestCase):
+    def test_simple_chain(self):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=False)
+
+        self.assertEqual(sub.nodes, {"seed.py", "middle.py", "leaf.py"})
+
+    def test_max_depth(self):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", max_depth=1, collapse_sterile=False)
+
+        # depth=0 is seed, depth=1 explores children of seed only
+        self.assertIn("seed.py", sub.nodes)
+        self.assertIn("middle.py", sub.nodes)
+        self.assertNotIn("leaf.py", sub.nodes)
+
+    def test_sterile_collapsing(self):
+        """Tree with 3 sterile childless siblings → collapsed into one summary."""
+        pfc = make_branching_tree()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=True)
+
+        # child_c, child_d, child_e are sterile and childless BUT
+        # child_a and child_b are also children of seed, so only the sterile ones collapse
+        collapsed_keys = list(sub.collapsed.keys())
+        self.assertEqual(len(collapsed_keys), 1)
+        self.assertEqual(list(sub.collapsed.values())[0], 3)
+
+        # The individual sterile nodes should be gone
+        self.assertNotIn("child_c.py", sub.nodes)
+        self.assertNotIn("child_d.py", sub.nodes)
+        self.assertNotIn("child_e.py", sub.nodes)
+
+    def test_sterile_collapsing_threshold(self):
+        """Only 2 sterile siblings → NOT collapsed."""
+        pfc = make_branching_tree()
+        # Remove one sterile child
+        del pfc["child_e.py"]
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=True)
+
+        # child_c and child_d remain (only 2, below threshold of 3)
+        self.assertIn("child_c.py", sub.nodes)
+        self.assertIn("child_d.py", sub.nodes)
+        self.assertEqual(len(sub.collapsed), 0)
+
+    def test_collapsing_disabled(self):
+        pfc = make_branching_tree()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=False)
+
+        # All sterile nodes preserved
+        self.assertIn("child_c.py", sub.nodes)
+        self.assertIn("child_d.py", sub.nodes)
+        self.assertIn("child_e.py", sub.nodes)
+
+    def test_from_non_root(self):
+        pfc = make_branching_tree()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "child_a.py", collapse_sterile=False)
+
+        self.assertIn("child_a.py", sub.nodes)
+        self.assertIn("grandchild_1.py", sub.nodes)
+        self.assertIn("grandchild_2.py", sub.nodes)
+        self.assertNotIn("seed.py", sub.nodes)
+
+
+# ---------------------------------------------------------------------------
+# TestDecorate
+# ---------------------------------------------------------------------------
+
+
+class TestDecorate(unittest.TestCase):
+    def _make_graph_and_subgraph(self, pfc=None):
+        pfc = pfc or make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=False)
+        return graph, sub
+
+    def test_seed_node_styling(self):
+        graph, sub = self._make_graph_and_subgraph()
+        decorated = decorate(sub, graph)
+
+        seed_style = decorated.nodes["seed.py"]
+        self.assertEqual(seed_style.shape, "doubleoctagon")
+        self.assertEqual(seed_style.fillcolor, COLOR_SEED)
+
+    def test_sterile_node_styling(self):
+        graph, sub = self._make_graph_and_subgraph()
+        decorated = decorate(sub, graph)
+
+        leaf_style = decorated.nodes["leaf.py"]
+        # leaf.py is sterile BUT also has zombie+tachycardia overlays
+        # The fill is sterile since sterile takes priority over normal
+        # But zombie border overrides to BORDER_ZOMBIE... then tachycardia overrides
+        self.assertIn("dashed", leaf_style.style)
+
+    def test_fertile_node_styling(self):
+        pfc = make_branching_tree()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=False)
+        decorated = decorate(sub, graph)
+
+        # seed has 10 finds (≥ FERTILE_THRESHOLD=5) but is also a seed → seed wins
+        seed_style = decorated.nodes["seed.py"]
+        self.assertEqual(seed_style.shape, "doubleoctagon")
+
+    def test_zombie_border(self):
+        graph, sub = self._make_graph_and_subgraph()
+        decorated = decorate(sub, graph)
+
+        # leaf.py has zombie_traces=2
+        leaf_style = decorated.nodes["leaf.py"]
+        # Tachycardia (0.3 > 0.1) applies after zombie, overriding color
+        # Both zombie and tachycardia are checked but tachycardia overwrites
+        self.assertIn(leaf_style.color, [BORDER_ZOMBIE, BORDER_TACHYCARDIA])
+        self.assertGreater(leaf_style.penwidth, 1.0)
+
+    def test_ghost_node_styling(self):
+        pfc = {
+            "leaf.py": {
+                "parent_id": "ghost.py",
+                "lineage_depth": 1,
+                "is_pruned": False,
+                "discovery_mutation": {"strategy": "havoc", "transformers": [], "jit_stats": {}},
+            }
+        }
+        graph = build_adjacency_graph(pfc)
+        sub = extract_ancestry(graph, "leaf.py")
+        decorated = decorate(sub, graph)
+
+        ghost_style = decorated.nodes["ghost.py"]
+        self.assertEqual(ghost_style.style, "dotted")
+        self.assertEqual(ghost_style.fontcolor, "gray")
+        self.assertEqual(ghost_style.fillcolor, COLOR_GHOST)
+        self.assertIn("[pruned]", ghost_style.label)
+
+    def test_collapsed_node_styling(self):
+        pfc = make_branching_tree()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=True)
+        decorated = decorate(sub, graph)
+
+        # Find the collapsed node
+        collapsed_nodes = [n for n in decorated.nodes if n.startswith("__collapsed_")]
+        self.assertEqual(len(collapsed_nodes), 1)
+        ns = decorated.nodes[collapsed_nodes[0]]
+        self.assertEqual(ns.shape, "note")
+        self.assertEqual(ns.fillcolor, COLOR_COLLAPSED)
+        self.assertIn("sterile leaves", ns.label)
+
+    def test_edge_colors(self):
+        graph, sub = self._make_graph_and_subgraph()
+        decorated = decorate(sub, graph)
+
+        edge_map = {(p, c): es for p, c, es in decorated.edges}
+        # middle.py was created by "havoc"
+        havoc_edge = edge_map.get(("seed.py", "middle.py"))
+        self.assertIsNotNone(havoc_edge)
+        self.assertEqual(havoc_edge.color, STRATEGY_COLORS["havoc"])
+
+        # leaf.py was created by "sniper"
+        sniper_edge = edge_map.get(("middle.py", "leaf.py"))
+        self.assertIsNotNone(sniper_edge)
+        self.assertEqual(sniper_edge.color, STRATEGY_COLORS["sniper"])
+
+    def test_label_style_minimal(self):
+        graph, sub = self._make_graph_and_subgraph()
+        decorated = decorate(sub, graph, label_style="minimal")
+
+        # Minimal: just the filename
+        self.assertEqual(decorated.nodes["seed.py"].label, "seed.py")
+        self.assertEqual(decorated.nodes["middle.py"].label, "middle.py")
+
+    def test_label_style_standard(self):
+        graph, sub = self._make_graph_and_subgraph()
+        decorated = decorate(sub, graph, label_style="standard")
+
+        label = decorated.nodes["middle.py"].label
+        self.assertIn("middle.py", label)
+        self.assertIn("havoc", label)
+        self.assertIn("depth=1", label)
+
+    def test_no_color(self):
+        graph, sub = self._make_graph_and_subgraph()
+        decorated = decorate(sub, graph, no_color=True)
+
+        for ns in decorated.nodes.values():
+            self.assertEqual(ns.fillcolor, "white")
+            self.assertEqual(ns.fontcolor, "black")
+        for _, _, es in decorated.edges:
+            self.assertEqual(es.color, "black")
+
+
+# ---------------------------------------------------------------------------
+# TestEmitDot
+# ---------------------------------------------------------------------------
+
+
+class TestEmitDot(unittest.TestCase):
+    def _make_decorated(self):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=False)
+        return decorate(sub, graph)
+
+    def test_basic_structure(self):
+        dot = emit_dot(self._make_decorated())
+        self.assertTrue(dot.startswith("digraph lineage {"))
+        self.assertTrue(dot.rstrip().endswith("}"))
+
+    def test_nodes_emitted(self):
+        dot = emit_dot(self._make_decorated())
+        self.assertIn('"seed.py"', dot)
+        self.assertIn('"middle.py"', dot)
+        self.assertIn('"leaf.py"', dot)
+
+    def test_edges_emitted(self):
+        dot = emit_dot(self._make_decorated())
+        self.assertIn('"seed.py" -> "middle.py"', dot)
+        self.assertIn('"middle.py" -> "leaf.py"', dot)
+
+    def test_edge_labels(self):
+        dot = emit_dot(self._make_decorated())
+        # Edges should have strategy labels
+        self.assertIn("havoc", dot)
+        self.assertIn("sniper", dot)
+
+    def test_tooltips_included(self):
+        dot = emit_dot(self._make_decorated())
+        self.assertIn("tooltip=", dot)
+
+
+# ---------------------------------------------------------------------------
+# TestEmitJson
+# ---------------------------------------------------------------------------
+
+
+class TestEmitJson(unittest.TestCase):
+    def _make_json_output(self):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=False)
+        decorated = decorate(sub, graph)
+        return emit_json(decorated, graph, sub)
+
+    def test_valid_json(self):
+        output = self._make_json_output()
+        data = json.loads(output)
+        self.assertIsInstance(data, dict)
+
+    def test_schema(self):
+        data = json.loads(self._make_json_output())
+        self.assertIn("nodes", data)
+        self.assertIn("edges", data)
+        self.assertIn("statistics", data)
+
+    def test_node_entries(self):
+        data = json.loads(self._make_json_output())
+        for node in data["nodes"]:
+            self.assertIn("id", node)
+            self.assertIn("metadata", node)
+            self.assertIn("style", node)
+
+    def test_edge_entries(self):
+        data = json.loads(self._make_json_output())
+        for edge in data["edges"]:
+            self.assertIn("source", edge)
+            self.assertIn("target", edge)
+            self.assertIn("style", edge)
+
+
+# ---------------------------------------------------------------------------
+# TestResolveTarget
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTarget(unittest.TestCase):
+    def test_plain_filename(self):
+        pfc = {"1234.py": {"parent_id": None}}
+        filename, target_type = resolve_target("1234.py", pfc)
+        self.assertEqual(filename, "1234.py")
+        self.assertEqual(target_type, "file")
+
+    def test_path_to_file(self):
+        pfc = {"1234.py": {"parent_id": None}}
+        filename, target_type = resolve_target("corpus/jit_interesting_tests/1234.py", pfc)
+        self.assertEqual(filename, "1234.py")
+        self.assertEqual(target_type, "file")
+
+    def test_nonexistent_file(self):
+        pfc = {"1234.py": {"parent_id": None}}
+        with self.assertRaises(SystemExit):
+            resolve_target("nonexistent.py", pfc)
+
+    def test_crash_directory(self, *_args):
+        """Crash directory with metadata.json resolves to warmup file."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            crash_dir = Path(tmpdir) / "crash_001"
+            crash_dir.mkdir()
+            meta = {"session_corpus_files": {"warmup": "parent.py"}}
+            (crash_dir / "metadata.json").write_text(json.dumps(meta))
+
+            pfc = {"parent.py": {"parent_id": None}}
+            filename, target_type = resolve_target(str(crash_dir), pfc)
+            self.assertEqual(filename, "parent.py")
+            self.assertEqual(target_type, "crash_dir")
+
+
+# ---------------------------------------------------------------------------
+# TestRenderGraphviz
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGraphviz(unittest.TestCase):
+    @patch("lafleur.lineage.shutil.which", return_value=None)
+    def test_dot_not_installed(self, mock_which):
+        result = render_graphviz("digraph {}", Path("out.png"))
+        self.assertFalse(result)
+
+    @patch("lafleur.lineage.subprocess.run")
+    @patch("lafleur.lineage.shutil.which", return_value="/usr/bin/dot")
+    def test_correct_command_args(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        result = render_graphviz("digraph {}", Path("out.svg"), fmt="svg")
+
+        self.assertTrue(result)
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        self.assertEqual(cmd, ["dot", "-Tsvg", "-o", "out.svg"])
+
+
+# ---------------------------------------------------------------------------
+# TestStatistics
+# ---------------------------------------------------------------------------
+
+
+class TestStatistics(unittest.TestCase):
+    @patch("sys.stderr")
+    def test_ancestry_stats(self, mock_stderr):
+        pfc = make_simple_chain()
+        graph = build_adjacency_graph(pfc)
+        chain = ["seed.py", "middle.py", "leaf.py"]
+        print_ancestry_stats(chain, graph)
+
+        output = "".join(call.args[0] for call in mock_stderr.write.call_args_list)
+        self.assertIn("Lineage for leaf.py", output)
+        self.assertIn("Seed: seed.py", output)
+        self.assertIn("depth=2", output)
+
+    @patch("sys.stderr")
+    def test_descendants_stats(self, mock_stderr):
+        pfc = make_branching_tree()
+        graph = build_adjacency_graph(pfc)
+        sub = extract_descendants(graph, "seed.py", collapse_sterile=False)
+        print_descendants_stats(sub, graph)
+
+        output = "".join(call.args[0] for call in mock_stderr.write.call_args_list)
+        self.assertIn("Lineage Statistics:", output)
+        self.assertIn("Nodes:", output)
+        self.assertIn("Strategies:", output)
+
+    @patch("sys.stderr")
+    def test_ancestry_stats_empty_chain(self, mock_stderr):
+        """Empty chain produces no output."""
+        graph = build_adjacency_graph({})
+        print_ancestry_stats([], graph)
+        mock_stderr.write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestCLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI(unittest.TestCase):
+    def test_no_mode_shows_help(self):
+        """No subcommand shows help and exits 0."""
+        with patch("sys.argv", ["lafleur-lineage"]):
+            from lafleur.lineage import main
+
+            with patch("sys.exit", side_effect=SystemExit(0)) as mock_exit:
+                with patch("argparse.ArgumentParser.print_help"):
+                    with self.assertRaises(SystemExit):
+                        main()
+                mock_exit.assert_called_with(0)
+
+    @patch("lafleur.lineage.load_coverage_state")
+    def test_ancestry_mode_e2e(self, mock_load):
+        """End-to-end ancestry mode produces DOT output."""
+        mock_load.return_value = {"per_file_coverage": make_simple_chain()}
+
+        with patch(
+            "sys.argv",
+            ["lafleur-lineage", "--state-path", "fake.pkl", "ancestry", "leaf.py"],
+        ):
+            from lafleur.lineage import main
+
+            with patch("builtins.print") as mock_print:
+                main()
+
+            # The first positional print call should be the DOT output
+            printed = mock_print.call_args_list
+            dot_calls = [c for c in printed if c.kwargs.get("file") is not sys.stderr]
+            self.assertTrue(any("digraph lineage" in str(c) for c in dot_calls))
+
+    @patch("lafleur.lineage.load_coverage_state")
+    def test_descendants_mode_e2e(self, mock_load):
+        """End-to-end descendants mode produces DOT output."""
+        mock_load.return_value = {"per_file_coverage": make_simple_chain()}
+
+        with patch(
+            "sys.argv",
+            ["lafleur-lineage", "--state-path", "fake.pkl", "descendants", "seed.py"],
+        ):
+            from lafleur.lineage import main
+
+            with patch("builtins.print") as mock_print:
+                main()
+
+            printed = mock_print.call_args_list
+            dot_calls = [c for c in printed if c.kwargs.get("file") is not sys.stderr]
+            self.assertTrue(any("digraph lineage" in str(c) for c in dot_calls))
+
+    @patch("lafleur.lineage.load_coverage_state")
+    def test_json_mode(self, mock_load):
+        """--json flag emits valid JSON."""
+        mock_load.return_value = {"per_file_coverage": make_simple_chain()}
+
+        with patch(
+            "sys.argv",
+            [
+                "lafleur-lineage",
+                "--state-path",
+                "fake.pkl",
+                "--json",
+                "descendants",
+                "seed.py",
+            ],
+        ):
+            from lafleur.lineage import main
+
+            with patch("builtins.print") as mock_print:
+                main()
+
+            printed = mock_print.call_args_list
+            json_calls = [c for c in printed if c.kwargs.get("file") is not sys.stderr]
+            # Should have at least one call with JSON content
+            json_output = str(json_calls[0])
+            self.assertIn("nodes", json_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `lafleur/lineage.py` — the core lineage visualization tool with graph construction, ancestry mode (trace file to seed), descendants mode (show what a file produced), DOT/JSON emission, Graphviz rendering, strategy-colored edges, ghost nodes for pruned intermediates, sterile leaf collapsing, and statistics output
- Registers `lafleur-lineage` CLI entry point in pyproject.toml
- 49 new tests in `tests/test_lineage.py` covering graph construction, ancestry/descendants extraction, decoration, DOT/JSON emission, target resolution, rendering, statistics, and CLI

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy lafleur/` passes
- [x] All 49 new tests pass
- [x] Full test suite (1516 tests) passes (1 pre-existing failure in test_jit_tuner unrelated to this PR)
- [x] CLI help works: `--help`, `ancestry --help`, `descendants --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)