### PR TITLE
refactor: rename camelCase functions in mutators/utils.py to snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ All notable changes to this project should be documented in this file.
 - Extracted 7 formatting methods from `CampaignAggregator` into module-level functions, reducing class method count and improving separation of concerns, by @devdanzin.
 - Added 28 tests for previously untested `ArtifactManager` methods: `truncate_huge_log`, `compress_log_stream`, `process_log_file`, and `_classify_crash`, by @devdanzin.
 - Added `RunStats` TypedDict to `types.py` and updated `run_stats` parameter types across `utils.py`, `orchestrator.py`, `artifacts.py`, `corpus_manager.py`, `scoring.py`, and `report.py`, by @devdanzin.
+- Renamed 10 camelCase generator functions in `mutators/utils.py` to snake_case for naming consistency, by @devdanzin.
 - Removed obsolete `@unittest.skipIf(sys.version_info < (3, 14))` guards from t-string tests in `test_generic.py`, since Python 3.14+ is the minimum supported version, by @devdanzin.
 - Extracted `_decorate_special_node` and `_prune_by_strahler` helpers in `lineage.py`, reducing nesting in `decorate` and `extract_forest`, by @devdanzin.
 - Decomposed `InterestingnessScorer.calculate_score` into `_score_timing`, `_score_jit_vitals`, and `_score_coverage` private methods in `scoring.py`, by @devdanzin.

--- a/doc/dev/04_mutation_engine.md
+++ b/doc/dev/04_mutation_engine.md
@@ -153,10 +153,10 @@ To support the advanced JIT-specific mutators, `lafleur/mutators/utils.py` conta
 
 Key generators include:
 
-* **`genStatefulLenObject`**: Generates a class whose `__len__` method returns different values on subsequent calls.
-* **`genUnstableHashObject`**: Generates a class whose `__hash__` method is not constant, violating a core requirement for dictionary keys.
-* **`genStatefulIterObject`**: Generates a class whose `__iter__` method returns iterators that change the type of yielded items mid-iteration.
-* **`genStatefulBoolObject`**: Generates a class whose `__bool__` method alternates between `True` and `False`.
-* **`genStatefulIndexObject`**: Generates a class whose `__index__` method returns different integers on each call.
+* **`gen_stateful_len_object`**: Generates a class whose `__len__` method returns different values on subsequent calls.
+* **`gen_unstable_hash_object`**: Generates a class whose `__hash__` method is not constant, violating a core requirement for dictionary keys.
+* **`gen_stateful_iter_object`**: Generates a class whose `__iter__` method returns iterators that change the type of yielded items mid-iteration.
+* **`gen_stateful_bool_object`**: Generates a class whose `__bool__` method alternates between `True` and `False`.
+* **`gen_stateful_index_object`**: Generates a class whose `__index__` method returns different integers on each call.
 
 These generators are used by mutators like `MagicMethodMutator` and `IterableMutator` to create objects that appear normal during the JIT's tracing phase but misbehave once optimized code runs.

--- a/lafleur/mutators/scenarios_data.py
+++ b/lafleur/mutators/scenarios_data.py
@@ -17,16 +17,16 @@ from textwrap import dedent, indent
 from typing import Any, Callable, cast
 
 from lafleur.mutators.utils import (
-    genStatefulIterObject,
-    genStatefulLenObject,
-    genUnstableHashObject,
+    gen_stateful_iter_object,
+    gen_stateful_len_object,
+    gen_unstable_hash_object,
 )
 
 
 def _create_len_attack(prefix: str) -> list[ast.stmt]:
     """Generate a self-contained scenario to attack len()."""
     var_name = f"len_obj_{prefix}"
