### PR TITLE
refactor: replace __name__.replace() with strategy_map dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Replaced fragile `__name__.replace()` strategy name extraction in `mutation_controller.py` with an explicit `strategy_map` dict mapping methods to canonical names, by @devdanzin.
 - Extracted `_prompt_issue_number` and `_prompt_note` shared helpers in `triage.py` to deduplicate interactive input logic between `run_interactive_triage` and `run_review_triage`, with unified EOF handling via `_EOFReceived` sentinel, by @devdanzin.
 - Extracted `_compose_session` helper in `execution.py` to isolate session file composition logic (solo/standard/mixer) from `execute_child`, reducing nesting depth, by @devdanzin.
 - Split `artifacts.py:check_for_crash` into `_classify_crash` (detection/filtering) and `check_for_crash` (artifact saving), separating crash classification from persistence, by @devdanzin.

--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -383,17 +383,21 @@ class MutationController:
         tree_copy = normalizer.visit(tree_copy)
 
         # --- Strategy selection ---
+        # Canonical mapping from strategy method to name, used for both
+        # forced selection and adaptive weight lookup.
+        strategy_map: dict[MutationStrategy, str] = {
+            self._run_deterministic_stage: "deterministic",
+            self._run_havoc_stage: "havoc",
+            self._run_spam_stage: "spam",
+            self._run_helper_sniper_stage: "helper_sniper",
+            self._run_sniper_stage: "sniper",
+        }
+
         chosen_strategy: MutationStrategy
         if self.forced_strategy is not None:
             # Diagnostic mode: bypass adaptive selection
-            strategy_map: dict[str, MutationStrategy] = {
-                "deterministic": self._run_deterministic_stage,
-                "havoc": self._run_havoc_stage,
-                "spam": self._run_spam_stage,
-                "helper_sniper": self._run_helper_sniper_stage,
-                "sniper": self._run_sniper_stage,
-            }
-            chosen_strategy = strategy_map[self.forced_strategy]
+            name_to_strategy = {v: k for k, v in strategy_map.items()}
+            chosen_strategy = name_to_strategy[self.forced_strategy]
             chosen_name = self.forced_strategy
             self.score_tracker.record_attempt(chosen_name)
         else:
@@ -408,9 +412,7 @@ class MutationController:
             if watched_keys:
                 strategy_candidates.append(self._run_sniper_stage)
 
-            strategy_names = [
-                s.__name__.replace("_run_", "").replace("_stage", "") for s in strategy_candidates
-            ]
+            strategy_names = [strategy_map[s] for s in strategy_candidates]
 
             dynamic_weights = self.score_tracker.get_weights(strategy_names)
 
@@ -420,7 +422,7 @@ class MutationController:
                 dynamic_weights[sniper_idx] = max(dynamic_weights[sniper_idx], avg_weight * 1.5)
 
             chosen_strategy = RANDOM.choices(strategy_candidates, weights=dynamic_weights, k=1)[0]
-            chosen_name = chosen_strategy.__name__.replace("_run_", "").replace("_stage", "")
+            chosen_name = strategy_map[chosen_strategy]
             self.score_tracker.record_attempt(chosen_name)
 
         len_body = (


### PR DESCRIPTION
## Summary
- Replaced fragile `s.__name__.replace('_run_', '').replace('_stage', '')` with explicit `strategy_map` dict
- Shared map between forced and adaptive strategy selection paths
- Names are now explicit string literals rather than derived from method names

## Test plan
- [x] All 2061 tests pass
- [x] ruff format and check pass

Closes #788

Generated with [Claude Code](https://claude.com/claude-code)