### PR TITLE
refactor: consolidate duplicated utilities into utils.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Consolidated duplicated `parse_timestamp`, `format_duration`, and `discover_instances` utilities into `lafleur/utils.py`, removing copies from `report.py`, `campaign.py`, and `triage.py`, by @devdanzin.
 - Removed obsolete `@unittest.skipIf(sys.version_info < (3, 14))` guards from t-string tests in `test_generic.py`, since Python 3.14+ is the minimum supported version, by @devdanzin.
 - Extracted `_decorate_special_node` and `_prune_by_strahler` helpers in `lineage.py`, reducing nesting in `decorate` and `extract_forest`, by @devdanzin.
 - Decomposed `InterestingnessScorer.calculate_score` into `_score_timing`, `_score_jit_vitals`, and `_score_coverage` private methods in `scoring.py`, by @devdanzin.

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -18,7 +18,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
-from lafleur.utils import load_json_file
+from lafleur.utils import (
+    discover_instances,
+    load_json_file,
+    parse_timestamp,
+)
 
 if TYPE_CHECKING:
     from lafleur.registry import CrashRegistry
@@ -294,40 +298,6 @@ def load_crash_attribution_summary(log_path: Path) -> CrashAttributionSummary | 
         combined_transformer_scores=combined_transformer,
         combined_strategy_scores=combined_strategy,
     )
