### PR TITLE
Deduplicate load_json_file into utils.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Deduplicated `load_json_file()` from `report.py`, `campaign.py`, and `triage.py` into `lafleur/utils.py`, fixing divergent exception syntax between copies, by @devdanzin.
 - `SniperMutator` with two new attack vectors: `executor_assassinate` (uses `_testinternalcapi.invalidate_executors()` to rip JIT executors out from under active traces, targeting GH-143604) and `globals_detach` (uses `types.FunctionType(func.__code__, new_globals)` to execute JIT-compiled code with detached globals, targeting GH-138378), for both helper functions and builtins, by @devdanzin.
 - `GlobalOptimizationInvalidator` with two new attack vectors: `namespace_swap` (executes JIT-warmed code via `types.FunctionType` with alternate globals containing wrong types, targeting GH-138378) and `globals_dict_mutate` (directly mutates `func.__globals__` in-place after JIT warmup to corrupt cached dict pointers), complementing the existing `evil_global_swap` strategy, by @devdanzin.
 - `UnpackingChaosMutator` with two new `_JitChaosIterator` modes: `backing_store_mutate` (actively modifies the backing list via `clear()`/`extend()`/`insert()`/`pop()` mid-iteration, targeting GH-143123) and `exception_storm` (conditionally raises `StopIteration`/`TypeError`/`ValueError` during iteration), by @devdanzin.

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -18,6 +18,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
 
+from lafleur.utils import load_json_file
+
 
 class GlobalCorpusData(TypedDict):
     """Type definition for global corpus aggregation data."""
@@ -83,15 +85,6 @@ WASTE_EVENT_TYPES: frozenset[str] = frozenset(
         "core_code_syntax_error",
     }
 )
-
-
-def load_json_file(path: Path) -> dict[str, Any] | None:
-    """Load a JSON file, returning None if it doesn't exist or is invalid."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            return json.load(f)
-    except FileNotFoundError, json.JSONDecodeError, OSError:
-        return None
 
 
 def load_health_summary(health_log_path: Path) -> HealthSummary | None:

--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -19,15 +19,7 @@ from lafleur.campaign import (
     load_health_summary,
     load_timeout_summary,
 )
-
-
-def load_json_file(path: Path) -> dict[str, Any] | None:
-    """Load a JSON file, returning None if it doesn't exist or is invalid."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            return json.load(f)
-    except FileNotFoundError, json.JSONDecodeError, OSError:
-        return None
+from lafleur.utils import load_json_file
 
 
 def load_latest_timeseries_entry(instance_dir: Path) -> dict[str, Any] | None:

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -16,15 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from lafleur.registry import CrashRegistry
-
-
-def load_json_file(path: Path) -> dict[str, Any] | None:
-    """Load a JSON file, returning None if it doesn't exist or is invalid."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return None
+from lafleur.utils import load_json_file
 
 
 def get_revision_date(revision: str) -> int | None:
@@ -46,7 +38,7 @@ def get_revision_date(revision: str) -> int | None:
         )
         if result.returncode == 0:
             return int(result.stdout.strip())
-    except (subprocess.TimeoutExpired, ValueError, OSError):
+    except subprocess.TimeoutExpired, ValueError, OSError:
         pass
     return None
 
@@ -60,7 +52,7 @@ def parse_iso_timestamp(timestamp_str: str) -> int | None:
             timestamp_str = timestamp_str[:-1] + "+00:00"
         dt = datetime.fromisoformat(timestamp_str)
         return int(dt.timestamp())
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 
@@ -278,7 +270,7 @@ def import_campaign(args: argparse.Namespace) -> None:
                 if len(rev_part) >= 8:
                     cpython_revision = rev_part
                     revision_date = get_revision_date(cpython_revision)
-            except (IndexError, ValueError):
+            except IndexError, ValueError:
                 pass
 
         # Fall back to start_time for revision_date proxy

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -27,6 +27,15 @@ FUZZING_ENV.update(
 )
 
 
+def load_json_file(path: Path) -> dict[str, Any] | None:
+    """Load a JSON file, returning None if it doesn't exist or is invalid."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError, json.JSONDecodeError, OSError:
+        return None
+
+
 def _default_run_stats() -> dict[str, Any]:
     """Return the canonical default run statistics structure."""
     return {


### PR DESCRIPTION
## Summary
- Extract triplicated `load_json_file()` from `report.py`, `campaign.py`, and `triage.py` into `lafleur/utils.py`
- All three consumers now import from the shared location
- Net reduction: 13 lines removed

## Test plan
- [x] All 2028 tests pass
- [x] `ruff format` and `ruff check` clean

Closes #750

Generated with [Claude Code](https://claude.com/claude-code)