### PR TITLE
Add encoding='utf-8' to open() calls missing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Added explicit `encoding="utf-8"` to 10 text-mode `open()` calls missing it across 6 modules, matching the majority convention, by @devdanzin.
 - Replaced deprecated `IOError` with `OSError` in 11 locations across 8 modules, removing redundant dual-catches at `coverage.py` and `utils.py`, by @devdanzin.
 - Replaced 6 naive `datetime.now()` calls with `datetime.now(timezone.utc)` in `report.py`, `campaign.py`, and `triage.py` to prevent potential timezone mixing errors, by @devdanzin.
 - `learning.py::save_state()` and `save_telemetry()` had no exception handling — a disk-full or permission error would crash the entire fuzzer mid-campaign. Now wrapped in try/except matching the `_log_crash_attribution()` pattern, by @devdanzin.

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -237,7 +237,7 @@ class CorpusManager:
             log_path = TMP_DIR / f"sync_{source_path.stem}.log"
             print(f"  -> Analyzing {filename} (timeout: {self.execution_timeout}s)...")
             try:
-                with open(log_path, "w") as log_file:
+                with open(log_path, "w", encoding="utf-8") as log_file:
                     start_time = time.monotonic()
                     result = subprocess.run(
                         [self.target_python, str(source_path)],
@@ -471,7 +471,7 @@ class CorpusManager:
 
         # Execute it to get a log (also using the configurable timeout)
         try:
-            with open(tmp_log, "w") as log_file:
+            with open(tmp_log, "w", encoding="utf-8") as log_file:
                 t0 = time.monotonic()
                 result = subprocess.run(
                     [self.target_python, tmp_source],

--- a/lafleur/execution.py
+++ b/lafleur/execution.py
@@ -504,7 +504,7 @@ class ExecutionManager:
                                 selection = self.corpus_manager.select_parent()
                                 if selection:
                                     polluters.append(selection[0])
-                        except (AttributeError, IndexError):
+                        except AttributeError, IndexError:
                             # Corpus empty or select_parent not available
                             pass
 
@@ -535,7 +535,7 @@ class ExecutionManager:
                 cmd = [self.target_python, str(child_source_path)]
 
             coverage_env = self._build_env(jit=True, debug_logs=True)
-            with open(child_log_path, "w") as log_file:
+            with open(child_log_path, "w", encoding="utf-8") as log_file:
                 start_time = time.monotonic()
                 result = subprocess.run(
                     cmd,

--- a/lafleur/learning.py
+++ b/lafleur/learning.py
@@ -74,7 +74,7 @@ class MutatorScoreTracker:
         """Load the last known scores and attempts from a file."""
         if MUTATOR_SCORES_FILE.is_file():
             try:
-                with open(MUTATOR_SCORES_FILE, "r") as f:
+                with open(MUTATOR_SCORES_FILE, "r", encoding="utf-8") as f:
                     data = json.load(f)
                 self.scores = defaultdict(float, data.get("scores", {}))
                 self.attempts = defaultdict(int, data.get("attempts", {}))
@@ -97,7 +97,7 @@ class MutatorScoreTracker:
                 "attempts": dict(self.attempts),
                 "attempt_counter": self._attempt_counter,
             }
-            with open(MUTATOR_SCORES_FILE, "w") as f:
+            with open(MUTATOR_SCORES_FILE, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
         except OSError as e:
             print(
@@ -259,7 +259,7 @@ class MutatorScoreTracker:
                 "attempts": dict(self.attempts),
                 "success_rates": success_rates,
             }
-            with open(MUTATOR_TELEMETRY_LOG, "a") as f:
+            with open(MUTATOR_TELEMETRY_LOG, "a", encoding="utf-8") as f:
                 f.write(json.dumps(datapoint) + "\n")
         except OSError as e:
             print(

--- a/lafleur/lineage.py
+++ b/lafleur/lineage.py
@@ -435,7 +435,7 @@ def resolve_session_scripts(
     metadata_path = crash_dir / "metadata.json"
     metadata: dict = {}
     if metadata_path.exists():
-        with open(metadata_path) as f:
+        with open(metadata_path, encoding="utf-8") as f:
             metadata = json.load(f)
 
     # Strategy 1: session_corpus_files from metadata
@@ -508,7 +508,7 @@ def extract_session_ancestry(
     metadata_path = crash_dir / "metadata.json"
     crash_meta: dict = {}
     if metadata_path.exists():
-        with open(metadata_path) as f:
+        with open(metadata_path, encoding="utf-8") as f:
             crash_meta = json.load(f)
 
     crash_node_id = f"__crash_{crash_dir.name}"
@@ -707,9 +707,9 @@ def scan_crashes(crashes_dir: Path) -> list[dict]:
             continue
 
         try:
-            with open(metadata_path) as f:
+            with open(metadata_path, encoding="utf-8") as f:
                 meta = json.load(f)
-        except (json.JSONDecodeError, OSError):
+        except json.JSONDecodeError, OSError:
             continue
 
         crash_info: dict = {
@@ -1661,7 +1661,7 @@ def render_ancestry_svg(
             timeout=60,
         )
         return result.stdout if result.returncode == 0 else None
-    except (subprocess.TimeoutExpired, OSError):
+    except subprocess.TimeoutExpired, OSError:
         return None
 
 

--- a/lafleur/state_tool.py
+++ b/lafleur/state_tool.py
@@ -126,7 +126,7 @@ def main() -> None:
         print(json.dumps(migrated_state, indent=2, default=set_to_list))
 
     elif args.output_file.suffix == ".json":
-        with open(args.output_file, "w") as json_f:
+        with open(args.output_file, "w", encoding="utf-8") as json_f:
             json.dump(migrated_state, json_f, indent=2, default=set_to_list)
         print(f"State saved as JSON to {args.output_file}")
 


### PR DESCRIPTION
## Summary
- Add explicit `encoding="utf-8"` to 10 text-mode `open()` calls across 6 modules
- Matches the majority convention used in 23+ other locations
- Exception-tuple syntax (PEP 758) confirmed as project standard via ruff

## Test plan
- [x] All 2028 tests pass
- [x] `ruff format` and `ruff check` clean

Closes #756

Generated with [Claude Code](https://claude.com/claude-code)