-
-
-def parse_timestamp(timestamp_str: str | None) -> datetime | None:
-    """Parse an ISO format timestamp string into a datetime object."""
-    if not timestamp_str:
-        return None
-    try:
-        if timestamp_str.endswith("Z"):
-            timestamp_str = timestamp_str[:-1] + "+00:00"
-        return datetime.fromisoformat(timestamp_str)
-    except ValueError, TypeError:
-        return None
-
-
-def format_duration(seconds: float) -> str:
-    """Format a duration in seconds to a human-readable string."""
-    if seconds < 0:
-        return "N/A"
-
-    days, remainder = divmod(int(seconds), 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes, secs = divmod(remainder, 60)
-
-    parts = []
-    if days > 0:
-        parts.append(f"{days}d")
-    if hours > 0:
-        parts.append(f"{hours}h")
-    if minutes > 0:
-        parts.append(f"{minutes}m")
-    if secs > 0 or not parts:
-        parts.append(f"{secs}s")
-
-    return " ".join(parts)
 
 
 @dataclass
@@ -1566,34 +1536,6 @@ def generate_html_report(aggregator: CampaignAggregator) -> str:
 {_HTML_SORT_JS}  </script>
 </body>
 </html>"""
-
-
-def discover_instances(root_dir: Path) -> list[Path]:
-    """
-    Discover lafleur instance directories under a root directory.
-
-    Args:
-        root_dir: Root directory to search.
-
-    Returns:
-        List of paths to valid instance directories.
-    """
-    instances: list[Path] = []
-
-    if not root_dir.exists():
-        return instances
-
-    # Check if root_dir itself is an instance
-    if (root_dir / "logs" / "run_metadata.json").exists():
-        instances.append(root_dir)
-        return instances
-
-    # Search subdirectories
-    for subdir in sorted(root_dir.iterdir()):
-        if subdir.is_dir() and (subdir / "logs" / "run_metadata.json").exists():
-            instances.append(subdir)
-
-    return instances
 
 
 def main() -> None:

--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -19,7 +19,7 @@ from lafleur.campaign import (
     load_health_summary,
     load_timeout_summary,
 )
-from lafleur.utils import load_json_file
+from lafleur.utils import format_duration, load_json_file, parse_timestamp
 
 
 def load_latest_timeseries_entry(instance_dir: Path) -> dict[str, Any] | None:
@@ -59,41 +59,6 @@ def load_latest_timeseries_entry(instance_dir: Path) -> dict[str, Any] | None:
             continue
 
     return None
-
-
-def parse_timestamp(timestamp_str: str | None) -> datetime | None:
-    """Parse an ISO format timestamp string into a datetime object."""
-    if not timestamp_str:
-        return None
-    try:
-        # Handle various ISO formats
-        if timestamp_str.endswith("Z"):
-            timestamp_str = timestamp_str[:-1] + "+00:00"
-        return datetime.fromisoformat(timestamp_str)
-    except ValueError, TypeError:
-        return None
-
-
-def format_duration(seconds: float) -> str:
-    """Format a duration in seconds to a human-readable string."""
-    if seconds < 0:
-        return "N/A"
-
-    days, remainder = divmod(int(seconds), 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes, secs = divmod(remainder, 60)
-
-    parts = []
-    if days > 0:
-        parts.append(f"{days}d")
-    if hours > 0:
-        parts.append(f"{hours}h")
-    if minutes > 0:
-        parts.append(f"{minutes}m")
-    if secs > 0 or not parts:
-        parts.append(f"{secs}s")
-
-    return " ".join(parts)
 
 
 def format_number(value: int | float | None, suffix: str = "") -> str:

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from lafleur.registry import CrashRegistry
-from lafleur.utils import load_json_file, save_json_file
+from lafleur.utils import discover_instances, load_json_file, save_json_file
 
 
 def get_revision_date(revision: str) -> int | None:
@@ -54,26 +54,6 @@ def parse_iso_timestamp(timestamp_str: str) -> int | None:
         return int(dt.timestamp())
     except ValueError, TypeError:
         return None
-
-
-def discover_instances(root_dir: Path) -> list[Path]:
-    """Discover lafleur instance directories under a root directory."""
-    instances: list[Path] = []
-
-    if not root_dir.exists():
-        return instances
-
-    # Check if root_dir itself is an instance
-    if (root_dir / "logs" / "run_metadata.json").exists():
-        instances.append(root_dir)
-        return instances
-
-    # Search subdirectories
-    for subdir in sorted(root_dir.iterdir()):
-        if subdir.is_dir() and (subdir / "logs" / "run_metadata.json").exists():
-            instances.append(subdir)
-
-    return instances
 
 
 # ============================================================================

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -70,6 +70,71 @@ def append_jsonl(path: Path, record: dict[str, Any]) -> None:
         print(f"[!] Warning: Could not append to {path}: {e}", file=sys.stderr)
 
 
+def parse_timestamp(timestamp_str: str | None) -> datetime | None:
+    """Parse an ISO format timestamp string into a datetime object."""
+    if not timestamp_str:
+        return None
+    try:
+        # Handle various ISO formats
+        if timestamp_str.endswith("Z"):
+            timestamp_str = timestamp_str[:-1] + "+00:00"
+        return datetime.fromisoformat(timestamp_str)
+    except ValueError, TypeError:
+        return None
+
+
+def format_duration(seconds: float) -> str:
+    """Format a duration in seconds to a human-readable string."""
+    if seconds < 0:
+        return "N/A"
+
+    days, remainder = divmod(int(seconds), 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, secs = divmod(remainder, 60)
+
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0:
+        parts.append(f"{minutes}m")
+    if secs > 0 or not parts:
+        parts.append(f"{secs}s")
+
+    return " ".join(parts)
+
+
+def discover_instances(root_dir: Path) -> list[Path]:
+    """Discover lafleur instance directories under a root directory.
+
+    An instance directory is identified by having a ``logs/run_metadata.json`` file.
+    If *root_dir* itself is an instance, it is returned as the sole element.
+
+    Args:
+        root_dir: Root directory to search.
+
+    Returns:
+        List of paths to valid instance directories.
+    """
+    instances: list[Path] = []
+
+    if not root_dir.exists():
+        return instances
+
+    # Check if root_dir itself is an instance
+    if (root_dir / "logs" / "run_metadata.json").exists():
+        instances.append(root_dir)
+        return instances
+
+    # Search subdirectories
+    for subdir in sorted(root_dir.iterdir()):
+        if subdir.is_dir() and (subdir / "logs" / "run_metadata.json").exists():
+            instances.append(subdir)
+
+    return instances
+
+
 def _default_run_stats() -> dict[str, Any]:
     """Return the canonical default run statistics structure."""
     return {

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -15,13 +15,11 @@ from lafleur.campaign import (
     load_health_summary,
     load_timeout_summary,
     load_crash_attribution_summary,
-    parse_timestamp,
-    format_duration,
-    discover_instances,
     main,
     CrashInfo,
     HealthSummary,
 )
+from lafleur.utils import discover_instances, format_duration, parse_timestamp
 
 
 class TestLoadJsonFile(unittest.TestCase):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -16,12 +16,12 @@ from lafleur.report import (
     generate_report,
     load_json_file,
     load_latest_timeseries_entry,
-    format_duration,
     format_number,
     get_jit_asan_status,
     truncate_string,
     load_crash_data,
 )
+from lafleur.utils import format_duration
 
 
 class TestReportHelpers(unittest.TestCase):

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -14,12 +14,12 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from lafleur.registry import CrashRegistry
+from lafleur.utils import discover_instances
 from lafleur.triage import (
     do_export_issues,
     do_import_issues,
     get_triage_candidates,
     handle_triage_action,
-    discover_instances,
     load_json_file,
     get_revision_date,
     parse_iso_timestamp,


### PR DESCRIPTION
## Summary
- Move `parse_timestamp`, `format_duration`, and `discover_instances` from `report.py`, `campaign.py`, and `triage.py` into `lafleur/utils.py`
- Update all consumer modules and test files to import from the canonical location
- Net reduction of ~50 lines of duplicated code

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] All 208 tests in `test_campaign.py`, `test_triage.py`, and `test_report.py` pass

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)