### PR TITLE
refactor: add RunStats TypedDict for type-safe run statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ All notable changes to this project should be documented in this file.
 - Consolidated duplicated `parse_timestamp`, `format_duration`, and `discover_instances` utilities into `lafleur/utils.py`, removing copies from `report.py`, `campaign.py`, and `triage.py`, by @devdanzin.
 - Extracted 7 formatting methods from `CampaignAggregator` into module-level functions, reducing class method count and improving separation of concerns, by @devdanzin.
 - Added 28 tests for previously untested `ArtifactManager` methods: `truncate_huge_log`, `compress_log_stream`, `process_log_file`, and `_classify_crash`, by @devdanzin.
+- Added `RunStats` TypedDict to `types.py` and updated `run_stats` parameter types across `utils.py`, `orchestrator.py`, `artifacts.py`, `corpus_manager.py`, `scoring.py`, and `report.py`, by @devdanzin.
 - Removed obsolete `@unittest.skipIf(sys.version_info < (3, 14))` guards from t-string tests in `test_generic.py`, since Python 3.14+ is the minimum supported version, by @devdanzin.
 - Extracted `_decorate_special_node` and `_prune_by_strahler` helpers in `lineage.py`, reducing nesting in `decorate` and `extract_forest`, by @devdanzin.
 - Decomposed `InterestingnessScorer.calculate_score` into `_score_timing`, `_score_jit_vitals`, and `_score_coverage` private methods in `scoring.py`, by @devdanzin.

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from lafleur.coverage import CoverageManager
     from lafleur.health import HealthMonitor
     from lafleur.learning import MutatorScoreTracker
-    from lafleur.types import MutationInfo
+    from lafleur.types import MutationInfo, RunStats
 
 # Log processing constants
 TIMEOUT_LOG_COMPRESSION_THRESHOLD = 1_048_576  # 1 MB
