### PR TITLE
refactor: fix API surface inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ All notable changes to this project should be documented in this file.
 - Extracted `_decorate_special_node` and `_prune_by_strahler` helpers in `lineage.py`, reducing nesting in `decorate` and `extract_forest`, by @devdanzin.
 - Decomposed `InterestingnessScorer.calculate_score` into `_score_timing`, `_score_jit_vitals`, and `_score_coverage` private methods in `scoring.py`, by @devdanzin.
 - Introduced `ScoringContext` frozen dataclass to bundle 9 parameters of `score_and_decide_interestingness` in `scoring.py`, reducing the method signature from 11 to 3 parameters, by @devdanzin.
+- Fixed API surface inconsistencies: changed `driver.py:main()` from returning `int` to `None` (using `sys.exit()`) matching all other entry points, prefixed internal ctypes structs `PyVMData`/`PyExecutorObject` with underscore, and removed private `_dump_unparse_diagnostics` from `mutators/__init__.py` `__all__`, by @devdanzin.
 - Replaced fragile `__name__.replace()` strategy name extraction in `mutation_controller.py` with an explicit `strategy_map` dict mapping methods to canonical names, by @devdanzin.
 - Extracted `_prompt_issue_number` and `_prompt_note` shared helpers in `triage.py` to deduplicate interactive input logic between `run_interactive_triage` and `run_review_triage`, with unified EOF handling via `_EOFReceived` sentinel, by @devdanzin.
 - Extracted `_compose_session` helper in `execution.py` to isolate session file composition logic (solo/standard/mixer) from `execute_child`, reducing nesting depth, by @devdanzin.

--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -63,7 +63,7 @@ BLOOM_WORDS = 8  # _Py_BLOOM_WORDS (uint32 words in filter)
 # Source: Include/internal/pycore_optimizer.h
 #
 # If introspection produces unexpected values after a CPython update,
-# compare ctypes.sizeof(PyExecutorObject) against the C struct size
+# compare ctypes.sizeof(_PyExecutorObject) against the C struct size
 # and update these definitions accordingly.
 # ---------------------------------------------------------------------------
 
@@ -83,7 +83,7 @@ _PyExecutorLinkListNode._fields_ = [
 ]
 
 
-class PyVMData(ctypes.Structure):
+class _PyVMData(ctypes.Structure):
     # Matches _PyVMData in pycore_optimizer.h
     _fields_ = [
         ("opcode", ctypes.c_uint8),
@@ -99,14 +99,14 @@ class PyVMData(ctypes.Structure):
     ]
 
 
