### PR TITLE
fix: deduplicate utilities across CLI modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Deduplicated `load_json_file`, `parse_timestamp`, and `format_duration` utilities from `report.py`, `campaign.py`, and `triage.py` into `lafleur/utils.py`, and deduplicated `TMP_DIR` constant from `orchestrator.py` into `corpus_manager.py`, by @devdanzin.
 - `SniperMutator` with two new attack vectors: `executor_assassinate` (uses `_testinternalcapi.invalidate_executors()` to rip JIT executors out from under active traces, targeting GH-143604) and `globals_detach` (uses `types.FunctionType(func.__code__, new_globals)` to execute JIT-compiled code with detached globals, targeting GH-138378), for both helper functions and builtins, by @devdanzin.
 - `GlobalOptimizationInvalidator` with two new attack vectors: `namespace_swap` (executes JIT-warmed code via `types.FunctionType` with alternate globals containing wrong types, targeting GH-138378) and `globals_dict_mutate` (directly mutates `func.__globals__` in-place after JIT warmup to corrupt cached dict pointers), complementing the existing `evil_global_swap` strategy, by @devdanzin.
 - `UnpackingChaosMutator` with two new `_JitChaosIterator` modes: `backing_store_mutate` (actively modifies the backing list via `clear()`/`extend()`/`insert()`/`pop()` mid-iteration, targeting GH-143123) and `exception_storm` (conditionally raises `StopIteration`/`TypeError`/`ValueError` during iteration), by @devdanzin.

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -18,6 +18,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
 
+from lafleur.utils import load_json_file, parse_timestamp
+
 
 class GlobalCorpusData(TypedDict):
     """Type definition for global corpus aggregation data."""
@@ -83,15 +85,6 @@ WASTE_EVENT_TYPES: frozenset[str] = frozenset(
         "core_code_syntax_error",
     }
 )
-
-
-def load_json_file(path: Path) -> dict[str, Any] | None:
-    """Load a JSON file, returning None if it doesn't exist or is invalid."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            return json.load(f)
-    except FileNotFoundError, json.JSONDecodeError, OSError:
-        return None
 
 
 def load_health_summary(health_log_path: Path) -> HealthSummary | None:
@@ -298,40 +291,6 @@ def load_crash_attribution_summary(log_path: Path) -> CrashAttributionSummary | 
         combined_transformer_scores=combined_transformer,
         combined_strategy_scores=combined_strategy,
     )
-
-
-def parse_timestamp(timestamp_str: str | None) -> datetime | None:
-    """Parse an ISO format timestamp string into a datetime object."""
-    if not timestamp_str:
-        return None
-    try:
-        if timestamp_str.endswith("Z"):
-            timestamp_str = timestamp_str[:-1] + "+00:00"
-        return datetime.fromisoformat(timestamp_str)
-    except ValueError, TypeError:
-        return None
-
-
-def format_duration(seconds: float) -> str:
-    """Format a duration in seconds to a human-readable string."""
-    if seconds < 0:
-        return "N/A"
-
-    days, remainder = divmod(int(seconds), 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes, secs = divmod(remainder, 60)
-
-    parts = []
-    if days > 0:
-        parts.append(f"{days}d")
-    if hours > 0:
-        parts.append(f"{hours}h")
-    if minutes > 0:
-        parts.append(f"{minutes}m")
-    if secs > 0 or not parts:
-        parts.append(f"{secs}s")
-
-    return " ".join(parts)
 
 
 @dataclass

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -26,7 +26,7 @@ from enum import Enum, auto
 from pathlib import Path
 from textwrap import dedent
 
-from lafleur.corpus_manager import CORPUS_DIR, CorpusManager
+from lafleur.corpus_manager import CORPUS_DIR, TMP_DIR, CorpusManager
 from lafleur.health import HealthMonitor
 from lafleur.coverage import CoverageManager, load_coverage_state
 from lafleur.analysis import CrashFingerprinter
@@ -58,7 +58,6 @@ class FlowControl(Enum):
 
 # --- Paths for Fuzzer Outputs (relative to current working directory) ---
 # This allows running multiple fuzzer instances from different directories.
-TMP_DIR = Path("tmp_fuzz_run")
 CRASHES_DIR = Path("crashes")
 REGRESSIONS_DIR = Path("regressions")
 TIMEOUTS_DIR = Path("timeouts")

--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -19,15 +19,7 @@ from lafleur.campaign import (
     load_health_summary,
     load_timeout_summary,
 )
-
-
-def load_json_file(path: Path) -> dict[str, Any] | None:
-    """Load a JSON file, returning None if it doesn't exist or is invalid."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            return json.load(f)
-    except FileNotFoundError, json.JSONDecodeError, OSError:
-        return None
+from lafleur.utils import format_duration, load_json_file, parse_timestamp
 
 
 def load_latest_timeseries_entry(instance_dir: Path) -> dict[str, Any] | None:
@@ -67,41 +59,6 @@ def load_latest_timeseries_entry(instance_dir: Path) -> dict[str, Any] | None:
             continue
 
     return None
