### PR TITLE
Standardize naive datetime.now() to use timezone.utc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Replaced 6 naive `datetime.now()` calls with `datetime.now(timezone.utc)` in `report.py`, `campaign.py`, and `triage.py` to prevent potential timezone mixing errors, by @devdanzin.
 - `learning.py::save_state()` and `save_telemetry()` had no exception handling — a disk-full or permission error would crash the entire fuzzer mid-campaign. Now wrapped in try/except matching the `_log_crash_attribution()` pattern, by @devdanzin.
 - `corpus_manager.py::generate_new_seed()` fusil subprocess had no timeout, no return code check, and no output file verification — failures were silently ignored. Now validates all three, by @devdanzin.
 - Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -892,7 +892,9 @@ class CampaignAggregator:
         regression = by_type.get("regression_timeout", 0)
         if jit_hangs > 0 or regression > 0:
             lines.append(f"  JIT Hangs: {jit_hangs:,}  |  Regression Timeouts: {regression:,}")
-        lines.append(f"Report Date:    {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(
+            f"Report Date:    {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')} UTC"
+        )
         lines.append("")
 
         # ========== INSTANCE LEADERBOARD ==========
@@ -1234,7 +1236,7 @@ def generate_html_report(aggregator: CampaignAggregator) -> str:
         else "N/A"
     )
 
-    report_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    report_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
     # Fleet health data
     fleet_waste_rate = aggregator.get_fleet_waste_rate()

--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -385,7 +385,7 @@ def generate_report(instance_dir: Path) -> str:
     lines.append(f"Run ID:         {run_id}")
     lines.append(f"Hostname:       {hostname}")
     lines.append(f"Platform:       {truncate_string(platform_info, 60)}")
-    lines.append(f"Report Date:    {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"Report Date:    {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')} UTC")
     lines.append("")
 
     # ========== SYSTEM ==========

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -11,7 +11,7 @@ import argparse
 import json
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -393,9 +393,11 @@ def record_issue_wizard(args: argparse.Namespace) -> None:
         url = f"https://github.com/python/cpython/issues/{issue_number}"
 
     reported_by = input("Reported by (your GitHub username): ").strip()
-    reported_date = input(f"Reported date (default: {datetime.now().date().isoformat()}): ").strip()
+    reported_date = input(
+        f"Reported date (default: {datetime.now(timezone.utc).date().isoformat()}): "
+    ).strip()
     if not reported_date:
-        reported_date = datetime.now().date().isoformat()
+        reported_date = datetime.now(timezone.utc).date().isoformat()
 
     description = input("Brief description: ").strip()
 
@@ -456,7 +458,7 @@ def record_issue_wizard(args: argparse.Namespace) -> None:
                     fingerprint=fingerprint,
                     run_id="manual",
                     instance_name="manual",
-                    timestamp=datetime.now().isoformat(),
+                    timestamp=datetime.now(timezone.utc).isoformat(),
                 )
                 registry.link_crash_to_issue(fingerprint, issue_number)
                 print(f"[+] Created crash record and linked to issue #{issue_number}")


### PR DESCRIPTION
## Summary
- Replace 6 naive `datetime.now()` calls with `datetime.now(timezone.utc)` across `report.py`, `campaign.py`, and `triage.py`
- Add missing `timezone` import to `triage.py`
- Report timestamps now include "UTC" suffix for clarity

## Test plan
- [x] All 2028 tests pass
- [x] `ruff format` and `ruff check` clean

Closes #752

Generated with [Claude Code](https://claude.com/claude-code)