### PR TITLE
feat: structured timeout metadata log (timeout_events.jsonl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ All notable changes to this project should be documented in this file.
 - Added complete `lafleur-lineage` section to TOOLING.md with modes, options, example workflow, and output formats, by @devdanzin.
 - Added seed generation and management guide (`doc/dev/11_seeding.md`) covering fusil integration, seeding workflow, hand-rolled seed templates, and best practices, by @devdanzin.
 - Cross-referenced `11_seeding.md` from CLAUDE.md, architecture overview, glossary (Fusil, Seed), and getting started guide, by @devdanzin.
+- A **TimeoutLogger** structured metadata system that logs every timeout event to `timeout_events.jsonl` with type, parent ID, mutation strategy, transformers, lineage depth, execution stage, and timeout duration, by @devdanzin.
+- A `load_timeout_summary()` reader function in campaign.py that aggregates timeout metadata into counters by type, parent, strategy, transformer, and execution stage, by @devdanzin.
+
+### Fixed
+
+- Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -17,7 +17,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import psutil
 from compression import zstd
@@ -53,6 +53,31 @@ CRASH_KEYWORDS = [
     "panic",
     "AddressSanitizer",
 ]
+
+
+class TimeoutLogger:
+    """Append-only JSONL logger for structured timeout metadata."""
+
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+
+    def record(self, metadata: dict[str, Any]) -> None:
+        """Append a single timeout event to the JSONL log.
+
+        Args:
+            metadata: Dictionary with timeout event fields. A timestamp is
+                added automatically if not already present.
+        """
+        if "timestamp" not in metadata:
+            metadata["timestamp"] = datetime.now(timezone.utc).isoformat()
+        try:
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(metadata) + "\n")
+        except OSError as e:
+            print(
+                f"  [!] Warning: Could not write timeout metadata: {e}",
+                file=sys.stderr,
+            )
 
 
 class ArtifactManager:
@@ -775,7 +800,7 @@ class TelemetryManager:
         # Add system resource metrics
         try:
             datapoint["system_load_1min"] = psutil.getloadavg()[0]
-        except (OSError, AttributeError):
+        except OSError, AttributeError:
             datapoint["system_load_1min"] = None
 
         datapoint["process_rss_mb"] = round(psutil.Process().memory_info().rss / (1024 * 1024), 2)

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -56,6 +56,19 @@ class CrashAttributionSummary(TypedDict):
     combined_strategy_scores: Counter[str]
 
 
+class TimeoutSummary(TypedDict):
+    """Aggregated timeout metadata from timeout_events.jsonl."""
+
+    total_timeouts: int
+    total_timeout_seconds: float
+    by_type: Counter[str]
+    by_parent: Counter[str]
+    by_strategy: Counter[str]
+    by_transformer: Counter[str]
+    by_stage: Counter[str]
+    sum_lineage_depth: int
+
+
 # Constants matching the learning system multipliers
 CRASH_DIRECT_WEIGHT = 5
 CRASH_LINEAGE_WEIGHT = 2
@@ -77,7 +90,7 @@ def load_json_file(path: Path) -> dict[str, Any] | None:
     try:
         with open(path, encoding="utf-8") as f:
             return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    except FileNotFoundError, json.JSONDecodeError, OSError:
         return None
 
 
@@ -140,6 +153,65 @@ def load_health_summary(health_log_path: Path) -> HealthSummary | None:
         "waste_event_count": waste_event_count,
         "crash_profile": crash_profile,
         "parent_offenders": parent_offenders,
