### PR TITLE
docs: update CLAUDE.md with missing modules and corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Updated CLAUDE.md: renamed stale `coverage_parser.py` reference to `coverage.py`, added 6 missing modules (`analysis.py`, `health.py`, `learning.py`, `metadata.py`, `types.py`, `uop_names.py`) to the project structure, by @devdanzin.
 - Guarded `psutil.Process().memory_info()` call in telemetry (`artifacts.py`) with try/except to prevent crashes on edge-case process states, by @devdanzin.
 - Standardized CLI path arguments to `type=Path` in `orchestrator.py`, `jit_tuner.py`, `triage.py`, and `report.py`, removing redundant `Path()` wrapping at call sites, by @devdanzin.
 - Sent all error/warning output in `minimize.py` to stderr instead of stdout, by @devdanzin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,14 @@ lafleur-triage export-issues known_issues.json
     - `utils.py` — Shared utilities for mutators
     - `helper_injection.py` — HelperFunctionInjector for Sniper targeting
     - `sniper.py` — SniperMutator for surgical Bloom filter invalidation
-  - `coverage_parser.py` — Parses JIT trace logs for uop-edge coverage
+  - `coverage.py` — JIT trace log parsing and uop-edge coverage extraction
   - `corpus_manager.py` — Manages test case corpus and scheduling
+  - `learning.py` — Adaptive mutation strategy learning (epsilon-greedy selection)
+  - `analysis.py` — Crash fingerprinting and classification
+  - `health.py` — HealthMonitor observability (adverse event logging)
+  - `metadata.py` — Run metadata generation and persistence
+  - `types.py` — Shared type definitions (JitStats, MutationInfo, etc.)
+  - `uop_names.py` — Micro-op name mappings for coverage analysis
   - `report.py` — Single-instance text reporter CLI
   - `campaign.py` — Multi-instance campaign aggregator with HTML reports
   - `registry.py` — SQLite-based crash registry for historical tracking


### PR DESCRIPTION
## Summary
- Rename stale `coverage_parser.py` reference to `coverage.py` in project structure
- Add 6 missing modules: `analysis.py`, `health.py`, `learning.py`, `metadata.py`, `types.py`, `uop_names.py`

## Test plan
- [x] Documentation-only change

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)