### PR TITLE
docs: add module docstring to analysis.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Added module docstring to `analysis.py` describing crash fingerprinting and classification, by @devdanzin.
 - Added missing `REPORTED` and `FIXED` choices to `lafleur-triage list --status`, matching the full set of valid triage statuses, by @devdanzin.
 - Added explicit `encoding="utf-8"` to 10 text-mode `open()` calls missing it across 6 modules, matching the majority convention, by @devdanzin.
 - Replaced deprecated `IOError` with `OSError` in 11 locations across 8 modules, removing redundant dual-catches at `coverage.py` and `utils.py`, by @devdanzin.

--- a/lafleur/analysis.py
+++ b/lafleur/analysis.py
@@ -1,3 +1,10 @@
+"""Crash fingerprinting and classification for lafleur findings.
+
+Provides types and logic for categorising crash logs into reproducible
+fingerprints (ASAN violations, C assertions, Python panics, signals)
+and extracting structured signatures for deduplication.
+"""
+
 from dataclasses import dataclass, asdict
 from enum import Enum
 import re


### PR DESCRIPTION
## Summary
- Add module-level docstring to `lafleur/analysis.py` describing its crash fingerprinting and classification purpose

## Test plan
- [x] Documentation-only change

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)