### PR TITLE
fix: remove redundant from __future__ import annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Removed redundant `from __future__ import annotations` from 17 files (16 source + 1 test) since the project targets Python 3.14+ where PEP 649 deferred evaluation is the default, by @devdanzin.
 - Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.
 
 ### Enhanced

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -6,8 +6,6 @@ This module provides:
 - TelemetryManager: run statistics persistence and time-series logging
 """
 
-from __future__ import annotations
-
 import difflib
 import json
 import random

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -6,8 +6,6 @@ lafleur fuzzing instances, deduplicate findings, and produce fleet-wide
 summaries for campaign analysis.
 """
 
-from __future__ import annotations
-
 import argparse
 import html
 import json

--- a/lafleur/corpus_analysis.py
+++ b/lafleur/corpus_analysis.py
@@ -6,8 +6,6 @@ of the fuzzing corpus, computing statistics about file sizes, execution
 times, lineage depths, and mutation effectiveness.
 """
 
-from __future__ import annotations
-
 import statistics
 from collections import Counter
 from collections.abc import Sequence

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -201,7 +201,7 @@ class CorpusManager:
                 file_id = int(Path(filename).stem)
                 if file_id > current_max_id:
                     current_max_id = file_id
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 continue  # Ignore non-integer filenames
 
         if current_max_id > self.corpus_file_counter:

--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -15,8 +15,6 @@ Output Protocol:
     [DRIVER:ERROR] <script_path>   - Emitted when a script raises an exception
 """
 
-from __future__ import annotations
-
 import argparse
 import collections.abc
 import ctypes
@@ -197,7 +195,7 @@ def _emit_stats(stats: dict) -> None:
             try:
                 json.dumps(v)
                 safe[k] = v
-            except (TypeError, ValueError, OverflowError):
+            except TypeError, ValueError, OverflowError:
                 safe[k] = repr(v)
         safe["_serialization_fallback"] = True
         print(f"[DRIVER:STATS] {json.dumps(safe)}", flush=True)
@@ -274,7 +272,7 @@ def snapshot_executor_state(namespace: dict) -> dict[tuple[int, int], int]:
                                 id(executor), ctypes.POINTER(PyExecutorObject)
                             )
                             snapshot[(id(code), offset)] = executor_ptr.contents.exit_count
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         pass
 
     return snapshot
@@ -429,7 +427,7 @@ def get_jit_stats(namespace: dict, baseline: dict[tuple[int, int], int] | None =
                         if executor:
                             executor_count += 1
                             inspect_executor(executor, id(code), offset)
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         pass
 
     result = {

--- a/lafleur/execution.py
+++ b/lafleur/execution.py
@@ -504,7 +504,7 @@ class ExecutionManager:
                                 selection = self.corpus_manager.select_parent()
                                 if selection:
                                     polluters.append(selection[0])
-                        except (AttributeError, IndexError):
+                        except AttributeError, IndexError:
                             # Corpus empty or select_parent not available
                             pass
 

--- a/lafleur/lineage.py
+++ b/lafleur/lineage.py
@@ -7,8 +7,6 @@ file back to its seed) and descendants (show what a file produced) modes.
 Output formats: Graphviz DOT (default), JSON, or rendered images (PNG/SVG/PDF).
 """
 
-from __future__ import annotations
-
 import argparse
 import hashlib
 import json
@@ -709,7 +707,7 @@ def scan_crashes(crashes_dir: Path) -> list[dict]:
         try:
             with open(metadata_path) as f:
                 meta = json.load(f)
-        except (json.JSONDecodeError, OSError):
+        except json.JSONDecodeError, OSError:
             continue
 
         crash_info: dict = {
@@ -1661,7 +1659,7 @@ def render_ancestry_svg(
             timeout=60,
         )
         return result.stdout if result.returncode == 0 else None
-    except (subprocess.TimeoutExpired, OSError):
+    except subprocess.TimeoutExpired, OSError:
         return None
 
 

--- a/lafleur/metadata.py
+++ b/lafleur/metadata.py
@@ -234,7 +234,7 @@ def get_git_info() -> dict[str, str | bool]:
         is_dirty = bool(result.stdout.strip()) if result.returncode == 0 else False
 
         return {"commit": commit_hash, "dirty": is_dirty}
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+    except subprocess.TimeoutExpired, FileNotFoundError, OSError:
         return {"commit": "unknown", "dirty": False}
 
 

--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -8,8 +8,6 @@ This module provides the MutationController class ("The Alchemist") which handle
 - Extracting boilerplate and core code from source files
 """
 
-from __future__ import annotations
-
 import ast
 import copy
 import math

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -7,8 +7,6 @@ the `SlicingMutator`, a meta-mutator designed to efficiently fuzz very large
 functions by operating on small, random slices of their body.
 """
 
-from __future__ import annotations
-
 import ast
 import pickle
 import random

--- a/lafleur/mutators/generic.py
+++ b/lafleur/mutators/generic.py
@@ -7,8 +7,6 @@ perturbing constants, changing container types, and injecting basic control
 flow structures like loops and guards.
 """
 
-from __future__ import annotations
-
 import ast
 import builtins
 import copy
@@ -173,7 +171,7 @@ class LiteralTypeSwapMutator(ast.NodeTransformer):
             # Try converting to int (may fail for inf/nan)
             try:
                 replacements.append(int(val))
-            except (ValueError, OverflowError):
+            except ValueError, OverflowError:
                 pass
             replacements.append(str(val))
 
@@ -334,7 +332,7 @@ class BoundaryValuesMutator(ast.NodeTransformer):
             try:
                 new_node = ast.parse(new_value_str, mode="eval").body
                 return new_node
-            except (SyntaxError, ValueError):
+            except SyntaxError, ValueError:
                 return node
         return node
 

--- a/lafleur/mutators/scenarios_control.py
+++ b/lafleur/mutators/scenarios_control.py
@@ -8,8 +8,6 @@ to break traces, and generating loops with many side-exits to stress the JIT's
 guard emission and bailout mechanisms.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys
@@ -1264,7 +1262,7 @@ class PatternMatchingChaosMutator(ast.NodeTransformer):
             ast.fix_missing_locations(match_node)
             return match_node
 
-        except (AttributeError, IndexError):
+        except AttributeError, IndexError:
             return None
 
     def visit_For(self, node: ast.For) -> ast.stmt:
@@ -1327,7 +1325,7 @@ class PatternMatchingChaosMutator(ast.NodeTransformer):
             ast.fix_missing_locations(new_for)
             return new_for
 
-        except (AttributeError, IndexError):
+        except AttributeError, IndexError:
             return None
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:

--- a/lafleur/mutators/scenarios_data.py
+++ b/lafleur/mutators/scenarios_data.py
@@ -8,8 +8,6 @@ lying equality), corrupting built-in namespaces, and creating scenarios that
 misuse collection primitives like iterators and slices.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/mutators/scenarios_runtime.py
