### PR TITLE
refactor: extract _clamp_and_decay() helper in scoring.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ All notable changes to this project should be documented in this file.
 
 - Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.
 
+### Refactored
+
+- Extracted `_clamp_and_decay()` helper in `scoring.py` to deduplicate three identical clamp-then-decay blocks in `_prepare_new_coverage_result`, by @devdanzin.
+
 ### Enhanced
 
 - `SniperMutator` with two new attack vectors: `executor_assassinate` (uses `_testinternalcapi.invalidate_executors()` to rip JIT executors out from under active traces, targeting GH-143604) and `globals_detach` (uses `types.FunctionType(func.__code__, new_globals)` to execute JIT-compiled code with detached globals, targeting GH-138378), for both helper functions and builtins, by @devdanzin.

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -46,6 +46,28 @@ TACHYCARDIA_DECAY_FACTOR = 0.95
 MAX_DENSITY_GROWTH_FACTOR = 5.0
 
 
+def _clamp_and_decay(
+    child_value: float, parent_value: float, label: str, fmt: str = ".4f"
+) -> float:
+    """Clamp a metric to prevent runaway spikes, then apply tachycardia decay.
+
+    If the parent had a positive value, the child is clamped to at most
+    parent * MAX_DENSITY_GROWTH_FACTOR. The result is then decayed by
+    TACHYCARDIA_DECAY_FACTOR.
+    """
+    if parent_value > 0:
+        clamped = min(parent_value * MAX_DENSITY_GROWTH_FACTOR, child_value)
+    else:
+        clamped = child_value
+    decayed = clamped * TACHYCARDIA_DECAY_FACTOR
+    if clamped > 0:
+        print(
+            f"  [~] {label}: {clamped:{fmt}} -> {decayed:{fmt}}",
+            file=sys.stderr,
+        )
+    return decayed
+
+
 @dataclass
 class NewCoverageInfo:
     """A data class to hold the counts of new coverage found."""
@@ -721,60 +743,23 @@ class ScoringManager:
         # This is the crucial step: if it's new and not a duplicate, we commit the coverage.
         self._update_global_coverage(child_coverage)
 
-        # --- Dynamic Density Clamping ---
-        # Prevent a single massive spike from setting an unreachable bar for the next generation.
-        child_density = jit_stats.get("max_exit_density") or 0.0
-        parent_density = parent_jit_stats.get("max_exit_density") or 0.0
-
-        if parent_density > 0:
-            clamped_density = min(parent_density * MAX_DENSITY_GROWTH_FACTOR, child_density)
-        else:
-            clamped_density = child_density
-
-        # Also clamp delta density if present
-        child_delta_density = jit_stats.get("child_delta_max_exit_density") or 0.0
-        parent_delta_density = parent_jit_stats.get("child_delta_max_exit_density") or 0.0
-
-        if parent_delta_density > 0:
-            clamped_delta_density = min(
-                parent_delta_density * MAX_DENSITY_GROWTH_FACTOR, child_delta_density
-            )
-        else:
-            clamped_delta_density = child_delta_density
-
-        # Also clamp delta exits if present
-        child_delta_exits = jit_stats.get("child_delta_total_exits") or 0
-        parent_delta_exits = parent_jit_stats.get("child_delta_total_exits") or 0
-
-        if parent_delta_exits > 0:
-            clamped_delta_exits = min(
-                parent_delta_exits * MAX_DENSITY_GROWTH_FACTOR, child_delta_exits
-            )
-        else:
-            clamped_delta_exits = child_delta_exits
-
-        # --- Tachycardia Decay ---
-        saved_density = clamped_density * TACHYCARDIA_DECAY_FACTOR
-        saved_delta_density = clamped_delta_density * TACHYCARDIA_DECAY_FACTOR
-        saved_delta_exits = clamped_delta_exits * TACHYCARDIA_DECAY_FACTOR
-
-        if clamped_density > 0:
-            print(
-                f"  [~] Tachycardia decay: {clamped_density:.4f} -> {saved_density:.4f}",
-                file=sys.stderr,
-            )
-        if clamped_delta_density > 0:
-            print(
-                f"  [~] Tachycardia delta decay: {clamped_delta_density:.4f} -> "
-                f"{saved_delta_density:.4f}",
-                file=sys.stderr,
-            )
-        if clamped_delta_exits > 0:
-            print(
-                f"  [~] Tachycardia delta exits decay: {clamped_delta_exits:.0f} -> "
-                f"{saved_delta_exits:.0f}",
-                file=sys.stderr,
-            )
+        # --- Dynamic Density Clamping + Tachycardia Decay ---
+        saved_density = _clamp_and_decay(
+            jit_stats.get("max_exit_density") or 0.0,
+            parent_jit_stats.get("max_exit_density") or 0.0,
+            "Tachycardia decay",
+        )
+        saved_delta_density = _clamp_and_decay(
+            jit_stats.get("child_delta_max_exit_density") or 0.0,
+            parent_jit_stats.get("child_delta_max_exit_density") or 0.0,
+            "Tachycardia delta decay",
+        )
+        saved_delta_exits = _clamp_and_decay(
+            jit_stats.get("child_delta_total_exits") or 0,
+            parent_jit_stats.get("child_delta_total_exits") or 0,
+            "Tachycardia delta exits decay",
+            fmt=".0f",
+        )
 
         jit_stats_for_save = jit_stats.copy()
         jit_stats_for_save["max_exit_density"] = saved_density


### PR DESCRIPTION
## Summary
- Extract `_clamp_and_decay()` helper function to deduplicate three identical clamp-then-decay blocks in `_prepare_new_coverage_result`
- Reduces 35 lines of repeated logic (3 clamp blocks + 3 decay blocks + 3 print blocks) to 3 concise calls
- Net reduction: -11 lines while improving readability

## Test plan
- [x] All 2028 tests pass
- [x] Scoring-specific tests pass (test_scoring.py, test_jit_scoring.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)