### PR TITLE
docs: fix misleading docstring on genStatefulGetitemObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Fixed misleading docstring on `genStatefulGetitemObject` in `mutators/utils.py` (said `__iter__`, actually `__getitem__`), by @devdanzin.
 - Removed dead code: unused `_create_guard_side_effect_function` method in `scenarios_control.py` and unused `COLOR_TIMEOUT` constant in `lineage.py`, by @devdanzin.
 - Added missing `-> None` return type annotations to 10 functions across `generic.py`, `helper_injection.py`, `scenarios_data.py`, `minimize.py`, `orchestrator.py`, and `driver.py`, by @devdanzin.
 - Consolidated duplicated `parse_timestamp`, `format_duration`, and `discover_instances` utilities into `lafleur/utils.py`, removing copies from `report.py`, `campaign.py`, and `triage.py`, by @devdanzin.

--- a/lafleur/mutators/utils.py
+++ b/lafleur/mutators/utils.py
@@ -379,7 +379,7 @@ def genStatefulStrReprObject(var_name: str) -> str:
 
 
 def genStatefulGetitemObject(var_name: str) -> str:
-    """Generate the source code for a class whose `__iter__` returns different iterators."""
+    """Generate a class whose ``__getitem__`` returns different types based on call count."""
     class_name = f"StatefulGetitem_{var_name}"
     setup_code = dedent(f"""
         class {class_name}:


### PR DESCRIPTION
## Summary
- Fix docstring that incorrectly said `__iter__` returns different iterators; the class actually implements `__getitem__` returning different types based on call count

## Test plan
- [x] Documentation-only change, no tests needed

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)