### PR TITLE
refactor: tighten bare dict annotations and add missing type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ All notable changes to this project should be documented in this file.
 - Added 28 tests for previously untested `ArtifactManager` methods: `truncate_huge_log`, `compress_log_stream`, `process_log_file`, and `_classify_crash`, by @devdanzin.
 - Added `RunStats` TypedDict to `types.py` and updated `run_stats` parameter types across `utils.py`, `orchestrator.py`, `artifacts.py`, `corpus_manager.py`, `scoring.py`, and `report.py`, by @devdanzin.
 - Renamed 10 camelCase generator functions in `mutators/utils.py` to snake_case for naming consistency, by @devdanzin.
+- Tightened bare `dict` annotations to `dict[str, Any]` across `lineage.py`, `minimize.py`, `scoring.py`, `driver.py`, and `corpus_manager.py`, fixed `.get() or 0` → `.get(, 0)` in `scoring.py`, and added missing type hints in `bump_version.py` and `state_tool.py`, by @devdanzin.
 - Removed obsolete `@unittest.skipIf(sys.version_info < (3, 14))` guards from t-string tests in `test_generic.py`, since Python 3.14+ is the minimum supported version, by @devdanzin.
 - Extracted `_decorate_special_node` and `_prune_by_strahler` helpers in `lineage.py`, reducing nesting in `decorate` and `extract_forest`, by @devdanzin.
 - Decomposed `InterestingnessScorer.calculate_score` into `_score_timing`, `_score_jit_vitals`, and `_score_coverage` private methods in `scoring.py`, by @devdanzin.

--- a/lafleur/bump_version.py
+++ b/lafleur/bump_version.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import sys
 
 
-def bump_version(new_version):
+def bump_version(new_version: str) -> None:
     # Update pyproject.toml
     pyproject = Path("pyproject.toml")
     content = pyproject.read_text(encoding="utf-8")

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -15,7 +15,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from lafleur.coverage import HarnessCoverage, save_coverage_state, CoverageManager
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
@@ -519,7 +519,7 @@ class CorpusManager:
                 build_lineage_func=orchestrator_build_lineage_func,
             )
 
-    def _get_edge_set_from_profile(self, lineage_profile: dict) -> set[int]:
+    def _get_edge_set_from_profile(self, lineage_profile: dict[str, Any]) -> set[int]:
         """A helper to extract the set of all unique edge IDs from a lineage profile."""
         all_edges = set()
         for harness_data in lineage_profile.values():

--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -25,6 +25,7 @@ import sys
 import traceback
 from pathlib import Path
 from types import CodeType, FunctionType, MethodType, ModuleType
+from typing import Any
 
 # Try to import JIT introspection modules
 try:
@@ -135,7 +136,7 @@ def check_bloom(bloom_filter: _PyBloomFilter, obj_address: int) -> bool:
 
 def scan_watched_variables(
     executor_ptr: ctypes.POINTER(PyExecutorObject),  # type: ignore[valid-type]
-    namespace: dict,
+    namespace: dict[str, Any],
 ) -> list[str]:
     """Identify which globals/builtins are watched by this executor."""
     watched = []