+++ b/lafleur/mutators/scenarios_runtime.py
@@ -8,8 +8,6 @@ versioning caches, using frame introspection to corrupt local variables
 from outside their scope, and triggering side effects via object finalizers.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/mutators/scenarios_types.py
+++ b/lafleur/mutators/scenarios_types.py
@@ -8,8 +8,6 @@ call sites to stress inline caches, confusing attribute lookup mechanisms, and
 modifying class hierarchies (MRO) at runtime.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/mutators/utils.py
+++ b/lafleur/mutators/utils.py
@@ -8,8 +8,6 @@ testing, and a library of generator functions for creating "evil" objects
 with stateful or contract-violating behaviors used by various scenarios.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/registry.py
+++ b/lafleur/registry.py
@@ -5,8 +5,6 @@ This module provides a SQLite-based registry for storing crash fingerprints,
 sightings across fuzzing runs, and links to reported GitHub issues.
 """
 
-from __future__ import annotations
-
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -5,8 +5,6 @@ This module provides a command-line interface for importing crashes from
 fuzzing campaigns and linking them to GitHub issues.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import subprocess
@@ -23,7 +21,7 @@ def load_json_file(path: Path) -> dict[str, Any] | None:
     try:
         with open(path, encoding="utf-8") as f:
             return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    except FileNotFoundError, json.JSONDecodeError, OSError:
         return None
 
 
@@ -46,7 +44,7 @@ def get_revision_date(revision: str) -> int | None:
         )
         if result.returncode == 0:
             return int(result.stdout.strip())
-    except (subprocess.TimeoutExpired, ValueError, OSError):
+    except subprocess.TimeoutExpired, ValueError, OSError:
         pass
     return None
 
@@ -60,7 +58,7 @@ def parse_iso_timestamp(timestamp_str: str) -> int | None:
             timestamp_str = timestamp_str[:-1] + "+00:00"
         dt = datetime.fromisoformat(timestamp_str)
         return int(dt.timestamp())
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 
@@ -278,7 +276,7 @@ def import_campaign(args: argparse.Namespace) -> None:
                 if len(rev_part) >= 8:
                     cpython_revision = rev_part
                     revision_date = get_revision_date(cpython_revision)
-            except (IndexError, ValueError):
+            except IndexError, ValueError:
                 pass
 
         # Fall back to start_time for revision_date proxy

--- a/lafleur/types.py
+++ b/lafleur/types.py
@@ -12,8 +12,6 @@ untyped dict returned by analyze_run(), enabling isinstance()-based
 dispatch and preventing accidental mutation.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TypedDict
 

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,7 +1,5 @@
 """Tests for lafleur.lineage — corpus lineage visualization tool."""
 
-from __future__ import annotations
-
 import json
 import sys
 import unittest


### PR DESCRIPTION
## Summary
- Remove `from __future__ import annotations` from 17 files (16 source + 1 test)
- The project targets Python 3.14+ where PEP 649 deferred evaluation is the default, making this import unnecessary
- No runtime annotation inspection (`get_type_hints`, `__annotations__`) exists in the codebase

## Test plan
- [x] All 2028 tests pass
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)