+    }
+
+
+def load_timeout_summary(log_path: Path) -> TimeoutSummary | None:
+    """Load and aggregate timeout metadata from a JSONL log.
+
+    Args:
+        log_path: Path to the timeout_events.jsonl file.
+
+    Returns:
+        Aggregated timeout summary, or None if the file doesn't exist or is empty.
+    """
+    if not log_path.exists():
+        return None
+
+    total_timeouts = 0
+    total_timeout_seconds = 0.0
+    by_type: Counter[str] = Counter()
+    by_parent: Counter[str] = Counter()
+    by_strategy: Counter[str] = Counter()
+    by_transformer: Counter[str] = Counter()
+    by_stage: Counter[str] = Counter()
+    sum_lineage_depth = 0
+
+    try:
+        with open(log_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                total_timeouts += 1
+                total_timeout_seconds += event.get("timeout_seconds", 0)
+                by_type[event.get("type", "unknown")] += 1
+                by_parent[event.get("parent_id", "unknown")] += 1
+                by_strategy[event.get("strategy", "unknown")] += 1
+                for transformer in event.get("transformers", []):
+                    by_transformer[transformer] += 1
+                by_stage[event.get("execution_stage", "unknown")] += 1
+                sum_lineage_depth += event.get("lineage_depth", 0)
+    except OSError:
+        return None
+
+    if total_timeouts == 0:
+        return None
+
+    return {
+        "total_timeouts": total_timeouts,
+        "total_timeout_seconds": total_timeout_seconds,
+        "by_type": by_type,
+        "by_parent": by_parent,
+        "by_strategy": by_strategy,
+        "by_transformer": by_transformer,
+        "by_stage": by_stage,
+        "sum_lineage_depth": sum_lineage_depth,
     }
 
 
@@ -236,7 +308,7 @@ def parse_timestamp(timestamp_str: str | None) -> datetime | None:
         if timestamp_str.endswith("Z"):
             timestamp_str = timestamp_str[:-1] + "+00:00"
         return datetime.fromisoformat(timestamp_str)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 
@@ -287,6 +359,7 @@ class InstanceData:
     stats: dict[str, Any] | None = None
     corpus_stats: dict[str, Any] | None = None
     health_summary: HealthSummary | None = None
+    timeout_summary: TimeoutSummary | None = None
     status: str = "Unknown"
     speed: float = 0.0
     coverage: int = 0
@@ -365,6 +438,7 @@ class CampaignAggregator:
         stats = load_json_file(path / "fuzz_run_stats.json")
         corpus_stats = load_json_file(path / "corpus_stats.json")
         health_summary = load_health_summary(path / "logs" / "health_events.jsonl")
+        timeout_summary = load_timeout_summary(path / "logs" / "timeout_events.jsonl")
 
         # Determine instance name
         name = metadata.get("instance_name", path.name) if metadata else path.name
@@ -376,6 +450,7 @@ class CampaignAggregator:
             stats=stats,
             corpus_stats=corpus_stats,
             health_summary=health_summary,
+            timeout_summary=timeout_summary,
             relative_dir=path.name,
         )
 
@@ -428,7 +503,7 @@ class CampaignAggregator:
             if heartbeat_time:
                 age = (now - heartbeat_time).total_seconds()
                 return "Running" if age < threshold_seconds else "Stopped"
-        except (OSError, ValueError):
+        except OSError, ValueError:
             pass  # File doesn't exist or is unreadable — fall through
 
         # Fallback: last_update_time from stats (written once per session)

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -30,7 +30,7 @@ from lafleur.corpus_manager import CORPUS_DIR, CorpusManager
 from lafleur.health import HealthMonitor
 from lafleur.coverage import CoverageManager, load_coverage_state
 from lafleur.analysis import CrashFingerprinter