-
-
-def parse_timestamp(timestamp_str: str | None) -> datetime | None:
-    """Parse an ISO format timestamp string into a datetime object."""
-    if not timestamp_str:
-        return None
-    try:
-        # Handle various ISO formats
-        if timestamp_str.endswith("Z"):
-            timestamp_str = timestamp_str[:-1] + "+00:00"
-        return datetime.fromisoformat(timestamp_str)
-    except ValueError, TypeError:
-        return None
-
-
-def format_duration(seconds: float) -> str:
-    """Format a duration in seconds to a human-readable string."""
-    if seconds < 0:
-        return "N/A"
-
-    days, remainder = divmod(int(seconds), 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes, secs = divmod(remainder, 60)
-
-    parts = []
-    if days > 0:
-        parts.append(f"{days}d")
-    if hours > 0:
-        parts.append(f"{hours}h")
-    if minutes > 0:
-        parts.append(f"{minutes}m")
-    if secs > 0 or not parts:
-        parts.append(f"{secs}s")
-
-    return " ".join(parts)
 
 
 def format_number(value: int | float | None, suffix: str = "") -> str:

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -16,15 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from lafleur.registry import CrashRegistry
-
-
-def load_json_file(path: Path) -> dict[str, Any] | None:
-    """Load a JSON file, returning None if it doesn't exist or is invalid."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return None
+from lafleur.utils import load_json_file
 
 
 def get_revision_date(revision: str) -> int | None:
@@ -46,7 +38,7 @@ def get_revision_date(revision: str) -> int | None:
         )
         if result.returncode == 0:
             return int(result.stdout.strip())
-    except (subprocess.TimeoutExpired, ValueError, OSError):
+    except subprocess.TimeoutExpired, ValueError, OSError:
         pass
     return None
 
@@ -60,7 +52,7 @@ def parse_iso_timestamp(timestamp_str: str) -> int | None:
             timestamp_str = timestamp_str[:-1] + "+00:00"
         dt = datetime.fromisoformat(timestamp_str)
         return int(dt.timestamp())
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 
@@ -278,7 +270,7 @@ def import_campaign(args: argparse.Namespace) -> None:
                 if len(rev_part) >= 8:
                     cpython_revision = rev_part
                     revision_date = get_revision_date(cpython_revision)
-            except (IndexError, ValueError):
+            except IndexError, ValueError:
                 pass
 
         # Fall back to start_time for revision_date proxy

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -12,6 +12,55 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TextIO
 
+# ---------------------------------------------------------------------------
+# Generic JSON / formatting helpers (shared by report, campaign, triage CLIs)
+# ---------------------------------------------------------------------------
+
+
+def load_json_file(path: Path) -> dict[str, Any] | None:
+    """Load a JSON file, returning None if it doesn't exist or is invalid."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError, json.JSONDecodeError, OSError:
+        return None
+
+
+def parse_timestamp(timestamp_str: str | None) -> datetime | None:
+    """Parse an ISO format timestamp string into a datetime object."""
+    if not timestamp_str:
+        return None
+    try:
+        # Handle various ISO formats
+        if timestamp_str.endswith("Z"):
+            timestamp_str = timestamp_str[:-1] + "+00:00"
+        return datetime.fromisoformat(timestamp_str)
+    except ValueError, TypeError:
+        return None
+
+
+def format_duration(seconds: float) -> str:
+    """Format a duration in seconds to a human-readable string."""
+    if seconds < 0:
+        return "N/A"
+
+    days, remainder = divmod(int(seconds), 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, secs = divmod(remainder, 60)
+
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0:
+        parts.append(f"{minutes}m")
+    if secs > 0 or not parts:
+        parts.append(f"{secs}s")
+
+    return " ".join(parts)
+
+
 RUN_STATS_FILE = Path("fuzz_run_stats.json")
 
 # Standard environment variables for running JIT-enabled Python targets.

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -11,17 +11,15 @@ from lafleur.campaign import (
     CampaignAggregator,
     InstanceData,
     generate_html_report,
-    load_json_file,
     load_health_summary,
     load_timeout_summary,
     load_crash_attribution_summary,
-    parse_timestamp,
-    format_duration,
     discover_instances,
     main,
     CrashInfo,
     HealthSummary,
 )
+from lafleur.utils import format_duration, load_json_file, parse_timestamp
 
 
 class TestLoadJsonFile(unittest.TestCase):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -14,14 +14,13 @@ from collections import Counter
 from lafleur.report import (
     _format_timeout_section,
     generate_report,
-    load_json_file,
     load_latest_timeseries_entry,
-    format_duration,
     format_number,
     get_jit_asan_status,
     truncate_string,
     load_crash_data,
 )
+from lafleur.utils import format_duration, load_json_file
 
 
 class TestReportHelpers(unittest.TestCase):

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -14,13 +14,13 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from lafleur.registry import CrashRegistry
+from lafleur.utils import load_json_file
 from lafleur.triage import (
     do_export_issues,
     do_import_issues,
     get_triage_candidates,
     handle_triage_action,
     discover_instances,
-    load_json_file,
     get_revision_date,
     parse_iso_timestamp,
     import_campaign,


### PR DESCRIPTION
## Summary
- Move `load_json_file`, `parse_timestamp`, and `format_duration` from `report.py`, `campaign.py`, and `triage.py` into `lafleur/utils.py` as the canonical implementations
- Deduplicate `TMP_DIR` constant (keep in `corpus_manager.py`, import in `orchestrator.py`)
- Update all test imports to reference `lafleur.utils` instead of the individual CLI modules

## Test plan
- [x] All 2028 tests pass
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)