### PR TITLE
docs: update CLAUDE.md with missing entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project should be documented in this file.
 - Added complete `lafleur-lineage` section to TOOLING.md with modes, options, example workflow, and output formats, by @devdanzin.
 - Added seed generation and management guide (`doc/dev/11_seeding.md`) covering fusil integration, seeding workflow, hand-rolled seed templates, and best practices, by @devdanzin.
 - Cross-referenced `11_seeding.md` from CLAUDE.md, architecture overview, glossary (Fusil, Seed), and getting started guide, by @devdanzin.
+- Updated CLAUDE.md CLI Entry Points with `lafleur-driver` and `lafleur-lineage`, and Project Structure with `driver.py`, `lineage.py`, `minimize.py`, `state_tool.py`, and `corpus_analysis.py`, by @devdanzin.
 - A **TimeoutLogger** structured metadata system that logs every timeout event to `timeout_events.jsonl` with type, parent ID, mutation strategy, transformers, lineage depth, execution stage, and timeout duration, by @devdanzin.
 - A `load_timeout_summary()` reader function in campaign.py that aggregates timeout metadata into counters by type, parent, strategy, transformer, and execution stage, by @devdanzin.
 - A `--no-save-timeouts` CLI flag to skip saving normal timeout artifacts (.py source + .log files) to disk while preserving all structured metadata logging to `timeout_events.jsonl`. JIT hangs and regression timeouts are always saved regardless, by @devdanzin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,11 @@ lafleur-triage export-issues known_issues.json
   - `campaign.py` — Multi-instance campaign aggregator with HTML reports
   - `registry.py` — SQLite-based crash registry for historical tracking
   - `triage.py` — Interactive crash triage CLI
+  - `driver.py` — Session fuzzing driver for multi-script JIT state persistence
+  - `lineage.py` — Corpus lineage visualization (ancestry, descendants, forest, MRCA)
+  - `minimize.py` — Advanced session crash minimizer (script reduction + shrinkray)
+  - `state_tool.py` — CLI utility for inspecting and migrating coverage_state.pkl
+  - `corpus_analysis.py` — Corpus statistics and evolutionary history analysis
 - `tests/` — Test suite (unittest-based)
 - `doc/dev/` — Developer documentation
 - `docs/` — User-facing documentation (TOOLING.md)
@@ -412,4 +417,5 @@ Defined in `pyproject.toml` under `[project.scripts]`:
 - `lafleur-report` → `lafleur.report:main` — Single instance reporter
 - `lafleur-campaign` → `lafleur.campaign:main` — Campaign aggregator
 - `lafleur-triage` → `lafleur.triage:main` — Crash triage CLI
-  
+- `lafleur-driver` → `lafleur.driver:main` — Session fuzzing driver (multi-script JIT state persistence)
+- `lafleur-lineage` → `lafleur.lineage:main` — Corpus lineage visualization tool


### PR DESCRIPTION
## Summary
- Add `lafleur-driver` and `lafleur-lineage` to CLI Entry Points section
- Add `driver.py`, `lineage.py`, `minimize.py`, `state_tool.py`, `corpus_analysis.py` to Project Structure

## Test plan
- [x] 2028 tests pass

Closes #762

Generated with [Claude Code](https://claude.com/claude-code)