### PR TITLE
fix: add missing REPORTED and FIXED choices to triage list --status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Added missing `REPORTED` and `FIXED` choices to `lafleur-triage list --status`, matching the full set of valid triage statuses, by @devdanzin.
 - Added explicit `encoding="utf-8"` to 10 text-mode `open()` calls missing it across 6 modules, matching the majority convention, by @devdanzin.
 - Replaced deprecated `IOError` with `OSError` in 11 locations across 8 modules, removing redundant dual-catches at `coverage.py` and `utils.py`, by @devdanzin.
 - Replaced 6 naive `datetime.now()` calls with `datetime.now(timezone.utc)` in `report.py`, `campaign.py`, and `triage.py` to prevent potential timezone mixing errors, by @devdanzin.

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -823,7 +823,7 @@ def main() -> None:
     )
     list_parser.add_argument(
         "--status",
-        choices=["NEW", "TRIAGED", "IGNORED"],
+        choices=["NEW", "TRIAGED", "REPORTED", "IGNORED", "FIXED"],
         help="Filter by triage status",
     )
 


### PR DESCRIPTION
## Summary
- Add `REPORTED` and `FIXED` to the `--status` choices for `lafleur-triage list`, matching the full set of valid triage statuses

## Test plan
- [x] Single-line CLI fix, verified by inspection against `handle_triage_action` valid_statuses tuple

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)