@@ -721,7 +721,7 @@ class TelemetryManager:
 
     def __init__(
         self,
-        run_stats: dict,
+        run_stats: "RunStats",
         coverage_manager: "CoverageManager",
         corpus_manager: "CorpusManager",
         score_tracker: "MutatorScoreTracker",

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -15,11 +15,11 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable
 
 from lafleur.coverage import HarnessCoverage, save_coverage_state, CoverageManager
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
-from lafleur.types import CorpusFileMetadata, MutationInfo, NewCoverageResult
+from lafleur.types import CorpusFileMetadata, MutationInfo, NewCoverageResult, RunStats
 from lafleur.utils import ExecutionResult, FUZZING_ENV
 
 if TYPE_CHECKING:
@@ -131,7 +131,7 @@ class CorpusManager:
     def __init__(
         self,
         coverage_state: CoverageManager,
-        run_stats: dict[str, Any],
+        run_stats: RunStats,
         fusil_path: str | Path | None,
         get_boilerplate_func: Callable[..., str],
         execution_timeout: int = 10,

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -40,6 +40,7 @@ from lafleur.types import (
     DivergenceResult,
     MutationInfo,
     NewCoverageResult,
+    RunStats,
 )
 from lafleur.learning import MutatorScoreTracker
 from lafleur.mutation_controller import MutationController
@@ -135,7 +136,7 @@ class LafleurOrchestrator:
         max_crash_log_size: int = 400,
         target_python: str = sys.executable,
         deepening_probability: float = 0.2,
-        run_stats: dict | None = None,
+        run_stats: RunStats | None = None,
         no_ekg: bool = False,
         max_sessions: int | None = None,
         max_mutations_per_session: int | None = None,

--- a/lafleur/report.py
+++ b/lafleur/report.py
@@ -19,6 +19,7 @@ from lafleur.campaign import (
     load_health_summary,
     load_timeout_summary,
 )
+from lafleur.types import RunStats
 from lafleur.utils import format_duration, load_json_file, parse_timestamp
 
 
@@ -83,7 +84,7 @@ def _get_dir_size_mb(dir_path: Path) -> float | None:
 
 def _format_timeout_section(
     timeout_summary: TimeoutSummary | None,
-    run_stats: dict[str, Any] | None,
+    run_stats: RunStats | None,
     instance_dir: Path,
 ) -> list[str]:
     """Format the TIMEOUT ANALYSIS section for the instance report."""

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -30,6 +30,7 @@ from lafleur.types import (
     MutationInfo,
     NewCoverageResult,
     NoChangeResult,
+    RunStats,
 )
 from lafleur.utils import ExecutionResult
 
@@ -300,7 +301,7 @@ class ScoringManager:
         artifact_manager: "ArtifactManager | None" = None,
         corpus_manager: "CorpusManager | None" = None,
         get_core_code_func: Callable[[str], str] | None = None,
-        run_stats: dict | None = None,
+        run_stats: RunStats | None = None,
         health_monitor: "HealthMonitor | None" = None,
     ):
         """

--- a/lafleur/types.py
+++ b/lafleur/types.py
@@ -20,6 +20,48 @@ from typing import TypedDict
 from lafleur.coverage import HarnessCoverage
 
 
+class RunStats(TypedDict, total=False):
+    """Persistent run statistics written to fuzz_run_stats.json.
+
+    Uses total=False because:
+    - Some fields (regressions_found, global_uops, etc.) are only populated
+      after the first telemetry save, so they may be absent in fresh stats.
+    - Dynamic stat keys (jit_hangs_found, regression_timeouts_found) are
+      added at runtime by execute_child() and may not exist yet.
+    - Older stats files from previous versions may lack newer fields.
+    """
+
+    # --- Timestamps ---
+    start_time: str  # ISO 8601
+    last_update_time: str | None
+
+    # --- Session & mutation counters ---
+    total_sessions: int
+    total_mutations: int
+    corpus_size: int
+    corpus_file_counter: int
+    global_seed_counter: int
+
+    # --- Finding counters ---
+    crashes_found: int
+    timeouts_found: int
+    divergences_found: int
+    regressions_found: int
+    new_coverage_finds: int
+    sum_of_mutations_per_find: int
+    average_mutations_per_find: float
+
+    # --- Coverage summary ---
+    global_uops: int
+    global_edges: int
+    global_rare_events: int
+
+    # --- Runtime-only (not in defaults, added during execution) ---
+    timeouts_since_last_telemetry: int
+    jit_hangs_found: int
+    regression_timeouts_found: int
+
+
 class JitStats(TypedDict, total=False):
     """JIT vitals parsed from driver log output and stored in discovery_mutation.
 

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -4,13 +4,18 @@ This module contains generic, reusable helper functions and classes for the lafl
 It includes utilities for logging, managing run statistics, and structuring data.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
+
+if TYPE_CHECKING:
+    from lafleur.types import RunStats
 
 RUN_STATS_FILE = Path("fuzz_run_stats.json")
 
@@ -135,7 +140,7 @@ def discover_instances(root_dir: Path) -> list[Path]:
     return instances
 
 
-def _default_run_stats() -> dict[str, Any]:
+def _default_run_stats() -> RunStats:
     """Return the canonical default run statistics structure."""
     return {
         "start_time": datetime.now(timezone.utc).isoformat(),
@@ -154,7 +159,7 @@ def _default_run_stats() -> dict[str, Any]:
     }
 
 
-def load_run_stats() -> dict[str, Any]:
+def load_run_stats() -> RunStats:
     """
     Load the persistent run statistics from the JSON file.
     Returns a default structure if the file doesn't exist.
@@ -163,7 +168,7 @@ def load_run_stats() -> dict[str, Any]:
         return _default_run_stats()
     try:
         with open(RUN_STATS_FILE, "r", encoding="utf-8") as f:
-            stats: dict[str, Any] = json.load(f)
+            stats: RunStats = json.load(f)
             # Fill in any fields missing from older stats files
             defaults = _default_run_stats()
             for key, value in defaults.items():
@@ -178,7 +183,7 @@ def load_run_stats() -> dict[str, Any]:
         return _default_run_stats()
 
 
-def save_run_stats(stats: dict[str, Any]) -> None:
+def save_run_stats(stats: RunStats) -> None:
     """Save the updated run statistics to the JSON file."""
     save_json_file(RUN_STATS_FILE, stats)
 


### PR DESCRIPTION
## Summary
- Added `RunStats` TypedDict to `types.py` documenting all 21 known run_stats keys with proper types
- Updated `run_stats` parameter types from bare `dict` / `dict[str, Any]` to `RunStats` across 6 modules
- Removed unused `Any` import from `corpus_manager.py`

Closes #824

## Test plan
- [x] All 2081 tests pass
- [x] `ruff format` and `ruff check` clean
- [x] No circular imports (types.py → coverage.py chain doesn't touch utils.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)