### PR TITLE
fix: narrow _compose_session except clause to IndexError only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Narrowed `_compose_session` except clause from `AttributeError, IndexError` to just `IndexError` in `execution.py`, by @devdanzin.
 - Fixed misleading docstring on `genStatefulGetitemObject` in `mutators/utils.py` (said `__iter__`, actually `__getitem__`), by @devdanzin.
 - Removed dead code: unused `_create_guard_side_effect_function` method in `scenarios_control.py` and unused `COLOR_TIMEOUT` constant in `lineage.py`, by @devdanzin.
 - Added missing `-> None` return type annotations to 10 functions across `generic.py`, `helper_injection.py`, `scenarios_data.py`, `minimize.py`, `orchestrator.py`, and `driver.py`, by @devdanzin.

--- a/lafleur/execution.py
+++ b/lafleur/execution.py
@@ -448,7 +448,7 @@ class ExecutionManager:
                     selection = self.corpus_manager.select_parent()
                     if selection:
                         polluters.append(selection[0])
-            except AttributeError, IndexError:
+            except IndexError:
                 pass
 
             if polluters:


### PR DESCRIPTION
## Summary
- Remove `AttributeError` from the except clause in `_compose_session` — it cannot occur since `self.corpus_manager` is always initialized before this method is called
- The overly broad clause could mask real bugs

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] All 2061 tests pass

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)