### PR TITLE
refactor: standardize CLI path arguments to type=Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Standardized CLI path arguments to `type=Path` in `orchestrator.py`, `jit_tuner.py`, `triage.py`, and `report.py`, removing redundant `Path()` wrapping at call sites, by @devdanzin.
 - Sent all error/warning output in `minimize.py` to stderr instead of stdout, by @devdanzin.
 - Narrowed `_compose_session` except clause from `AttributeError, IndexError` to just `IndexError` in `execution.py`, by @devdanzin.
 - Fixed misleading docstring on `genStatefulGetitemObject` in `mutators/utils.py` (said `__iter__`, actually `__getitem__`), by @devdanzin.

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -132,7 +132,7 @@ class CorpusManager:
         self,
         coverage_state: CoverageManager,
         run_stats: dict[str, Any],
-        fusil_path: str,
+        fusil_path: str | Path | None,
         get_boilerplate_func: Callable[..., str],
         execution_timeout: int = 10,
         target_python: str = sys.executable,

--- a/lafleur/jit_tuner.py
+++ b/lafleur/jit_tuner.py
@@ -120,7 +120,7 @@ def main() -> None:
     )
     parser.add_argument(
         "cpython_dir",
-        type=str,
+        type=Path,
         help="Path to the root of the CPython source repository.",
     )
     parser.add_argument(
@@ -142,8 +142,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    cpython_src_path = Path(args.cpython_dir)
-    apply_jit_tweaks(cpython_src_path, args.dry_run, args.disabled_files, args.disabled_tweaks)
+    apply_jit_tweaks(args.cpython_dir, args.dry_run, args.disabled_files, args.disabled_tweaks)
     print("[*] Done.")
 
 

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -122,7 +122,7 @@ class LafleurOrchestrator:
 
     def __init__(
         self,
-        fusil_path: str,
+        fusil_path: str | Path | None,
         min_corpus_files: int = 1,
         differential_testing: bool = False,
         timeout: int = 10,
@@ -1026,7 +1026,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--fusil-path",
-        type=str,
+        type=Path,
         default=None,
         help="The absolute path to the classic fusil executable (fusil-python-threaded).",
     )

--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -732,13 +732,14 @@ Examples:
     parser.add_argument(
         "instance_dir",
         nargs="?",
+        type=Path,
         default=".",
         help="Path to the fuzzing instance directory (default: current directory)",
     )
 
     args = parser.parse_args()
 
-    instance_dir = Path(args.instance_dir).resolve()
+    instance_dir = args.instance_dir.resolve()
 
     if not instance_dir.exists():
         print(f"Error: Instance directory does not exist: {instance_dir}", file=sys.stderr)

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -207,7 +207,7 @@ def handle_triage_action(
 def import_campaign(args: argparse.Namespace) -> None:
     """Import crashes from a campaign directory into the registry."""
     registry = CrashRegistry(args.db)
-    campaign_dir = Path(args.campaign_dir).resolve()
+    campaign_dir = args.campaign_dir.resolve()
 
     if not campaign_dir.exists():
         print(f"Error: Directory not found: {campaign_dir}", file=sys.stderr)
@@ -800,7 +800,7 @@ def main() -> None:
     )
     import_parser.add_argument(
         "campaign_dir",
-        type=str,
+        type=Path,
         help="Campaign directory containing instance subdirectories",
     )
 

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -2312,7 +2312,7 @@ class TestMainCLIPlumbing(unittest.TestCase):
     def test_fusil_path_passed(self):
         """--fusil-path value reaches constructor."""
         _, kwargs = self._run_main(["--fusil-path", "/my/fusil"])
-        self.assertEqual(kwargs["fusil_path"], "/my/fusil")
+        self.assertEqual(kwargs["fusil_path"], Path("/my/fusil"))
 
     def test_fusil_path_default_none(self):
         """--fusil-path defaults to None."""
@@ -2429,7 +2429,7 @@ class TestMainCLIPlumbing(unittest.TestCase):
                 "spam",
             ]
         )
-        self.assertEqual(kwargs["fusil_path"], "/my/fusil")
+        self.assertEqual(kwargs["fusil_path"], Path("/my/fusil"))
         self.assertEqual(kwargs["min_corpus_files"], 10)
         self.assertTrue(kwargs["differential_testing"])
         self.assertEqual(kwargs["timeout"], 25)

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -502,7 +502,7 @@ class TestImportCampaign(unittest.TestCase):
 
     def test_exits_on_nonexistent_directory(self):
         """Test exit when campaign directory doesn't exist."""
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path / "nonexistent"))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path / "nonexistent")
 
         with self.assertRaises(SystemExit) as ctx:
             import_campaign(args)
@@ -510,7 +510,7 @@ class TestImportCampaign(unittest.TestCase):
 
     def test_exits_when_no_instances_found(self):
         """Test exit when no valid instances are found."""
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         with self.assertRaises(SystemExit) as ctx:
             import_campaign(args)
@@ -533,7 +533,7 @@ class TestImportCampaign(unittest.TestCase):
             json.dumps({"fingerprint": "ASSERT:test", "timestamp": "20250101_120000"})
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         import_campaign(args)
 

--- a/tests/test_triage_display.py
+++ b/tests/test_triage_display.py
@@ -626,7 +626,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
             ],
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         captured_output = StringIO()
         with patch("sys.stdout", captured_output):
@@ -656,7 +656,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
             crashes=[{"fingerprint": "ASSERT:from_inst2", "timestamp": "20250101_110000"}],
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         captured_output = StringIO()
         with patch("sys.stdout", captured_output):
@@ -683,7 +683,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
             ],
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         captured_output = StringIO()
         with patch("sys.stdout", captured_output):
@@ -707,7 +707,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
             ],
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         # Import twice
         captured_output = StringIO()
@@ -733,7 +733,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
             crashes=[{"fingerprint": "ASSERT:valid", "timestamp": "20250101_120000"}],
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         captured_output = StringIO()
         with patch("sys.stdout", captured_output):
@@ -752,7 +752,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
         (logs_dir / "run_metadata.json").write_text(json.dumps(metadata))
         # No crashes directory created
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         captured_output = StringIO()
         with patch("sys.stdout", captured_output):
@@ -770,7 +770,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
         crash_dir.mkdir(parents=True)
         (crash_dir / "metadata.json").write_text(json.dumps({"timestamp": "20250101_120000"}))
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         captured_output = StringIO()
         with patch("sys.stdout", captured_output):
@@ -787,7 +787,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
             crashes=[{"fingerprint": "ASSERT:summary", "timestamp": "20250101_120000"}],
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         captured_output = StringIO()
         with patch("sys.stdout", captured_output):
@@ -807,7 +807,7 @@ class TestImportCampaignDisplay(unittest.TestCase):
             crashes=[{"fingerprint": "ASSERT:rev", "timestamp": "20250101_120000"}],
         )
 
-        args = argparse.Namespace(db=self.db_path, campaign_dir=str(self.temp_path))
+        args = argparse.Namespace(db=self.db_path, campaign_dir=self.temp_path)
 
         import_campaign(args)
 


### PR DESCRIPTION
## Summary
- Convert `--fusil-path`, `cpython_dir`, `campaign_dir`, and `instance_dir` argparse arguments from `type=str` to `type=Path`
- Remove redundant `Path()` wrapping at call sites
- Update `fusil_path` type hints to `str | Path | None` in orchestrator and corpus_manager
- Update test fixtures to pass `Path` objects directly

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] All 2061 tests pass

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)