### PR TITLE
feat(lineage): multi-lineage, forest, HTML pan/zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ All notable changes to this project should be documented in this file.
 - Tree metrics for `lafleur-lineage`: branching factor, subtree sizes, imbalance (coefficient of variation), and success rate (exact with `total_mutations_against`, lower-bound fallback), with `--show-success-rate` CLI flag, by @devdanzin.
 - `--show-discoveries` flag for `lafleur-lineage` that labels edges with specific UOP edges and rare events discovered (ancestry/mrca modes), using reverse coverage maps for human-readable names, by @devdanzin.
 - Enriched JSON output for `lafleur-lineage` including per-node metrics (Strahler, subtree size, branching factor, imbalance, success rate) and per-edge discovery labels, by @devdanzin.
+- Multi-lineage session crash ancestry for `lafleur-lineage`: `--multi-lineage` traces all session scripts' lineages converging on a crash node, with role-based edge styling (warmup=thinner, polluter=dashed, convergence=bold), unresolved script nodes, and session ancestry statistics, by @devdanzin.
+- `--attack-only` flag for `lafleur-lineage` ancestry mode to trace only the attack script's lineage, ignoring warmup and polluter scripts, by @devdanzin.
+- Forest mode for `lafleur-lineage`: `forest` subcommand shows all lineage trees in the corpus with `--max-depth`, `--min-descendants`, `--min-strahler` filtering, `--no-collapse-sterile` option, and Strahler-based pruning of low-complexity branches, by @devdanzin.
+- HTML pan/zoom output for `lafleur-lineage`: `--html PATH` generates an interactive HTML file wrapping SVG with svg-pan-zoom.js for navigating large lineage graphs, by @devdanzin.
 
 ### Enhanced
 


### PR DESCRIPTION
## Summary
- Multi-lineage session crash ancestry: `--multi-lineage` traces all session scripts' lineages converging on a crash node with role-based edge styling
- Forest mode: `forest` subcommand with `--max-depth`, `--min-descendants`, `--min-strahler` filtering and Strahler-based pruning
- HTML pan/zoom output: `--html PATH` generates interactive HTML with svg-pan-zoom.js
- Session script resolution via `session_corpus_files` metadata or content hash fallback
- 34 new tests (115 total lineage tests, 1965 full suite)

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy lafleur/lineage.py` passes
- [x] All 115 lineage tests pass
- [x] Full test suite (1965 tests) passes
- [x] Multi-lineage decoration: warmup edges thinner, polluter dashed, convergence bold
- [x] Forest mode filters by min_descendants and min_strahler
- [x] HTML output contains DOCTYPE, SVG content, and svg-pan-zoom script
- [x] Unresolved session scripts appear as distinct yellow/dashed nodes
- [x] `resolve_target()` returns Path for crash directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)