-from lafleur.artifacts import ArtifactManager, TelemetryManager
+from lafleur.artifacts import ArtifactManager, TelemetryManager, TimeoutLogger
 from lafleur.execution import ExecutionManager
 from lafleur.scoring import ScoringManager
 from lafleur.types import (
@@ -67,6 +67,13 @@ LOGS_DIR = Path("logs")
 RUN_LOGS_DIR = LOGS_DIR / "run_logs"
 HEARTBEAT_FILE = LOGS_DIR / "heartbeat"
 HEARTBEAT_INTERVAL_SECONDS = 60  # Write heartbeat at most once per minute
+
+# Map timeout stat keys to (type, execution_stage) for structured metadata logging
+TIMEOUT_STAT_KEYS: dict[str, tuple[str, str]] = {
+    "timeouts_found": ("timeout", "coverage"),
+    "jit_hangs_found": ("jit_hang", "differential_jit"),
+    "regression_timeouts_found": ("regression_timeout", "timing_jit"),
+}
 
 # --- Sterility Thresholds ---
 # Maximum sterile mutations in a deepening session before abandoning the lineage.
@@ -218,6 +225,8 @@ class LafleurOrchestrator:
         self.health_monitor = HealthMonitor(log_path=LOGS_DIR / "health_events.jsonl")
         self.mutation_controller.health_monitor = self.health_monitor
         self.corpus_manager.health_monitor = self.health_monitor
+        self.timeout_logger = TimeoutLogger(log_path=LOGS_DIR / "timeout_events.jsonl")
+        self.execution_timeout = timeout
 
         run_timestamp = self.run_stats.get("start_time", datetime.now(timezone.utc).isoformat())
         safe_timestamp = run_timestamp.replace(":", "-").replace("+", "Z")
@@ -762,10 +771,35 @@ class LafleurOrchestrator:
                 )
                 if stat_key:
                     self.run_stats[stat_key] = self.run_stats.get(stat_key, 0) + 1
-                if stat_key == "timeout_count":
+                if stat_key == "timeouts_found":
                     self.health_monitor.record_timeout(ctx.parent_id)
                 else:
                     self.health_monitor.reset_timeout_streak()
+
+                # Record structured timeout metadata
+                if stat_key in TIMEOUT_STAT_KEYS:
+                    timeout_type, execution_stage = TIMEOUT_STAT_KEYS[stat_key]
+                    self.timeout_logger.record(
+                        {
+                            "type": timeout_type,
+                            "parent_id": ctx.parent_id,
+                            "mutation_seed": mutation_seed,
+                            "strategy": (
+                                mutation_info.get("strategy", "unknown")
+                                if mutation_info
+                                else "unknown"
+                            ),
+                            "transformers": (
+                                mutation_info.get("transformers", []) if mutation_info else []
+                            ),
+                            "session_id": session_id,
+                            "mutation_index": mutation_index,
+                            "lineage_depth": ctx.parent_metadata.get("lineage_depth", 0),
+                            "execution_stage": execution_stage,
+                            "timeout_seconds": self.execution_timeout,
+                        }
+                    )
+
                 if not exec_result:
                     continue
 

--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -13,7 +13,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from lafleur.campaign import load_crash_attribution_summary, load_health_summary
+from lafleur.campaign import (
+    load_crash_attribution_summary,
+    load_health_summary,
+    load_timeout_summary,
+)
 
 
 def load_json_file(path: Path) -> dict[str, Any] | None:
@@ -21,7 +25,7 @@ def load_json_file(path: Path) -> dict[str, Any] | None:
     try:
         with open(path, encoding="utf-8") as f:
             return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    except FileNotFoundError, json.JSONDecodeError, OSError:
         return None
 
 
@@ -58,7 +62,7 @@ def load_latest_timeseries_entry(instance_dir: Path) -> dict[str, Any] | None:
                 last_line = tail[0].strip()
                 if last_line:
                     return json.loads(last_line)
-        except (OSError, json.JSONDecodeError):
+        except OSError, json.JSONDecodeError:
             continue
 
     return None
@@ -73,7 +77,7 @@ def parse_timestamp(timestamp_str: str | None) -> datetime | None:
         if timestamp_str.endswith("Z"):
             timestamp_str = timestamp_str[:-1] + "+00:00"
         return datetime.fromisoformat(timestamp_str)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 
@@ -240,6 +244,7 @@ def generate_report(instance_dir: Path) -> str:
     total_mutations = stats.get("total_mutations", 0) if stats else 0
     speed = total_mutations / duration_seconds if duration_seconds > 0 else 0.0
     health_summary = load_health_summary(instance_dir / "logs" / "health_events.jsonl")
+    timeout_summary = load_timeout_summary(instance_dir / "logs" / "timeout_events.jsonl")  # noqa: F841 — rendering added in timeout analytics feature
 
     # ========== HEADER ==========
     lines.append("=" * 80)

