### PR TITLE
feat(lineage): MRCA, Strahler, metrics, discoveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ All notable changes to this project should be documented in this file.
 - **Tombstone metadata** for pruned corpus files: pruning now retains a minimal metadata entry (`parent_id`, `discovery_mutation`, `lineage_depth`, `discovery_time`, `is_pruned: True`) instead of deleting entirely, preserving lineage graph connectivity for the lineage tool, by @devdanzin.
 - **Session corpus filenames** in crash metadata: session crash bundles now record the parent corpus filename and polluter IDs in `metadata.json` under `session_corpus_files`, enabling direct lineage-to-crash mapping without content-hash searching, by @devdanzin.
 - A `lafleur-lineage` CLI tool for corpus lineage visualization with ancestry mode (trace a file back to its seed) and descendants mode (show what a file produced), DOT/JSON output, optional Graphviz rendering, strategy-colored edges, ghost nodes for pruned intermediates, sterile leaf collapsing, and statistics summary, by @devdanzin.
+- MRCA mode for `lafleur-lineage`: find the most recent common ancestor of two or more corpus files, with Y-shaped subgraph extraction, disjoint seed detection, and blue-bordered MRCA node decoration, by @devdanzin.
+- Strahler stream order computation for structural analysis of lineage trees, with `--show-strahler` CLI flag, by @devdanzin.
+- Tree metrics for `lafleur-lineage`: branching factor, subtree sizes, imbalance (coefficient of variation), and success rate (exact with `total_mutations_against`, lower-bound fallback), with `--show-success-rate` CLI flag, by @devdanzin.
+- `--show-discoveries` flag for `lafleur-lineage` that labels edges with specific UOP edges and rare events discovered (ancestry/mrca modes), using reverse coverage maps for human-readable names, by @devdanzin.
+- Enriched JSON output for `lafleur-lineage` including per-node metrics (Strahler, subtree size, branching factor, imbalance, success rate) and per-edge discovery labels, by @devdanzin.
 
 ### Enhanced
 


### PR DESCRIPTION
## Summary
- Adds MRCA mode (`lafleur-lineage mrca`) to find the most recent common ancestor of 2+ corpus files, with Y-shaped subgraph extraction and disjoint seed detection
- Computes Strahler stream order, branching factor, subtree sizes, imbalance (CV), and success rate for structural analysis
- `--show-strahler`, `--show-success-rate`, `--show-discoveries` CLI flags for enriched node/edge labels
- Enriched JSON output with per-node metrics and per-edge discovery labels
- MRCA node gets blue border decoration; stats output for all three modes
- 32 new tests (81 total for lineage module)

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy lafleur/` passes
- [x] All 81 lineage tests pass
- [x] Full test suite (1931 tests) passes
- [x] `lafleur-lineage mrca --help` shows the new mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)