@@ -172,7 +173,7 @@ def scan_watched_variables(
     return watched
 
 
-def _emit_stats(stats: dict) -> None:
+def _emit_stats(stats: dict[str, Any]) -> None:
     """Safely emit a [DRIVER:STATS] JSON line to stdout.
 
     Handles serialization failures gracefully by:
@@ -229,7 +230,7 @@ def walk_code_objects(
             yield from walk_code_objects(const, visited)
 
 
-def snapshot_executor_state(namespace: dict) -> dict[tuple[int, int], int]:
+def snapshot_executor_state(namespace: dict[str, Any]) -> dict[tuple[int, int], int]:
     """Record exit_count for all JIT executors currently in the namespace.
 
     Walks the shared namespace and records the current exit_count for every
@@ -341,7 +342,9 @@ class _JitMetrics:
         return result
 
 
-def get_jit_stats(namespace: dict, baseline: dict[tuple[int, int], int] | None = None) -> dict:
+def get_jit_stats(
+    namespace: dict[str, Any], baseline: dict[tuple[int, int], int] | None = None
+) -> dict[str, Any]:
     """Scan a namespace for functions and count active JIT executors.
 
     Uses _opcode.get_executor() to check if functions have been JIT-compiled.

--- a/lafleur/lineage.py
+++ b/lafleur/lineage.py
@@ -21,6 +21,7 @@ from collections import defaultdict, deque
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from statistics import mean
+from typing import Any
 
 from lafleur.types import CorpusFileMetadata
 from lafleur.utils import load_json_file
@@ -677,7 +678,7 @@ def extract_forest(
 # ---------------------------------------------------------------------------
 
 
-def scan_crashes(crashes_dir: Path) -> list[dict]:
+def scan_crashes(crashes_dir: Path) -> list[dict[str, Any]]:
     """Scan the crashes directory for crash metadata.
 
     Reads metadata.json from each crash subdirectory.
@@ -691,7 +692,7 @@ def scan_crashes(crashes_dir: Path) -> list[dict]:
     - session_roles: dict of role→corpus filename (if session crash)
     - timestamp: discovery timestamp
     """
-    results: list[dict] = []
+    results: list[dict[str, Any]] = []
 
     if not crashes_dir.is_dir():
         return results
@@ -735,7 +736,7 @@ def scan_crashes(crashes_dir: Path) -> list[dict]:
 
 def attach_crashes(
     subgraph: Subgraph,
-    crashes: list[dict],
+    crashes: list[dict[str, Any]],
     graph: LineageGraph,
 ) -> int:
     """Add crash nodes to an existing subgraph.
@@ -907,7 +908,7 @@ def compute_edge_discoveries(
     parent_id: str,
     child_id: str,
     graph: LineageGraph,
-    state: dict,
+    state: dict[str, Any],
 ) -> list[str]:
     """Compute what new coverage the child discovered relative to its parent.
 
@@ -975,7 +976,7 @@ def compute_edge_discoveries(
 
 def _build_node_label(
     node: str,
-    metadata: dict,
+    metadata: dict[str, Any],
     label_style: str,
     metrics: TreeMetrics | None = None,
     show_strahler: bool = False,
@@ -1024,7 +1025,9 @@ def _build_node_label(
     return "\\n".join(parts)
 
 
-def _success_rate_label_parts(node: str, metadata: dict, metrics: TreeMetrics) -> list[str]:
+def _success_rate_label_parts(
+    node: str, metadata: dict[str, Any], metrics: TreeMetrics
+) -> list[str]:
     """Build success rate label parts for a node."""
     if metadata.get("parent_id") is None:
         return []  # Seed — skip
@@ -1040,7 +1043,7 @@ def _success_rate_label_parts(node: str, metadata: dict, metrics: TreeMetrics) -
         return [f"rate\\u2265{total_finds}/{denom} (\\u2264{rate:.1%})"]
 
 
-def _build_tooltip(metadata: dict) -> str:
+def _build_tooltip(metadata: dict[str, Any]) -> str:
     """Build a tooltip with full metadata dump."""
     dm = metadata.get("discovery_mutation", {})
     jit_stats = dm.get("jit_stats", {})
@@ -1254,7 +1257,7 @@ def _decorate_special_node(
 
 def _decorate_corpus_node(
     node: str,
-    metadata: dict,
+    metadata: dict[str, Any],
     label_style: str,
     metrics: TreeMetrics | None,
     show_strahler: bool,

--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 from lafleur.utils import FUZZING_ENV, load_json_file
 
@@ -34,7 +35,7 @@ def _make_repro_env() -> dict[str, str]:
     return env
 
 
-def extract_grep_pattern(metadata: dict) -> str:
+def extract_grep_pattern(metadata: dict[str, Any]) -> str:
     """Extract a grep pattern from the crash fingerprint metadata."""
     fingerprint = metadata.get("fingerprint", "")
 
@@ -106,7 +107,7 @@ def run_session(scripts: list[Path], target_python: str, timeout: int = 10) -> t
 
 
 def check_reproduction(
-    scripts: list[Path], metadata: dict, grep_pattern: str, target_python: str
+    scripts: list[Path], metadata: dict[str, Any], grep_pattern: str, target_python: str
 ) -> bool:
     """Check if the crash reproduces with the given scripts."""
     target_code = metadata.get("returncode", 0)
@@ -134,7 +135,7 @@ def check_reproduction(
     return code_match and grep_match
 
 
-def _load_and_validate_metadata(crash_dir: Path) -> tuple[dict, str, list[Path]]:
+def _load_and_validate_metadata(crash_dir: Path) -> tuple[dict[str, Any], str, list[Path]]:
     """Load metadata, validate returncode, extract grep pattern, and find scripts.
 
     Returns (metadata, grep_pattern, script_files).
@@ -171,7 +172,7 @@ def _load_and_validate_metadata(crash_dir: Path) -> tuple[dict, str, list[Path]]
 
 
 def _minimize_scripts(
-    script_files: list[Path], metadata: dict, grep_pattern: str, target_python: str
+    script_files: list[Path], metadata: dict[str, Any], grep_pattern: str, target_python: str
 ) -> list[Path]:
     """Stage 1: Identify which scripts are necessary for reproduction.
 
@@ -201,7 +202,7 @@ def _minimize_scripts(
 def _concatenate_scripts(
     necessary_scripts: list[Path],
     crash_dir: Path,
-    metadata: dict,
+    metadata: dict[str, Any],
     grep_pattern: str,
     target_python: str,
     force_overwrite: bool,
@@ -274,7 +275,7 @@ def _generate_bash_scripts(
     crash_dir: Path,
     target_file: Path,
     necessary_scripts: list[Path],
-    metadata: dict,
+    metadata: dict[str, Any],
     grep_pattern: str,
     target_python: str,
     use_concatenation: bool,

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -14,7 +14,7 @@ import hashlib
 import json
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from lafleur.coverage import (
     CoverageManager,
@@ -200,12 +200,13 @@ class InterestingnessScorer:
         """Score based on JIT tachycardia, zombie traces, chain depth, and stubs."""
         score = 0.0
 
-        zombie_traces = self.jit_stats.get("zombie_traces") or 0
-        max_chain_depth = self.jit_stats.get("max_chain_depth") or 0
-        min_code_size = self.jit_stats.get("min_code_size") or 0
+        zombie_traces = self.jit_stats.get("zombie_traces", 0)
+        max_chain_depth = self.jit_stats.get("max_chain_depth", 0)
+        min_code_size = self.jit_stats.get("min_code_size", 0)
 
         # Tachycardia: prefer delta metrics (child-isolated) when available from
         # session mode, fall back to absolute metrics for non-session runs.
+        # Delta fields may be None in old pickle data, so use `or` fallback.
         child_delta_density = self.jit_stats.get("child_delta_max_exit_density") or 0.0
         child_delta_exits = self.jit_stats.get("child_delta_total_exits") or 0
 
@@ -326,8 +327,8 @@ class ScoringManager:
 
     def find_new_coverage(
         self,
-        child_coverage: dict,
-        parent_lineage_profile: dict,
+        child_coverage: dict[str, Any],
+        parent_lineage_profile: dict[str, Any],
         parent_id: str | None,
     ) -> NewCoverageInfo:
         """
@@ -424,6 +425,7 @@ class ScoringManager:
                     json_str = line.split("[DRIVER:STATS]", 1)[1].strip()
                     stats = json.loads(json_str)
 
+                    # Driver may emit None for any field, so use `or` fallback.
                     aggregated_stats["max_exit_count"] = max(
                         aggregated_stats["max_exit_count"],
                         stats.get("max_exit_count") or 0,
@@ -445,7 +447,8 @@ class ScoringManager:
                     if code_size > 0:
                         min_code_sizes.append(code_size)
 
-                    # Delta metrics: overwrite each time (we want the LAST line = child)
+                    # Delta metrics: overwrite each time (we want the LAST line = child).
+                    # Use `or` fallback because driver may emit None for these fields.
                     if "delta_max_exit_density" in stats:
                         aggregated_stats["child_delta_max_exit_density"] = (
                             stats.get("delta_max_exit_density") or 0.0
@@ -550,11 +553,11 @@ class ScoringManager:
         print(f"  [+] Child IS NOT interesting with score: {score:.2f}", file=sys.stderr)
         return False
 
-    def _update_global_coverage(self, child_coverage: dict) -> None:
+    def _update_global_coverage(self, child_coverage: dict[str, Any]) -> None:
         """Commit the coverage from a new, interesting child to the global state."""
         merge_coverage_into_global(self.coverage_manager.state, child_coverage)
 
-    def _calculate_coverage_hash(self, coverage_profile: dict) -> str:
+    def _calculate_coverage_hash(self, coverage_profile: dict[str, Any]) -> str:
         """Create a deterministic SHA256 hash of a coverage profile's edges."""
         all_edges = []
         # We only hash the edges, as they provide the most significant signal.
@@ -568,7 +571,7 @@ class ScoringManager:
         return hashlib.sha256(canonical_string.encode("utf-8")).hexdigest()
 
     def _build_lineage_profile(
-        self, parent_lineage_profile: dict, child_baseline_profile: dict
+        self, parent_lineage_profile: dict[str, Any], child_baseline_profile: dict
     ) -> dict:
         """
         Create a new lineage profile by taking the union of a parent's
@@ -604,7 +607,7 @@ class ScoringManager:
     def analyze_run(
         self,
         exec_result: ExecutionResult,
-        parent_lineage_profile: dict,
+        parent_lineage_profile: dict[str, Any],
         parent_id: str | None,
         mutation_info: MutationInfo,
         mutation_seed: int,
@@ -696,7 +699,7 @@ class ScoringManager:
     def _prepare_new_coverage_result(
         self,
         exec_result: ExecutionResult,
-        child_coverage: dict,
+        child_coverage: dict[str, Any],
         jit_stats: JitStats,
         parent_jit_stats: JitStats,
         parent_id: str | None,

--- a/lafleur/state_tool.py
+++ b/lafleur/state_tool.py
@@ -117,7 +117,7 @@ def main() -> None:
         migrated_state = migrate_state_to_integers(state)
 
     # Convert sets to lists for JSON serialization
-    def set_to_list(obj):
+    def set_to_list(obj: object) -> list:
         if isinstance(obj, set):
             return sorted(list(obj))
         raise TypeError


### PR DESCRIPTION
## Summary
- Replaced bare `dict` with `dict[str, Any]` in ~20 function signatures across 5 modules
- Added missing type hints to `bump_version.py` and `state_tool.py`

Closes #830

## Test plan
- [x] All 2081 tests pass
- [x] `ruff format` and `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)