### PR TITLE
refactor: replace dict[str, Any] with existing TypedDicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Replaced `dict[str, Any]` with existing TypedDicts (`HarnessCoverage`, `CorpusFileMetadata`, `CrashRegistry`) in function signatures across `types.py`, `campaign.py`, `corpus_manager.py`, and `lineage.py` for stronger static typing, by @devdanzin.
 - Deduplicated `load_json_file()` from `report.py`, `campaign.py`, and `triage.py` into `lafleur/utils.py`, fixing divergent exception syntax between copies, by @devdanzin.
 - Added missing `-> None` return annotations to 4 `learning.py` methods, deduplicated `TMP_DIR` constant in `orchestrator.py` (now imported from `corpus_manager`), standardized `triage.py` JSON indent from 4 to 2, and fixed `pyproject.toml` duplicate classifier and inconsistent quote style, by @devdanzin.
 - Migrated 3 inline JSON loading patterns in `lineage.py` to use shared `load_json_file()` from `utils.py`, by @devdanzin.

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -16,9 +16,12 @@ from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from lafleur.utils import load_json_file
+
+if TYPE_CHECKING:
+    from lafleur.registry import CrashRegistry
 
 
 class GlobalCorpusData(TypedDict):
@@ -812,7 +815,7 @@ class CampaignAggregator:
         else:
             return ("BAD", "Unhealthy")
 
-    def enrich_crashes_from_registry(self, registry: Any) -> None:
+    def enrich_crashes_from_registry(self, registry: CrashRegistry) -> None:
         """
         Enrich crash data with registry context.
 

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-from lafleur.coverage import save_coverage_state, CoverageManager
+from lafleur.coverage import HarnessCoverage, save_coverage_state, CoverageManager
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
 from lafleur.types import CorpusFileMetadata, MutationInfo, NewCoverageResult
 from lafleur.utils import ExecutionResult, FUZZING_ENV
@@ -356,7 +356,7 @@ class CorpusManager:
     def add_new_file(
         self,
         core_code: str,
-        baseline_coverage: dict[str, Any],
+        baseline_coverage: dict[str, HarnessCoverage],
         execution_time_ms: int,
         parent_id: str | None,
         mutation_info: MutationInfo,

--- a/lafleur/lineage.py
+++ b/lafleur/lineage.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from statistics import mean
 
+from lafleur.types import CorpusFileMetadata
 from lafleur.utils import load_json_file
 
 # ---------------------------------------------------------------------------
@@ -163,7 +164,7 @@ def load_coverage_state(state_path: Path) -> dict:
         sys.exit(1)
 
 
-def build_adjacency_graph(per_file_coverage: dict[str, dict]) -> LineageGraph:
+def build_adjacency_graph(per_file_coverage: dict[str, CorpusFileMetadata]) -> LineageGraph:
     """Build the full adjacency graph from per_file_coverage metadata."""
     children: dict[str, list[str]] = defaultdict(list)
     parent: dict[str, str | None] = {}
@@ -427,7 +428,7 @@ def extract_mrca(graph: LineageGraph, targets: list[str]) -> Subgraph:
 
 def resolve_session_scripts(
     crash_dir: Path,
-    per_file_coverage: dict[str, dict],
+    per_file_coverage: dict[str, CorpusFileMetadata],
 ) -> dict[str, str | None]:
     """Map session scripts in a crash directory to their corpus filenames.
 
@@ -496,7 +497,7 @@ def resolve_session_scripts(
 def extract_session_ancestry(
     graph: LineageGraph,
     crash_dir: Path,
-    per_file_coverage: dict[str, dict],
+    per_file_coverage: dict[str, CorpusFileMetadata],
     attack_only: bool = False,
 ) -> Subgraph:
     """Extract the merged ancestry of all session scripts, converging on a crash node.
@@ -2011,7 +2012,9 @@ def print_forest_stats(
 # ---------------------------------------------------------------------------
 
 
-def resolve_target(target_str: str, per_file_coverage: dict[str, dict]) -> tuple[str | Path, str]:
+def resolve_target(
+    target_str: str, per_file_coverage: dict[str, CorpusFileMetadata]
+) -> tuple[str | Path, str]:
     """Resolve a CLI target argument to a corpus filename or crash dir Path.
 
     Handles:

--- a/lafleur/types.py
+++ b/lafleur/types.py
@@ -153,7 +153,7 @@ class NewCoverageResult(AnalysisResult):
     """Returned when the child produced new coverage worth keeping."""
 
     core_code: str
-    baseline_coverage: dict
+    baseline_coverage: dict[str, HarnessCoverage]
     content_hash: str
     coverage_hash: str
     execution_time_ms: int


### PR DESCRIPTION
## Summary
- Tightened `NewCoverageResult.baseline_coverage` from bare `dict` to `dict[str, HarnessCoverage]`
- Changed `enrich_crashes_from_registry(registry: Any)` to use `CrashRegistry` type via `TYPE_CHECKING` guard
- Replaced `dict[str, Any]` with `dict[str, HarnessCoverage]` in `CorpusManager.add_new_file`
- Replaced `dict[str, dict]` with `dict[str, CorpusFileMetadata]` in 4 `lineage.py` functions

## Test plan
- [x] `ruff format` — no changes needed
- [x] `ruff check` — all checks passed
- [x] `pytest tests/ -v` — 2061 tests passed

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)