### PR TITLE
fix: guard psutil.Process().memory_info() in telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Guarded `psutil.Process().memory_info()` call in telemetry (`artifacts.py`) with try/except to prevent crashes on edge-case process states, by @devdanzin.
 - Standardized CLI path arguments to `type=Path` in `orchestrator.py`, `jit_tuner.py`, `triage.py`, and `report.py`, removing redundant `Path()` wrapping at call sites, by @devdanzin.
 - Sent all error/warning output in `minimize.py` to stderr instead of stdout, by @devdanzin.
 - Narrowed `_compose_session` except clause from `AttributeError, IndexError` to just `IndexError` in `execution.py`, by @devdanzin.

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -785,7 +785,12 @@ class TelemetryManager:
         except OSError, AttributeError:
             datapoint["system_load_1min"] = None
 
-        datapoint["process_rss_mb"] = round(psutil.Process().memory_info().rss / (1024 * 1024), 2)
+        try:
+            datapoint["process_rss_mb"] = round(
+                psutil.Process().memory_info().rss / (1024 * 1024), 2
+            )
+        except OSError, psutil.Error:
+            datapoint["process_rss_mb"] = None
 
         # Corpus size: use cache, refresh only when file count changes
         datapoint["corpus_size_mb"] = self._get_corpus_size_mb()


### PR DESCRIPTION
## Summary
- Wrap `psutil.Process().memory_info().rss` call in `artifacts.py` with try/except, matching the pattern used by surrounding telemetry calls

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] All 2061 tests pass

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)