### PR TITLE
test: remove obsolete Python 3.14 skipIf guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Removed obsolete `@unittest.skipIf(sys.version_info < (3, 14))` guards from t-string tests in `test_generic.py`, since Python 3.14+ is the minimum supported version, by @devdanzin.
 - Extracted `_decorate_special_node` and `_prune_by_strahler` helpers in `lineage.py`, reducing nesting in `decorate` and `extract_forest`, by @devdanzin.
 - Decomposed `InterestingnessScorer.calculate_score` into `_score_timing`, `_score_jit_vitals`, and `_score_coverage` private methods in `scoring.py`, by @devdanzin.
 - Introduced `ScoringContext` frozen dataclass to bundle 9 parameters of `score_and_decide_interestingness` in `scoring.py`, reducing the method signature from 11 to 3 parameters, by @devdanzin.

--- a/tests/mutators/test_generic.py
+++ b/tests/mutators/test_generic.py
@@ -8,7 +8,6 @@ lafleur/mutators/generic.py
 
 import ast
 import random
-import sys
 import unittest
 from textwrap import dedent
 from unittest.mock import patch
@@ -321,7 +320,6 @@ class TestLiteralTypeSwapMutator(unittest.TestCase):
         self.assertNotIn('b"Value:', result)
         self.assertNotIn('b".2f"', result)
 
-    @unittest.skipIf(sys.version_info < (3, 14), "t-strings require Python 3.14+")
     def test_literal_swap_tstring_safety(self):
         """
         Test that t-string literal parts are not mutated to prevent ast.unparse crash.
@@ -1477,7 +1475,6 @@ class TestStringInterpolationMutator(unittest.TestCase):
         self.assertIsInstance(reparsed, ast.Module)
         compile(result, "<test>", "exec")
 
-    @unittest.skipIf(sys.version_info < (3, 14), "t-strings require Python 3.14+")
     def test_injects_tstring(self):
         """Test t-string template injection (Python 3.14+)."""
         # NOTE: side_effect sequence is coupled to internal random call order.


### PR DESCRIPTION
## Summary
- Removed 2 `@unittest.skipIf(sys.version_info < (3, 14))` decorators from t-string tests
- Removed unused `sys` import
- Python 3.14+ is the minimum supported version per CLAUDE.md

## Test plan
- [x] All 2061 tests pass (both t-string tests now always run)
- [x] ruff format and check pass

Closes #796

Generated with [Claude Code](https://claude.com/claude-code)