--- a/tests/orchestrator/test_crash_detection.py
+++ b/tests/orchestrator/test_crash_detection.py
@@ -14,7 +14,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch, mock_open
-from lafleur.artifacts import ArtifactManager
+from lafleur.artifacts import ArtifactManager, TimeoutLogger
 from lafleur.analysis import CrashFingerprinter, CrashSignature, CrashType
 from lafleur.execution import ExecutionManager
 
@@ -1135,6 +1135,56 @@ class TestSessionCrashCorpusFilenames(unittest.TestCase):
         # session_corpus_files should still be present with warmup: None
         corpus_files = metadata["session_corpus_files"]
         self.assertIsNone(corpus_files["warmup"])
+
+
+class TestTimeoutLogger(unittest.TestCase):
+    """Test TimeoutLogger append-only JSONL logging."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.log_path = Path(self.temp_dir.name) / "timeout_events.jsonl"
+        self.logger = TimeoutLogger(log_path=self.log_path)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_record_creates_file(self):
+        """First record call creates the JSONL file."""
+        self.logger.record({"type": "timeout", "parent_id": "42.py"})
+        self.assertTrue(self.log_path.exists())
+
+    def test_record_appends_json_lines(self):
+        """Each record appends one JSON line."""
+        self.logger.record({"type": "timeout", "parent_id": "1.py"})
+        self.logger.record({"type": "jit_hang", "parent_id": "2.py"})
+        lines = self.log_path.read_text().strip().split("\n")
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(json.loads(lines[0])["parent_id"], "1.py")
+        self.assertEqual(json.loads(lines[1])["type"], "jit_hang")
+
+    def test_record_adds_timestamp_if_missing(self):
+        """Timestamp is auto-added when not provided."""
+        self.logger.record({"type": "timeout"})
+        event = json.loads(self.log_path.read_text().strip())
+        self.assertIn("timestamp", event)
+
+    def test_record_preserves_existing_timestamp(self):
+        """Existing timestamp is not overwritten."""
+        self.logger.record({"type": "timeout", "timestamp": "2026-01-01T00:00:00"})
+        event = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(event["timestamp"], "2026-01-01T00:00:00")
+
+    def test_record_handles_io_error(self):
+        """IOError is caught and printed, not raised."""
+        self.logger.log_path = Path("/nonexistent/dir/log.jsonl")
+        with patch("sys.stderr", new_callable=io.StringIO):
+            self.logger.record({"type": "timeout"})  # Should not raise
+
+    def test_record_includes_timeout_seconds(self):
+        """timeout_seconds field is preserved in the output."""
+        self.logger.record({"type": "timeout", "timeout_seconds": 10})
+        event = json.loads(self.log_path.read_text().strip())
+        self.assertEqual(event["timeout_seconds"], 10)
 
 
 if __name__ == "__main__":

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -1407,6 +1407,8 @@ class TestExecuteSingleMutation(unittest.TestCase):
         self.orchestrator.scoring_manager = MagicMock()
         self.orchestrator.artifact_manager = MagicMock()
         self.orchestrator.score_tracker = MagicMock()
+        self.orchestrator.timeout_logger = MagicMock()
+        self.orchestrator.execution_timeout = 10
 
         mock_harness = MagicMock()
         mock_harness.name = "uop_harness_test"
@@ -1614,6 +1616,62 @@ class TestExecuteSingleMutation(unittest.TestCase):
                 )
 
         self.assertEqual(outcome.new_child_filename, "new_child.py")
+
+    def _setup_timeout_test(self, stat_key: str) -> None:
+        """Helper to set up a timeout metadata recording test."""
+        mock_harness = MagicMock()
+        self.orchestrator.mutation_controller.get_mutated_harness.return_value = (
+            mock_harness,
+            {"strategy": "havoc", "transformers": ["MutA", "MutB"]},
+        )
+        self.orchestrator.mutation_controller.prepare_child_script.return_value = "code"
+        self.orchestrator.execution_manager.execute_child.return_value = (None, stat_key)
+
+    def test_records_timeout_metadata_on_timeout(self):
+        """Timeout metadata is logged when execute_child returns timeouts_found."""
+        self._setup_timeout_test("timeouts_found")
+
+        self.orchestrator._execute_single_mutation(
+            self.ctx, mutation_seed=42, mutation_index=3, session_id=5, mutation_id=7
+        )
+
+        self.orchestrator.timeout_logger.record.assert_called_once()
+        metadata = self.orchestrator.timeout_logger.record.call_args[0][0]
+        self.assertEqual(metadata["type"], "timeout")
+        self.assertEqual(metadata["parent_id"], "parent_test.py")
+        self.assertEqual(metadata["mutation_seed"], 42)
+        self.assertEqual(metadata["strategy"], "havoc")
+        self.assertEqual(metadata["transformers"], ["MutA", "MutB"])
+        self.assertEqual(metadata["session_id"], 5)
+        self.assertEqual(metadata["mutation_index"], 3)
+        self.assertEqual(metadata["execution_stage"], "coverage")
+        self.assertEqual(metadata["timeout_seconds"], 10)
+
+    def test_records_timeout_metadata_on_jit_hang(self):
+        """Timeout metadata is logged for JIT hangs."""
+        self._setup_timeout_test("jit_hangs_found")
+
+        self.orchestrator._execute_single_mutation(
+            self.ctx, mutation_seed=42, mutation_index=1, session_id=1, mutation_id=1
+        )
+
+        self.orchestrator.timeout_logger.record.assert_called_once()
+        metadata = self.orchestrator.timeout_logger.record.call_args[0][0]
+        self.assertEqual(metadata["type"], "jit_hang")
+        self.assertEqual(metadata["execution_stage"], "differential_jit")
+
+    def test_records_timeout_metadata_on_regression_timeout(self):
+        """Timeout metadata is logged for regression timeouts."""
+        self._setup_timeout_test("regression_timeouts_found")
+
+        self.orchestrator._execute_single_mutation(
+            self.ctx, mutation_seed=42, mutation_index=1, session_id=1, mutation_id=1
+        )
+
+        self.orchestrator.timeout_logger.record.assert_called_once()
+        metadata = self.orchestrator.timeout_logger.record.call_args[0][0]
+        self.assertEqual(metadata["type"], "regression_timeout")
+        self.assertEqual(metadata["execution_stage"], "timing_jit")
 
 
 class TestCleanupLogFile(unittest.TestCase):

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -12,6 +12,7 @@ from lafleur.campaign import (
     generate_html_report,
     load_json_file,
     load_health_summary,
+    load_timeout_summary,
     load_crash_attribution_summary,
     parse_timestamp,
     format_duration,
@@ -1238,3 +1239,116 @@ class TestCampaignCrashAttributionAggregation(unittest.TestCase):
         html_content = generate_html_report(aggregator)
         self.assertIn("Crash-Productive Mutators", html_content)
         self.assertIn("Attributed Crashes", html_content)
+
+
+class TestLoadTimeoutSummary(unittest.TestCase):
+    """Tests for load_timeout_summary reader function."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_events(self, events: list[dict]) -> Path:
+        path = self.temp_path / "timeout_events.jsonl"
+        with open(path, "w", encoding="utf-8") as f:
+            for event in events:
+                f.write(json.dumps(event) + "\n")
+        return path
+
+    def test_returns_none_for_missing_file(self):
+        result = load_timeout_summary(self.temp_path / "nonexistent.jsonl")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_empty_file(self):
+        path = self.temp_path / "timeout_events.jsonl"
+        path.write_text("")
+        result = load_timeout_summary(path)
+        self.assertIsNone(result)
+
+    def test_counts_total_timeouts(self):
+        path = self._write_events(
+            [
+                {"type": "timeout", "parent_id": "1.py", "timeout_seconds": 10},
+                {"type": "timeout", "parent_id": "2.py", "timeout_seconds": 10},
+                {"type": "jit_hang", "parent_id": "3.py", "timeout_seconds": 10},
+            ]
+        )
+        result = load_timeout_summary(path)
+        self.assertEqual(result["total_timeouts"], 3)
+
+    def test_sums_timeout_seconds(self):
+        path = self._write_events(
+            [
+                {"type": "timeout", "timeout_seconds": 10},
+                {"type": "timeout", "timeout_seconds": 10},
+                {"type": "jit_hang", "timeout_seconds": 15},
+            ]
+        )
+        result = load_timeout_summary(path)
+        self.assertAlmostEqual(result["total_timeout_seconds"], 35.0)
+
+    def test_counts_by_type(self):
+        path = self._write_events(
+            [
+                {"type": "timeout"},
+                {"type": "timeout"},
+                {"type": "jit_hang"},
+            ]
+        )
+        result = load_timeout_summary(path)
+        self.assertEqual(result["by_type"]["timeout"], 2)
+        self.assertEqual(result["by_type"]["jit_hang"], 1)
+
+    def test_counts_by_parent(self):
+        path = self._write_events(
+            [
+                {"type": "timeout", "parent_id": "42.py"},
+                {"type": "timeout", "parent_id": "42.py"},
+                {"type": "timeout", "parent_id": "7.py"},
+            ]
+        )
+        result = load_timeout_summary(path)
+        self.assertEqual(result["by_parent"]["42.py"], 2)
+        self.assertEqual(result["by_parent"]["7.py"], 1)
+
+    def test_counts_by_transformer(self):
+        path = self._write_events(
+            [
+                {"type": "timeout", "transformers": ["MutA", "MutB"]},
+                {"type": "timeout", "transformers": ["MutA"]},
+            ]
+        )
+        result = load_timeout_summary(path)
+        self.assertEqual(result["by_transformer"]["MutA"], 2)
+        self.assertEqual(result["by_transformer"]["MutB"], 1)
+
+    def test_counts_by_strategy(self):
+        path = self._write_events(
+            [
+                {"type": "timeout", "strategy": "havoc"},
+                {"type": "timeout", "strategy": "havoc"},
+                {"type": "timeout", "strategy": "sniper"},
+            ]
+        )
+        result = load_timeout_summary(path)
+        self.assertEqual(result["by_strategy"]["havoc"], 2)
+        self.assertEqual(result["by_strategy"]["sniper"], 1)
+
+    def test_skips_malformed_lines(self):
+        path = self.temp_path / "timeout_events.jsonl"
+        with open(path, "w") as f:
+            f.write(json.dumps({"type": "timeout"}) + "\n")
+            f.write("not valid json\n")
+            f.write(json.dumps({"type": "jit_hang"}) + "\n")
+        result = load_timeout_summary(path)
+        self.assertEqual(result["total_timeouts"], 2)
+
+    def test_handles_missing_fields_gracefully(self):
+        """Events with missing fields use defaults without crashing."""
+        path = self._write_events([{"type": "timeout"}])
+        result = load_timeout_summary(path)
+        self.assertEqual(result["total_timeouts"], 1)
+        self.assertEqual(result["by_parent"]["unknown"], 1)


### PR DESCRIPTION
## Summary
- Add `TimeoutLogger` class to `artifacts.py` for append-only JSONL logging of timeout events with type, parent ID, strategy, transformers, lineage depth, execution stage, and duration
- Add `load_timeout_summary()` reader to `campaign.py` that aggregates timeout metadata into counters (by type, parent, strategy, transformer, stage)
- Fix stat_key inconsistency: orchestrator checked `"timeout_count"` but `execution.py` returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger

## Test plan
- [x] 6 new `TestTimeoutLogger` tests (file creation, append, timestamp auto-add, timestamp preserve, IO error handling, field preservation)
- [x] 10 new `TestLoadTimeoutSummary` tests (missing file, empty file, total count, timeout seconds sum, by_type, by_parent, by_transformer, by_strategy, malformed lines, missing fields)
- [x] 3 new `TestExecuteSingleMutation` tests (metadata recording for timeout, jit_hang, regression_timeout stat keys)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy lafleur/` passes
- [x] All 2003 tests pass

Closes #725

Generated with [Claude Code](https://claude.com/claude-code)