### PR TITLE
fix: harden error handling in lineage.py and metadata.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ All notable changes to this project should be documented in this file.
 - Replaced 6 naive `datetime.now()` calls with `datetime.now(timezone.utc)` in `report.py`, `campaign.py`, and `triage.py` to prevent potential timezone mixing errors, by @devdanzin.
 - `learning.py::save_state()` and `save_telemetry()` had no exception handling — a disk-full or permission error would crash the entire fuzzer mid-campaign. Now wrapped in try/except matching the `_log_crash_attribution()` pattern, by @devdanzin.
 - `corpus_manager.py::generate_new_seed()` fusil subprocess had no timeout, no return code check, and no output file verification — failures were silently ignored. Now validates all three, by @devdanzin.
+- `lineage.py::load_coverage_state()` had no exception handling on `pickle.load()` — a corrupted state file would crash `lafleur-lineage` with an opaque error. Now catches `UnpicklingError`/`EOFError`/`OSError` with a clear message, by @devdanzin.
+- `metadata.py::get_installed_packages()` bare `except Exception: pass` silently swallowed all errors during package metadata collection. Now logs warnings to stderr, by @devdanzin.
 - Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.
 
 ### Enhanced

--- a/lafleur/lineage.py
+++ b/lafleur/lineage.py
@@ -152,8 +152,15 @@ class TreeMetrics:
 
 def load_coverage_state(state_path: Path) -> dict:
     """Load coverage_state.pkl and return the full state dict."""
-    with open(state_path, "rb") as f:
-        return pickle.load(f)
+    try:
+        with open(state_path, "rb") as f:
+            return pickle.load(f)
+    except (pickle.UnpicklingError, OSError, EOFError) as e:
+        print(
+            f"[!] Error: Could not load coverage state from {state_path}: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def build_adjacency_graph(per_file_coverage: dict[str, dict]) -> LineageGraph:

--- a/lafleur/metadata.py
+++ b/lafleur/metadata.py
@@ -246,8 +246,8 @@ def get_installed_packages() -> list[dict[str, str]]:
     for dist in distributions():
         try:
             packages.append({"name": dist.metadata["Name"], "version": dist.metadata["Version"]})
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[!] Warning: Could not read package metadata: {e}", file=sys.stderr)
     # Sort by name for consistent output
     return sorted(packages, key=lambda p: p["name"].lower())
 


### PR DESCRIPTION
## Summary
- Add try/except for `pickle.load()` in `lineage.py::load_coverage_state()` matching `coverage.py`'s pattern
- Replace bare `except Exception: pass` in `metadata.py::get_installed_packages()` with stderr warnings

## Test plan
- [x] ruff format/check pass
- [x] 2028 tests pass

Closes #768

Generated with [Claude Code](https://claude.com/claude-code)