### PR TITLE
fix: add missing return type annotations and module docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Added missing `-> None` return type annotations on `main()` in `minimize.py` and `orchestrator.py`, by @devdanzin.
+- Added module docstrings to `analysis.py` and `mutators/sniper.py`, by @devdanzin.
 - Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.
 
 ### Enhanced

--- a/lafleur/analysis.py
+++ b/lafleur/analysis.py
@@ -1,3 +1,10 @@
+"""Crash analysis and classification for lafleur findings.
+
+Provides CrashSignature extraction from stderr output, classifying crashes
+into types (ASAN, assertion, panic, segfault) and generating fingerprints
+for deduplication and minimization matching.
+"""
+
 from dataclasses import dataclass, asdict
 from enum import Enum
 import re

--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -447,7 +447,7 @@ def minimize_session(crash_dir: Path, target_python: str, force_overwrite: bool)
         print(f"    Result: {target_file} (requires predecessors)")
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Minimize a lafleur crash bundle.")
     parser.add_argument("crash_dir", type=Path, help="Path to the session crash directory")
     parser.add_argument(

--- a/lafleur/mutators/sniper.py
+++ b/lafleur/mutators/sniper.py
@@ -1,3 +1,10 @@
+"""SniperMutator for surgical Bloom filter invalidation.
+
+Targets helper functions detected in the JIT's Bloom filter, invalidating
+them mid-execution to trigger deoptimization, type confusion, and state
+corruption in optimized traces.
+"""
+
 import ast
 import random
 from textwrap import dedent

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -1018,7 +1018,7 @@ def _format_run_summary(
     return header + body
 
 
-def main():
+def main() -> None:
     """Parse command-line arguments and run the Lafleur Fuzzer Orchestrator."""
     parser = argparse.ArgumentParser(
         description="lafleur: A feedback-driven JIT fuzzer for CPython."


### PR DESCRIPTION
## Summary
- Add `-> None` return type annotation to `main()` in `minimize.py` and `orchestrator.py`
- Add module docstrings to `analysis.py` and `mutators/sniper.py`

## Test plan
- [x] All 2028 tests pass
- [x] mypy passes on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)