### PR TITLE
Replace deprecated IOError with OSError across codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Replaced deprecated `IOError` with `OSError` in 11 locations across 8 modules, removing redundant dual-catches at `coverage.py` and `utils.py`, by @devdanzin.
 - Replaced 6 naive `datetime.now()` calls with `datetime.now(timezone.utc)` in `report.py`, `campaign.py`, and `triage.py` to prevent potential timezone mixing errors, by @devdanzin.
 - `learning.py::save_state()` and `save_telemetry()` had no exception handling — a disk-full or permission error would crash the entire fuzzer mid-campaign. Now wrapped in try/except matching the `_log_crash_attribution()` pattern, by @devdanzin.
 - `corpus_manager.py::generate_new_seed()` fusil subprocess had no timeout, no return code check, and no output file verification — failures were silently ignored. Now validates all three, by @devdanzin.

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -703,7 +703,7 @@ class ArtifactManager:
         )
         try:
             diff_path.write_text("".join(diff))
-        except IOError as e:
+        except OSError as e:
             print(f"  [!] CRITICAL: Could not save divergence diff: {e}", file=sys.stderr)
             return
 
@@ -820,7 +820,7 @@ class TelemetryManager:
         try:
             with open(self.timeseries_log_path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(datapoint) + "\n")
-        except IOError as e:
+        except OSError as e:
             print(
                 f"[!] Warning: Could not write to time-series log file: {e}",
                 file=sys.stderr,

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -304,7 +304,7 @@ class CorpusManager:
                         print(f"[~] File content has changed for {filename}. Re-analyzing.")
                         del self.coverage_state.state["per_file_coverage"][filename]
                         files_to_analyze.add(filename)
-                except (IOError, KeyError) as e:
+                except (OSError, KeyError) as e:
                     print(f"[!] Error processing existing file {filename}: {e}. Re-analyzing.")
                     if filename in self.coverage_state.state["per_file_coverage"]:
                         del self.coverage_state.state["per_file_coverage"][filename]

--- a/lafleur/coverage.py
+++ b/lafleur/coverage.py
@@ -281,7 +281,7 @@ def load_coverage_state() -> dict[str, Any]:
 
         ensure_state_schema(state)
         return state
-    except (pickle.UnpicklingError, IOError, EOFError) as e:
+    except (pickle.UnpicklingError, OSError, EOFError) as e:
         print(f"Warning: Could not load coverage state file. Error: {e}", file=sys.stderr)
         state = {}
         ensure_state_schema(state)
@@ -299,7 +299,7 @@ def save_coverage_state(state: dict[str, Any]) -> None:
             pickle.dump(state, f)
         # The write was successful, now atomically rename the file.
         tmp_path.rename(COVERAGE_STATE_FILE)
-    except (IOError, OSError, pickle.PicklingError) as e:
+    except (OSError, pickle.PicklingError) as e:
         print(f"[!] Error during atomic save of coverage state: {e}", file=sys.stderr)
         # If an error occurred, try to clean up the temporary file.
         if tmp_path.exists():

--- a/lafleur/learning.py
+++ b/lafleur/learning.py
@@ -239,7 +239,7 @@ class MutatorScoreTracker:
         try:
             with open(CRASH_ATTRIBUTION_LOG, "a", encoding="utf-8") as f:
                 f.write(json.dumps(entry) + "\n")
-        except IOError as e:
+        except OSError as e:
             print(
                 f"[!] Warning: Could not write crash attribution log: {e}",
                 file=sys.stderr,

--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -157,7 +157,7 @@ class MutationController:
             parent_core_tree = cast(ast.Module, normalizer.visit(parent_core_tree))
             ast.fix_missing_locations(parent_core_tree)
 
-        except (IOError, SyntaxError) as e:
+        except (OSError, SyntaxError) as e:
             print(f"[!] Error processing parent file {parent_path.name}: {e}", file=sys.stderr)
             return None, None, None
 

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -609,7 +609,7 @@ class ScoringManager:
         log_content = ""
         try:
             log_content = exec_result.log_path.read_text()
-        except IOError as e:
+        except OSError as e:
             print(f"  [!] Warning: Could not read log file for analysis: {e}", file=sys.stderr)
 
         if self.artifact_manager.check_for_crash(

--- a/lafleur/state_tool.py
+++ b/lafleur/state_tool.py
@@ -106,7 +106,7 @@ def main() -> None:
     try:
         with open(args.input_file, "rb") as f:
             state = pickle.load(f)
-    except (pickle.UnpicklingError, IOError) as e:
+    except (pickle.UnpicklingError, OSError) as e:
         print(f"Error: Could not read pickle file: {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -71,7 +71,7 @@ def load_run_stats() -> dict[str, Any]:
                 if key != "start_time":
                     stats.setdefault(key, value)
             return stats
-    except (json.JSONDecodeError, IOError) as e:
+    except (json.JSONDecodeError, OSError) as e:
         print(
             f"Warning: Could not load run stats file. Starting fresh. Error: {e}",
             file=sys.stderr,
@@ -84,7 +84,7 @@ def save_run_stats(stats: dict[str, Any]) -> None:
     try:
         with open(RUN_STATS_FILE, "w", encoding="utf-8") as f:
             json.dump(stats, f, indent=2, sort_keys=True)
-    except (IOError, OSError) as e:
+    except OSError as e:
         print(
             f"Warning: Could not save run stats: {e}",
             file=sys.stderr,


### PR DESCRIPTION
## Summary
- Replace `IOError` with `OSError` in 11 locations across 8 modules
- Remove redundant dual-catches at `coverage.py` and `utils.py` where both were caught

## Test plan
- [x] All 2028 tests pass
- [x] `ruff format` and `ruff check` clean

Closes #754

Generated with [Claude Code](https://claude.com/claude-code)