### PR TITLE
refactor: add missing -> None return type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Added missing `-> None` return type annotations to 10 functions across `generic.py`, `helper_injection.py`, `scenarios_data.py`, `minimize.py`, `orchestrator.py`, and `driver.py`, by @devdanzin.
 - Consolidated duplicated `parse_timestamp`, `format_duration`, and `discover_instances` utilities into `lafleur/utils.py`, removing copies from `report.py`, `campaign.py`, and `triage.py`, by @devdanzin.
 - Removed obsolete `@unittest.skipIf(sys.version_info < (3, 14))` guards from t-string tests in `test_generic.py`, since Python 3.14+ is the minimum supported version, by @devdanzin.
 - Extracted `_decorate_special_node` and `_prune_by_strahler` helpers in `lineage.py`, reducing nesting in `decorate` and `extract_forest`, by @devdanzin.

--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -375,7 +375,7 @@ def get_jit_stats(namespace: dict, baseline: dict[tuple[int, int], int] | None =
 
     m = _JitMetrics()
 
-    def inspect_executor(executor, code_id: int, offset: int):
+    def inspect_executor(executor, code_id: int, offset: int) -> None:
         try:
             executor_ptr = ctypes.cast(id(executor), ctypes.POINTER(PyExecutorObject))
 

--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -440,7 +440,7 @@ def minimize_session(crash_dir: Path, target_python: str, force_overwrite: bool)
         print(f"    Result: {target_file} (requires predecessors)")
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Minimize a lafleur crash bundle.")
     parser.add_argument("crash_dir", type=Path, help="Path to the session crash directory")
     parser.add_argument(

--- a/lafleur/mutators/generic.py
+++ b/lafleur/mutators/generic.py
@@ -173,7 +173,7 @@ class LiteralTypeSwapMutator(ast.NodeTransformer):
             # Try converting to int (may fail for inf/nan)
             try:
                 replacements.append(int(val))
-            except (ValueError, OverflowError):
+            except ValueError, OverflowError:
                 pass
             replacements.append(str(val))
 
@@ -334,7 +334,7 @@ class BoundaryValuesMutator(ast.NodeTransformer):
             try:
                 new_node = ast.parse(new_value_str, mode="eval").body
                 return new_node
-            except (SyntaxError, ValueError):
+            except SyntaxError, ValueError:
                 return node
         return node
 
@@ -413,7 +413,7 @@ class VariableSwapper(ast.NodeTransformer):
 
     PROTECTED_NAMES = _static_protected_names.union(_exception_names)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.var_map = {}
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
@@ -463,7 +463,7 @@ class VariableRenamer(ast.NodeTransformer):
     with a recipient's setup code.
     """
 
-    def __init__(self, remapping_dict: dict[str, str]):
+    def __init__(self, remapping_dict: dict[str, str]) -> None:
         self.remapping_dict = remapping_dict
 
     def visit_Name(self, node: ast.Name) -> ast.Name:
@@ -1607,7 +1607,7 @@ class ImportPrunerMutator(ast.NodeTransformer):
     imports and try/except-wrapped imports).
     """
 
-    def __init__(self, removal_probability: float = 0.5):
+    def __init__(self, removal_probability: float = 0.5) -> None:
         """
         Initialize the pruner.
 

--- a/lafleur/mutators/helper_injection.py
+++ b/lafleur/mutators/helper_injection.py
@@ -60,7 +60,7 @@ class HelperFunctionInjector(ast.NodeTransformer):
         """),
     ]
 
-    def __init__(self, probability: float = 0.3):
+    def __init__(self, probability: float = 0.3) -> None:
         """
         Initialize the helper injector.
 

--- a/lafleur/mutators/scenarios_data.py
+++ b/lafleur/mutators/scenarios_data.py
@@ -1239,7 +1239,7 @@ class BloomFilterSaturator(ast.NodeTransformer):
         "multi_phase_attack",
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.module_vars_added = False
 
@@ -1630,7 +1630,7 @@ class AbstractInterpreterConfusionMutator(ast.NodeTransformer):
     JIT correctly handles exceptions from within index conversion and unwinds properly.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.chameleon_class_injected = False
 
@@ -2070,7 +2070,7 @@ class UnpackingChaosMutator(ast.NodeTransformer):
 
     HELPER_CLASS_NAME = "_JitChaosIterator"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.helper_injected = False
 

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -1019,7 +1019,7 @@ def _format_run_summary(
     return header + body
 
 
-def main():
+def main() -> None:
     """Parse command-line arguments and run the Lafleur Fuzzer Orchestrator."""
     parser = argparse.ArgumentParser(
         description="lafleur: A feedback-driven JIT fuzzer for CPython."


### PR DESCRIPTION
## Summary
- Add `-> None` return type annotations to 10 functions across 6 files
- Covers `__init__` methods, `main()` functions, and `inspect_executor()`

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] All 2061 tests pass

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)