### PR TITLE
refactor: group score_and_decide_interestingness params into ScoringContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Introduced `ScoringContext` frozen dataclass to bundle 9 parameters of `score_and_decide_interestingness` in `scoring.py`, reducing the method signature from 11 to 3 parameters, by @devdanzin.
 - Replaced fragile `__name__.replace()` strategy name extraction in `mutation_controller.py` with an explicit `strategy_map` dict mapping methods to canonical names, by @devdanzin.
 - Extracted `_prompt_issue_number` and `_prompt_note` shared helpers in `triage.py` to deduplicate interactive input logic between `run_interactive_triage` and `run_review_triage`, with unified EOF handling via `_EOFReceived` sentinel, by @devdanzin.
 - Extracted `_compose_session` helper in `execution.py` to isolate session file composition logic (solo/standard/mixer) from `execute_child`, reducing nesting depth, by @devdanzin.

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -38,6 +38,23 @@ if TYPE_CHECKING:
     from lafleur.corpus_manager import CorpusManager
     from lafleur.health import HealthMonitor
 
+
+@dataclass(frozen=True)
+class ScoringContext:
+    """Bundles parameters for interestingness scoring decisions."""
+
+    parent_id: str | None
+    mutation_info: MutationInfo
+    parent_file_size: int
+    parent_lineage_edge_count: int
+    child_file_size: int
+    jit_avg_time_ms: float | None = None
+    nojit_avg_time_ms: float | None = None
+    nojit_cv: float | None = None
+    jit_stats: JitStats | None = None
+    parent_jit_stats: JitStats | None = None
+
+
 # Coverage types tracked by the fuzzer
 COVERAGE_TYPES = ("uops", "edges", "rare_events")
 
@@ -472,38 +489,19 @@ class ScoringManager:
     def score_and_decide_interestingness(
         self,
         coverage_info: NewCoverageInfo,
-        parent_id: str | None,
-        mutation_info: MutationInfo,
-        parent_file_size: int,
-        parent_lineage_edge_count: int,
-        child_file_size: int,
-        jit_avg_time_ms: float | None,
-        nojit_avg_time_ms: float | None,
-        nojit_cv: float | None,
-        jit_stats: JitStats | None = None,
-        parent_jit_stats: JitStats | None = None,
+        ctx: ScoringContext,
     ) -> bool:
-        """
-        Use the scorer to decide if a child is interesting.
+        """Use the scorer to decide if a child is interesting.
 
         Args:
-            coverage_info: NewCoverageInfo with coverage counts
-            parent_id: ID of the parent file (None for seeds)
-            mutation_info: Information about the mutation applied
-            parent_file_size: Size of parent file in bytes
-            parent_lineage_edge_count: Number of edges in parent's lineage
-            child_file_size: Size of child file in bytes
-            jit_avg_time_ms: Average JIT execution time
-            nojit_avg_time_ms: Average non-JIT execution time
-            nojit_cv: Coefficient of variation for non-JIT timing
-            jit_stats: JIT statistics from child execution
-            parent_jit_stats: JIT statistics from parent
+            coverage_info: NewCoverageInfo with coverage counts.
+            ctx: ScoringContext bundling parent/child metadata and timing.
 
         Returns:
