### PR TITLE
Fix missing error handling in learning.py and corpus_manager.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- `learning.py::save_state()` and `save_telemetry()` had no exception handling — a disk-full or permission error would crash the entire fuzzer mid-campaign. Now wrapped in try/except matching the `_log_crash_attribution()` pattern, by @devdanzin.
+- `corpus_manager.py::generate_new_seed()` fusil subprocess had no timeout, no return code check, and no output file verification — failures were silently ignored. Now validates all three, by @devdanzin.
 - Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.
 
 ### Enhanced

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -201,7 +201,7 @@ class CorpusManager:
                 file_id = int(Path(filename).stem)
                 if file_id > current_max_id:
                     current_max_id = file_id
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 continue  # Ignore non-integer filenames
 
         if current_max_id > self.corpus_file_counter:
@@ -450,7 +450,24 @@ class CorpusManager:
             # "--keep-sessions",
         ]
         print(f"[*] Generating new seed with command: {' '.join(command)}")
-        subprocess.run(command, capture_output=True, env=FUZZING_ENV)
+        try:
+            result = subprocess.run(command, capture_output=True, env=FUZZING_ENV, timeout=120)
+            if result.returncode != 0:
+                print(
+                    f"[!] Seed generation failed (exit {result.returncode})",
+                    file=sys.stderr,
+                )
+                return
+        except subprocess.TimeoutExpired:
+            print("[!] Seed generation timed out after 120s", file=sys.stderr)
+            return
+        except OSError as e:
+            print(f"[!] Seed generation failed: {e}", file=sys.stderr)
+            return
+
+        if not tmp_source.exists():
+            print("[!] Seed generation produced no output file", file=sys.stderr)
+            return
 
         # Execute it to get a log (also using the configurable timeout)
         try:

--- a/lafleur/learning.py
+++ b/lafleur/learning.py
@@ -90,14 +90,20 @@ class MutatorScoreTracker:
 
     def save_state(self):
         """Save the current scores and attempts to a file."""
-        MUTATOR_SCORES_FILE.parent.mkdir(parents=True, exist_ok=True)
-        data = {
-            "scores": dict(self.scores),
-            "attempts": dict(self.attempts),
-            "attempt_counter": self._attempt_counter,
-        }
-        with open(MUTATOR_SCORES_FILE, "w") as f:
-            json.dump(data, f, indent=2)
+        try:
+            MUTATOR_SCORES_FILE.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                "scores": dict(self.scores),
+                "attempts": dict(self.attempts),
+                "attempt_counter": self._attempt_counter,
+            }
+            with open(MUTATOR_SCORES_FILE, "w") as f:
+                json.dump(data, f, indent=2)
+        except OSError as e:
+            print(
+                f"[!] Warning: Could not save mutator scores: {e}",
+                file=sys.stderr,
+            )
 
     def record_attempt(self, name: str) -> None:
         """Record an attempt for a strategy or transformer, applying periodic decay."""
@@ -241,16 +247,22 @@ class MutatorScoreTracker:
 
     def save_telemetry(self):
         """Save a snapshot of the current effectiveness metrics to a log."""
-        MUTATOR_TELEMETRY_LOG.parent.mkdir(parents=True, exist_ok=True)
-        success_rates = {
-            name: self.scores[name] / max(1, self.attempts.get(name, 1))
-            for name in self.strategies + self.all_transformers
-        }
-        datapoint = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "scores": dict(self.scores),
-            "attempts": dict(self.attempts),
-            "success_rates": success_rates,
-        }
-        with open(MUTATOR_TELEMETRY_LOG, "a") as f:
-            f.write(json.dumps(datapoint) + "\n")
+        try:
+            MUTATOR_TELEMETRY_LOG.parent.mkdir(parents=True, exist_ok=True)
+            success_rates = {
+                name: self.scores[name] / max(1, self.attempts.get(name, 1))
+                for name in self.strategies + self.all_transformers
+            }
+            datapoint = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "scores": dict(self.scores),
+                "attempts": dict(self.attempts),
+                "success_rates": success_rates,
+            }
+            with open(MUTATOR_TELEMETRY_LOG, "a") as f:
+                f.write(json.dumps(datapoint) + "\n")
+        except OSError as e:
+            print(
+                f"[!] Warning: Could not save mutator telemetry: {e}",
+                file=sys.stderr,
+            )

--- a/tests/test_corpus_manager.py
+++ b/tests/test_corpus_manager.py
@@ -1157,7 +1157,10 @@ class TestGenerateNewSeed(unittest.TestCase):
         mock_analyze = Mock(return_value={"status": "NO_NEW_COVERAGE"})
         mock_lineage = Mock()
 
-        with patch("builtins.open", mock_open()):
+        with patch("builtins.open", mock_open()), patch(
+            "lafleur.corpus_manager.TMP_DIR"
+        ) as mock_tmp:
+            mock_tmp.__truediv__ = Mock(side_effect=lambda name: Mock(exists=Mock(return_value=True)))
             self.corpus_manager.generate_new_seed(mock_analyze, mock_lineage)
 
         # Verify analyze was called with execution_time_ms=250 (not zero)


### PR DESCRIPTION
## Summary
- Wrap `save_state()` and `save_telemetry()` in try/except OSError to prevent disk-full errors from crashing the fuzzer
- Add timeout (120s), return code check, and output file verification to fusil subprocess in `generate_new_seed()`
- Update test to account for new subprocess validation

## Test plan
- [x] All 2028 tests pass
- [x] `ruff format` and `ruff check` clean

Closes #748

Generated with [Claude Code](https://claude.com/claude-code)