-    class_def_str = genStatefulLenObject(var_name)
+    class_def_str = gen_stateful_len_object(var_name)
     attack_code = dedent(f"""
 # len() attack injected by fuzzer
 {class_def_str}
@@ -43,7 +43,7 @@ for i_len in range(100):
 def _create_hash_attack(prefix: str) -> list[ast.stmt]:
     """Generate a self-contained scenario to attack hash()."""
     var_name = f"hash_obj_{prefix}"
-    class_def_str = genUnstableHashObject(var_name)
+    class_def_str = gen_unstable_hash_object(var_name)
     attack_code = dedent(f"""
 # hash() attack injected by fuzzer
 {class_def_str}
@@ -94,7 +94,7 @@ def _mutate_for_loop_iter(func_node: ast.FunctionDef) -> bool:
         if isinstance(stmt, ast.For):
             print(f"    -> Mutating for loop iterator in '{func_node.name}'", file=sys.stderr)
             prefix = f"iter_{random.randint(1000, 9999)}"
-            class_def_str = genStatefulIterObject(prefix)
+            class_def_str = gen_stateful_iter_object(prefix)
             class_def_node = cast(ast.ClassDef, ast.parse(class_def_str).body[0])
             func_node.body.insert(0, class_def_node)
             # Adjust index since we inserted a class def at position 0
@@ -284,7 +284,7 @@ class IterableMutator(ast.NodeTransformer):
         """Generate a scenario attacking tuple() with an unstable-type iterator."""
         print("    -> Injecting tuple() attack scenario...", file=sys.stderr)
         # For this attack, we can reuse the StatefulIterObject
-        class_def_str = genStatefulIterObject(prefix)
+        class_def_str = gen_stateful_iter_object(prefix)
         attack_code = dedent(f"""
 # tuple() attack injected by fuzzer
 print('[{prefix}] Running tuple() attack scenario...', file=sys.stderr)

--- a/lafleur/mutators/utils.py
+++ b/lafleur/mutators/utils.py
@@ -282,7 +282,7 @@ def is_simple_statement(node: ast.stmt) -> bool:
 # ==============================================================================
 
 
-def genLyingEqualityObject(var_name: str) -> str:
+def gen_lying_equality_object(var_name: str) -> str:
     """
     Generate a class that lies about equality.
     __eq__ and __ne__ both always return True after a while.
@@ -309,7 +309,7 @@ def genLyingEqualityObject(var_name: str) -> str:
     return setup_code
 
 
-def genStatefulLenObject(var_name: str) -> str:
+def gen_stateful_len_object(var_name: str) -> str:
     """Generate the source code for a class whose `__len__` is stateful."""
     class_name = f"StatefulLen_{var_name}"
     setup_code = dedent(f"""
@@ -327,7 +327,7 @@ def genStatefulLenObject(var_name: str) -> str:
     return setup_code
 
 
-def genUnstableHashObject(var_name: str) -> str:
+def gen_unstable_hash_object(var_name: str) -> str:
     """Generate the source code for a class whose `__hash__` is not constant."""
     class_name = f"UnstableHash_{var_name}"
     setup_code = dedent(f"""
@@ -345,7 +345,7 @@ def genUnstableHashObject(var_name: str) -> str:
     return setup_code
 
 
-def genStatefulStrReprObject(var_name: str) -> str:
+def gen_stateful_str_repr_object(var_name: str) -> str:
     """
     Generate a class with stateful __str__ and __repr__ methods.
     __repr__ will eventually return a non-string type to cause a TypeError.
@@ -378,7 +378,7 @@ def genStatefulStrReprObject(var_name: str) -> str:
     return setup_code
 
 
-def genStatefulGetitemObject(var_name: str) -> str:
+def gen_stateful_getitem_object(var_name: str) -> str:
     """Generate a class whose ``__getitem__`` returns different types based on call count."""
     class_name = f"StatefulGetitem_{var_name}"
     setup_code = dedent(f"""
@@ -399,7 +399,7 @@ def genStatefulGetitemObject(var_name: str) -> str:
     return setup_code
 
 
-def genStatefulGetattrObject(var_name: str) -> str:
+def gen_stateful_getattr_object(var_name: str) -> str:
     """
     Generate a class whose __getattr__ returns different values based on call count.
     """
@@ -422,7 +422,7 @@ def genStatefulGetattrObject(var_name: str) -> str:
     return setup_code
 
 
-def genStatefulBoolObject(var_name: str) -> str:
+def gen_stateful_bool_object(var_name: str) -> str:
     """
     Generate a class whose __bool__ result flips after a few calls.
     """
@@ -445,7 +445,7 @@ def genStatefulBoolObject(var_name: str) -> str:
     return setup_code
 
 
-def genStatefulIterObject(var_name: str) -> str:
+def gen_stateful_iter_object(var_name: str) -> str:
     """
     Generate a class whose __iter__ returns different iterators.
     """
@@ -467,7 +467,7 @@ def genStatefulIterObject(var_name: str) -> str:
     return setup_code
 
 
-def genStatefulIndexObject(var_name: str) -> str:
+def gen_stateful_index_object(var_name: str) -> str:
     """
     Generate a class whose __index__ returns different integer values.
     """
@@ -490,7 +490,7 @@ def genStatefulIndexObject(var_name: str) -> str:
     return setup_code
 
 
-def genSimpleObject(var_name: str) -> str:
+def gen_simple_object(var_name: str) -> str:
     class_name = f"C_{var_name}"  # We can use var_name because it will be unique
     setup_code = dedent(f"""
         class {class_name}:

--- a/tests/mutators/test_engine.py
+++ b/tests/mutators/test_engine.py
@@ -33,8 +33,8 @@ from lafleur.mutators.generic import (
 from lafleur.mutators.utils import RedundantStatementSanitizer
 from lafleur.mutators.utils import (
     FuzzerSetupNormalizer,
-    genStatefulBoolObject,
-    genStatefulIndexObject,
+    gen_stateful_bool_object,
+    gen_stateful_index_object,
 )
 
 
@@ -525,8 +525,8 @@ class TestASTMutator(unittest.TestCase):
         """Test combining multiple evil object generators."""
         # Generate a scenario using multiple evil objects
         code = dedent(f"""
-            {genStatefulBoolObject("bool_obj")}
-            {genStatefulIndexObject("idx_obj")}
+            {gen_stateful_bool_object("bool_obj")}
+            {gen_stateful_index_object("idx_obj")}
 
             def uop_harness_test():
                 data = [1, 2, 3, 4, 5]

--- a/tests/mutators/test_utils.py
+++ b/tests/mutators/test_utils.py
@@ -16,16 +16,16 @@ from lafleur.mutators.utils import (
     FuzzerSetupNormalizer,
     HarnessInstrumentor,
     RedundantStatementSanitizer,
-    genLyingEqualityObject,
-    genSimpleObject,
-    genStatefulBoolObject,
-    genStatefulGetattrObject,
-    genStatefulGetitemObject,
-    genStatefulIndexObject,
-    genStatefulIterObject,
-    genStatefulLenObject,
-    genStatefulStrReprObject,
-    genUnstableHashObject,
+    gen_lying_equality_object,
+    gen_simple_object,
+    gen_stateful_bool_object,
+    gen_stateful_getattr_object,
+    gen_stateful_getitem_object,
+    gen_stateful_index_object,
+    gen_stateful_iter_object,
+    gen_stateful_len_object,
+    gen_stateful_str_repr_object,
+    gen_unstable_hash_object,
     is_simple_statement,
 )
 
@@ -33,9 +33,9 @@ from lafleur.mutators.utils import (
 class TestEvilObjectGenerators(unittest.TestCase):
     """Test evil object generator functions."""
 
-    def test_genLyingEqualityObject(self):
+    def test_gen_lying_equality_object(self):
         """Test lying equality object generation."""
-        code = genLyingEqualityObject("test_eq")
+        code = gen_lying_equality_object("test_eq")
         self.assertIn("class LyingEquality_test_eq:", code)
         self.assertIn("def __eq__", code)
         self.assertIn("def __ne__", code)
@@ -47,9 +47,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genStatefulLenObject(self):
+    def test_gen_stateful_len_object(self):
         """Test stateful len object generation."""
-        code = genStatefulLenObject("test_len")
+        code = gen_stateful_len_object("test_len")
         self.assertIn("class StatefulLen_test_len:", code)
         self.assertIn("def __len__", code)
         self.assertIn("test_len = StatefulLen_test_len()", code)
@@ -60,9 +60,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genUnstableHashObject(self):
+    def test_gen_unstable_hash_object(self):
         """Test unstable hash object generation."""
-        code = genUnstableHashObject("test_hash")
+        code = gen_unstable_hash_object("test_hash")
         self.assertIn("class UnstableHash_test_hash:", code)
         self.assertIn("def __hash__", code)
         self.assertIn("fuzzer_rng.randint", code)
@@ -73,9 +73,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genSimpleObject(self):
+    def test_gen_simple_object(self):
         """Test simple object generation."""
-        code = genSimpleObject("test_obj")
+        code = gen_simple_object("test_obj")
         self.assertIn("class C_test_obj:", code)
         self.assertIn("self.x = 1", code)
         self.assertIn("self.y = 'y'", code)
@@ -87,9 +87,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genStatefulStrReprObject(self):
+    def test_gen_stateful_str_repr_object(self):
         """Test stateful str/repr object generation."""
-        code = genStatefulStrReprObject("test_str_repr")
+        code = gen_stateful_str_repr_object("test_str_repr")
         self.assertIn("class StatefulStrRepr_test_str_repr:", code)
         self.assertIn("def __str__", code)
         self.assertIn("def __repr__", code)
@@ -102,9 +102,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genStatefulGetitemObject(self):
+    def test_gen_stateful_getitem_object(self):
         """Test stateful getitem object generation."""
-        code = genStatefulGetitemObject("test_getitem")
+        code = gen_stateful_getitem_object("test_getitem")
         self.assertIn("class StatefulGetitem_test_getitem:", code)
         self.assertIn("def __getitem__", code)
         self.assertIn("return 99.9", code)  # Float return
@@ -117,9 +117,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genStatefulGetattrObject(self):
+    def test_gen_stateful_getattr_object(self):
         """Test stateful getattr object generation."""
-        code = genStatefulGetattrObject("test_getattr")
+        code = gen_stateful_getattr_object("test_getattr")
         self.assertIn("class StatefulGetattr_test_getattr:", code)
         self.assertIn("def __getattr__", code)
         self.assertIn("return b'evil_attribute'", code)
@@ -132,9 +132,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genStatefulBoolObject(self):
+    def test_gen_stateful_bool_object(self):
         """Test stateful bool object generation."""
-        code = genStatefulBoolObject("test_bool")
+        code = gen_stateful_bool_object("test_bool")
         self.assertIn("class StatefulBool_test_bool:", code)
         self.assertIn("def __bool__", code)
         self.assertIn("return False", code)
@@ -147,9 +147,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genStatefulIterObject(self):
+    def test_gen_stateful_iter_object(self):
         """Test stateful iter object generation."""
-        code = genStatefulIterObject("test_iter")
+        code = gen_stateful_iter_object("test_iter")
         self.assertIn("class StatefulIter_test_iter:", code)
         self.assertIn("def __iter__", code)
         self.assertIn("self._iterable = [1, 2, 3]", code)
@@ -162,9 +162,9 @@ class TestEvilObjectGenerators(unittest.TestCase):
         # Verify it actually runs — catches runtime issues ast.parse misses
         exec(code, {})
 
-    def test_genStatefulIndexObject(self):
+    def test_gen_stateful_index_object(self):
         """Test stateful index object generation."""
-        code = genStatefulIndexObject("test_index")
+        code = gen_stateful_index_object("test_index")
         self.assertIn("class StatefulIndex_test_index:", code)
         self.assertIn("def __index__", code)
         self.assertIn("return 99", code)  # Out-of-bounds index
@@ -180,16 +180,16 @@ class TestEvilObjectGenerators(unittest.TestCase):
     def test_all_evil_objects_are_executable(self):
         """Verify every evil object generator produces code that runs cleanly."""
         generators = [
-            (genLyingEqualityObject, "obj_eq"),
-            (genStatefulLenObject, "obj_len"),
-            (genUnstableHashObject, "obj_hash"),
-            (genSimpleObject, "obj_simple"),
-            (genStatefulStrReprObject, "obj_str"),
-            (genStatefulGetitemObject, "obj_getitem"),
-            (genStatefulGetattrObject, "obj_getattr"),
-            (genStatefulBoolObject, "obj_bool"),
-            (genStatefulIterObject, "obj_iter"),
-            (genStatefulIndexObject, "obj_index"),
+            (gen_lying_equality_object, "obj_eq"),
+            (gen_stateful_len_object, "obj_len"),
+            (gen_unstable_hash_object, "obj_hash"),
+            (gen_simple_object, "obj_simple"),
+            (gen_stateful_str_repr_object, "obj_str"),
+            (gen_stateful_getitem_object, "obj_getitem"),
+            (gen_stateful_getattr_object, "obj_getattr"),
+            (gen_stateful_bool_object, "obj_bool"),
+            (gen_stateful_iter_object, "obj_iter"),
+            (gen_stateful_index_object, "obj_index"),
         ]
         for gen_func, var_name in generators:
             with self.subTest(generator=gen_func.__name__):


### PR DESCRIPTION
## Summary
- Renamed 10 camelCase generator functions in `mutators/utils.py` to snake_case
- Updated all call sites in `scenarios_data.py`, test files, and dev docs

Closes #826

## Test plan
- [x] All 747 mutator tests pass
- [x] `ruff format` and `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)