-            True if the child is considered interesting
+            True if the child is considered interesting.
         """
-        if parent_id is None:
-            is_seed = "seed" in mutation_info.get("strategy", "")
+        if ctx.parent_id is None:
+            is_seed = "seed" in ctx.mutation_info.get("strategy", "")
             if coverage_info.is_interesting() or is_seed:
                 return True
             else:
@@ -513,15 +511,15 @@ class ScoringManager:
         # For normal mutations, use the scoring logic.
         scorer = InterestingnessScorer(
             coverage_info,
-            parent_file_size,
-            parent_lineage_edge_count,
-            child_file_size,
+            ctx.parent_file_size,
+            ctx.parent_lineage_edge_count,
+            ctx.child_file_size,
             self.timing_fuzz,
-            jit_avg_time_ms,
-            nojit_avg_time_ms,
-            nojit_cv,
-            jit_stats,
-            parent_jit_stats,
+            ctx.jit_avg_time_ms,
+            ctx.nojit_avg_time_ms,
+            ctx.nojit_cv,
+            ctx.jit_stats,
+            ctx.parent_jit_stats,
         )
         score = scorer.calculate_score()
 
@@ -663,19 +661,19 @@ class ScoringManager:
             ].get(parent_id, {})
             parent_jit_stats = parent_metadata.get("discovery_mutation", {}).get("jit_stats", {})
 
-        is_interesting = self.score_and_decide_interestingness(
-            coverage_info,
-            parent_id,
-            mutation_info,
-            parent_file_size,
-            parent_lineage_edge_count,
-            exec_result.source_path.stat().st_size,
-            exec_result.jit_avg_time_ms,
-            exec_result.nojit_avg_time_ms,
-            exec_result.nojit_cv,
-            jit_stats,
-            parent_jit_stats,
+        scoring_ctx = ScoringContext(
+            parent_id=parent_id,
+            mutation_info=mutation_info,
+            parent_file_size=parent_file_size,
+            parent_lineage_edge_count=parent_lineage_edge_count,
+            child_file_size=exec_result.source_path.stat().st_size,
+            jit_avg_time_ms=exec_result.jit_avg_time_ms,
+            nojit_avg_time_ms=exec_result.nojit_avg_time_ms,
+            nojit_cv=exec_result.nojit_cv,
+            jit_stats=jit_stats,
+            parent_jit_stats=parent_jit_stats,
         )
+        is_interesting = self.score_and_decide_interestingness(coverage_info, scoring_ctx)
 
         if is_interesting:
             return self._prepare_new_coverage_result(

--- a/tests/orchestrator/test_coverage.py
+++ b/tests/orchestrator/test_coverage.py
@@ -12,7 +12,7 @@ import io
 import unittest
 from unittest.mock import MagicMock, patch
 
-from lafleur.scoring import ScoringManager, NewCoverageInfo
+from lafleur.scoring import ScoringContext, ScoringManager, NewCoverageInfo
 
 
 class TestFindNewCoverage(unittest.TestCase):
@@ -327,18 +327,15 @@ class TestScoreAndDecideInterestingness(unittest.TestCase):
         coverage_info = NewCoverageInfo(global_uops=1)
         mutation_info = {"strategy": "seed_strategy"}
 
+        ctx = ScoringContext(
+            parent_id=None,
+            mutation_info=mutation_info,
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+        )
         with patch("sys.stderr", new_callable=io.StringIO):
-            result = self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id=None,  # Seed
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
-            )
+            result = self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         self.assertTrue(result)
 
@@ -347,18 +344,15 @@ class TestScoreAndDecideInterestingness(unittest.TestCase):
         coverage_info = NewCoverageInfo()
         mutation_info = {"strategy": "other_strategy"}
 
+        ctx = ScoringContext(
+            parent_id=None,
+            mutation_info=mutation_info,
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+        )
         with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
-            result = self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id=None,  # Seed
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
-            )
+            result = self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         self.assertFalse(result)
         self.assertIn("no JIT coverage", mock_stderr.getvalue())
@@ -367,20 +361,16 @@ class TestScoreAndDecideInterestingness(unittest.TestCase):
         """Test that score >= 10 is interesting."""
         # 2 global edges = 20 points
         coverage_info = NewCoverageInfo(global_edges=2)
-        mutation_info = {"strategy": "havoc"}
+        ctx = ScoringContext(
+            parent_id="parent1",
+            mutation_info={"strategy": "havoc"},
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+        )
 
         with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
-            result = self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id="parent1",
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
-            )
+            result = self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         self.assertTrue(result)
         self.assertIn("interesting with score", mock_stderr.getvalue())
@@ -389,20 +379,16 @@ class TestScoreAndDecideInterestingness(unittest.TestCase):
         """Test that score < 10 is not interesting."""
         # 1 relative edge = 1 point
         coverage_info = NewCoverageInfo(relative_edges=1)
-        mutation_info = {"strategy": "havoc"}
+        ctx = ScoringContext(
+            parent_id="parent1",
+            mutation_info={"strategy": "havoc"},
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+        )
 
         with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
-            result = self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id="parent1",
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
-            )
+            result = self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         self.assertFalse(result)
         self.assertIn("IS NOT interesting", mock_stderr.getvalue())
@@ -411,20 +397,19 @@ class TestScoreAndDecideInterestingness(unittest.TestCase):
         """Test that timing bonus can make it interesting."""
         self.scoring_manager = ScoringManager(self.coverage_manager, timing_fuzz=True)
         coverage_info = NewCoverageInfo()
-        mutation_info = {"strategy": "havoc"}
+        ctx = ScoringContext(
+            parent_id="parent1",
+            mutation_info={"strategy": "havoc"},
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+            jit_avg_time_ms=100.0,
+            nojit_avg_time_ms=10.0,
+            nojit_cv=0.1,
+        )
 
         with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
-            result = self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id="parent1",
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=100.0,  # 10x slowdown
-                nojit_avg_time_ms=10.0,
-                nojit_cv=0.1,
-            )
+            result = self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         self.assertTrue(result)
         self.assertIn("JIT slowdown", mock_stderr.getvalue())
@@ -433,40 +418,32 @@ class TestScoreAndDecideInterestingness(unittest.TestCase):
         """Test score exactly at threshold (10.0)."""
         # 1 global edge = 10 points (exactly at threshold)
         coverage_info = NewCoverageInfo(global_edges=1)
-        mutation_info = {"strategy": "havoc"}
+        ctx = ScoringContext(
+            parent_id="parent1",
+            mutation_info={"strategy": "havoc"},
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+        )
 
         with patch("sys.stderr", new_callable=io.StringIO):
-            result = self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id="parent1",
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
-            )
+            result = self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         self.assertTrue(result)
 
     def test_decide_logs_score(self):
         """Test that score is logged to stderr."""
         coverage_info = NewCoverageInfo(global_edges=1)
-        mutation_info = {"strategy": "havoc"}
+        ctx = ScoringContext(
+            parent_id="parent1",
+            mutation_info={"strategy": "havoc"},
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+        )
 
         with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
-            self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id="parent1",
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
-            )
+            self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         output = mock_stderr.getvalue()
         self.assertIn("10.00", output)  # Score should be logged
@@ -475,20 +452,19 @@ class TestScoreAndDecideInterestingness(unittest.TestCase):
         """Test that no timing bonus is given when timing_fuzz=False."""
         self.scoring_manager = ScoringManager(self.coverage_manager, timing_fuzz=False)
         coverage_info = NewCoverageInfo()
-        mutation_info = {"strategy": "havoc"}
+        ctx = ScoringContext(
+            parent_id="parent1",
+            mutation_info={"strategy": "havoc"},
+            parent_file_size=100,
+            parent_lineage_edge_count=50,
+            child_file_size=100,
+            jit_avg_time_ms=100.0,
+            nojit_avg_time_ms=10.0,
+            nojit_cv=0.1,
+        )
 
         with patch("sys.stderr", new_callable=io.StringIO):
-            result = self.scoring_manager.score_and_decide_interestingness(
-                coverage_info,
-                parent_id="parent1",
-                mutation_info=mutation_info,
-                parent_file_size=100,
-                parent_lineage_edge_count=50,
-                child_file_size=100,
-                jit_avg_time_ms=100.0,  # Would be 10x slowdown
-                nojit_avg_time_ms=10.0,
-                nojit_cv=0.1,
-            )
+            result = self.scoring_manager.score_and_decide_interestingness(coverage_info, ctx)
 
         # No timing bonus, score = 0, should not be interesting
         self.assertFalse(result)
@@ -529,17 +505,14 @@ class TestCoverageWorkflow(unittest.TestCase):
             coverage_hash = self.scoring_manager._calculate_coverage_hash(child_coverage)
 
             # Decide interestingness
-            is_interesting = self.scoring_manager.score_and_decide_interestingness(
-                info,
+            ctx = ScoringContext(
                 parent_id="parent1",
                 mutation_info={"strategy": "havoc"},
                 parent_file_size=100,
                 parent_lineage_edge_count=50,
                 child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
             )
+            is_interesting = self.scoring_manager.score_and_decide_interestingness(info, ctx)
 
         # Verify workflow
         self.assertEqual(info.global_uops, 1)
@@ -568,17 +541,14 @@ class TestCoverageWorkflow(unittest.TestCase):
                 child_coverage, parent_lineage_profile, parent_id="parent1"
             )
 
-            is_interesting = self.scoring_manager.score_and_decide_interestingness(
-                info,
+            ctx = ScoringContext(
                 parent_id="parent1",
                 mutation_info={"strategy": "havoc"},
                 parent_file_size=100,
                 parent_lineage_edge_count=50,
                 child_file_size=100,
-                jit_avg_time_ms=None,
-                nojit_avg_time_ms=None,
-                nojit_cv=None,
             )
+            is_interesting = self.scoring_manager.score_and_decide_interestingness(info, ctx)
 
         # Only relative coverage
         self.assertEqual(info.global_edges, 0)


### PR DESCRIPTION
## Summary
- Introduced `ScoringContext` frozen dataclass bundling parent/child metadata and timing parameters
- Reduced `score_and_decide_interestingness` signature from 11 to 3 parameters (self, coverage_info, ctx)
- Updated 10 test call sites and 1 internal call site to use the new dataclass

## Test plan
- [x] All 2061 tests pass
- [x] ruff format and check pass
- [x] Net reduction of 31 lines

Closes #790

Generated with [Claude Code](https://claude.com/claude-code)