-class PyExecutorObject(ctypes.Structure):
+class _PyExecutorObject(ctypes.Structure):
     # Matches _PyExecutorObject in pycore_optimizer.h
     _fields_ = [
         ("ob_refcnt", ctypes.c_ssize_t),
         ("ob_type", ctypes.c_void_p),
         ("ob_size", ctypes.c_ssize_t),
         ("trace", ctypes.c_void_p),
-        ("vm_data", PyVMData),  # Nested structure
+        ("vm_data", _PyVMData),  # Nested structure
         ("exit_count", ctypes.c_uint32),
         ("code_size", ctypes.c_uint32),
         ("jit_size", ctypes.c_size_t),
@@ -135,7 +135,7 @@ def check_bloom(bloom_filter: _PyBloomFilter, obj_address: int) -> bool:
 
 
 def scan_watched_variables(
-    executor_ptr: ctypes.POINTER(PyExecutorObject),  # type: ignore[valid-type]
+    executor_ptr: ctypes.POINTER(_PyExecutorObject),  # type: ignore[valid-type]
     namespace: dict[str, Any],
 ) -> list[str]:
     """Identify which globals/builtins are watched by this executor."""
@@ -272,7 +272,7 @@ def snapshot_executor_state(namespace: dict[str, Any]) -> dict[tuple[int, int], 
                         executor = _opcode.get_executor(code, offset)
                         if executor:
                             executor_ptr = ctypes.cast(
-                                id(executor), ctypes.POINTER(PyExecutorObject)
+                                id(executor), ctypes.POINTER(_PyExecutorObject)
                             )
                             snapshot[(id(code), offset)] = executor_ptr.contents.exit_count
                     except ValueError, TypeError:
@@ -380,7 +380,7 @@ def get_jit_stats(
 
     def inspect_executor(executor, code_id: int, offset: int) -> None:
         try:
-            executor_ptr = ctypes.cast(id(executor), ctypes.POINTER(PyExecutorObject))
+            executor_ptr = ctypes.cast(id(executor), ctypes.POINTER(_PyExecutorObject))
 
             if executor_ptr.contents.vm_data.pending_deletion:
                 m.zombie_traces += 1
@@ -610,7 +610,7 @@ def run_session(files: list[str], *, no_ekg: bool = False) -> int:
     return 1 if errors_occurred else 0
 
 
-def main() -> int:
+def main() -> None:
     """Main entry point for the session fuzzing driver."""
     parser = argparse.ArgumentParser(
         description="Session fuzzing driver - executes scripts in a shared process."
@@ -638,7 +638,7 @@ def main() -> int:
         print(f"[DRIVER:INFO] JIT introspection available: {HAS_OPCODE}", flush=True)
         print(f"[DRIVER:INFO] Scripts to execute: {args.files}", flush=True)
 
-    return run_session(args.files, no_ekg=args.no_ekg)
+    sys.exit(run_session(args.files, no_ekg=args.no_ekg))
 
 
 if __name__ == "__main__":

--- a/lafleur/mutators/__init__.py
+++ b/lafleur/mutators/__init__.py
@@ -19,7 +19,6 @@ from lafleur.mutators.generic import ImportPrunerMutator, StatementDuplicator, V
 __all__ = [
     "ASTMutator",
     "SlicingMutator",
-    "_dump_unparse_diagnostics",
     "FuzzerSetupNormalizer",
     "EmptyBodySanitizer",
     "HarnessInstrumentor",

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -247,9 +247,10 @@ class TestDriverMain(unittest.TestCase):
 
             captured_stdout = StringIO()
             with patch("sys.stdout", captured_stdout):
-                result = driver_main()
+                with self.assertRaises(SystemExit) as cm:
+                    driver_main()
 
-        self.assertEqual(result, 0)
+        self.assertEqual(cm.exception.code, 0)
         output = captured_stdout.getvalue()
         self.assertIn("[DRIVER:START]", output)
         self.assertIn("[DRIVER:STATS]", output)
@@ -264,9 +265,10 @@ class TestDriverMain(unittest.TestCase):
 
             captured_stdout = StringIO()
             with patch("sys.stdout", captured_stdout):
-                result = driver_main()
+                with self.assertRaises(SystemExit) as cm:
+                    driver_main()
 
-        self.assertEqual(result, 0)
+        self.assertEqual(cm.exception.code, 0)
         output = captured_stdout.getvalue()
         self.assertIn("[DRIVER:INFO]", output)
 
@@ -282,9 +284,10 @@ class TestDriverMain(unittest.TestCase):
 
             captured_stdout = StringIO()
             with patch("sys.stdout", captured_stdout):
-                result = driver_main()
+                with self.assertRaises(SystemExit) as cm:
+                    driver_main()
 
-        self.assertEqual(result, 0)
+        self.assertEqual(cm.exception.code, 0)
         output = captured_stdout.getvalue()
         self.assertIn("a.py", output)
         self.assertIn("b.py", output)

--- a/tests/test_driver_internals.py
+++ b/tests/test_driver_internals.py
@@ -447,7 +447,8 @@ class TestDriverVerboseMode(unittest.TestCase):
 
             captured_stdout = StringIO()
             with patch("sys.stdout", captured_stdout):
-                driver_main()
+                with self.assertRaises(SystemExit):
+                    driver_main()
 
         output = captured_stdout.getvalue()
         self.assertIn("[DRIVER:INFO]", output)
@@ -465,7 +466,8 @@ class TestDriverVerboseMode(unittest.TestCase):
 
             captured_stdout = StringIO()
             with patch("sys.stdout", captured_stdout):
-                driver_main()
+                with self.assertRaises(SystemExit):
+                    driver_main()
 
         output = captured_stdout.getvalue()
         self.assertIn("Scripts to execute", output)

--- a/tests/test_driver_jit.py
+++ b/tests/test_driver_jit.py
@@ -59,7 +59,7 @@ class TestJITIntrospection(unittest.TestCase):
             # Verify the type cast target
             # args[1] should be a pointer type to PyExecutorObject
             # Since we patched driver.ctypes, POINTER is also a mock.
-            # So args[1] is the result of driver.ctypes.POINTER(driver.PyExecutorObject)
+            # So args[1] is the result of driver.ctypes.POINTER(driver._PyExecutorObject)
 
     def test_introspection_exception_handling(self):
         """Test that get_jit_stats handles ctypes exceptions gracefully."""


### PR DESCRIPTION
## Summary
- Changed `driver.py:main()` from returning `int` to `None` (using `sys.exit()`), matching all other entry points
- Prefixed internal ctypes structs `PyVMData` → `_PyVMData` and `PyExecutorObject` → `_PyExecutorObject`
- Removed private `_dump_unparse_diagnostics` from `mutators/__init__.py` `__all__` (still importable, just not part of public API)

## Test plan
- [x] All 2081 tests pass
- [x] `ruff format` and `ruff check` clean
- [x] Updated tests to handle `SystemExit` from `main()` and new class names

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)