### PR TITLE
fix: guard .chmod() and HTML write against OSError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to this project should be documented in this file.
 - `lineage.py::load_coverage_state()` had no exception handling on `pickle.load()` — a corrupted state file would crash `lafleur-lineage` with an opaque error. Now catches `UnpicklingError`/`EOFError`/`OSError` with a clear message, by @devdanzin.
 - `metadata.py::get_installed_packages()` bare `except Exception: pass` silently swallowed all errors during package metadata collection. Now logs warnings to stderr, by @devdanzin.
 - Fixed stat_key inconsistency: orchestrator checked `"timeout_count"` but execution.py returns `"timeouts_found"`, causing `HealthMonitor.record_timeout()` to never trigger, by @devdanzin.
+- Guarded `.chmod()` calls in `artifacts.py` and `minimize.py` and HTML report write in `campaign.py` against `OSError` on restricted filesystems or disk-full conditions, by @devdanzin.
 
 ### Enhanced
 

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -421,7 +421,10 @@ class ArtifactManager:
             python3 {dest_name}
         """)
         reproduce_script.write_text(reproduce_content, encoding="utf-8")
-        reproduce_script.chmod(0o755)
+        try:
+            reproduce_script.chmod(0o755)
+        except OSError:
+            pass  # chmod may fail on restricted filesystems
 
         return crash_dir
 
@@ -494,7 +497,10 @@ class ArtifactManager:
         """).strip()
 
         reproduce_script.write_text(reproduce_content, encoding="utf-8")
-        reproduce_script.chmod(0o755)  # Make executable
+        try:
+            reproduce_script.chmod(0o755)
+        except OSError:
+            pass  # chmod may fail on restricted filesystems
 
         return crash_dir
 

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -1642,9 +1642,12 @@ Examples:
     # Generate HTML report if requested
     if args.html:
         html_report = generate_html_report(aggregator)
-        with open(args.html, "w", encoding="utf-8") as f:
-            f.write(html_report)
-        print(f"[+] HTML report saved to {args.html}", file=sys.stderr)
+        try:
+            with open(args.html, "w", encoding="utf-8") as f:
+                f.write(html_report)
+            print(f"[+] HTML report saved to {args.html}", file=sys.stderr)
+        except OSError as e:
+            print(f"[!] Failed to write HTML report to {args.html}: {e}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -353,7 +353,10 @@ fi
 exit 0
 """
     check_script_path.write_text(check_script_content, encoding="utf-8")
-    check_script_path.chmod(0o755)
+    try:
+        check_script_path.chmod(0o755)
+    except OSError:
+        pass  # chmod may fail on restricted filesystems
 
     # Generate reproduce_minimized.sh
     repro_script_path = crash_dir / "reproduce_minimized.sh"
@@ -366,7 +369,10 @@ export ASAN_OPTIONS=detect_leaks=0
 {repro_cmd_display}
 """
     repro_script_path.write_text(repro_script_content, encoding="utf-8")
-    repro_script_path.chmod(0o755)
+    try:
+        repro_script_path.chmod(0o755)
+    except OSError:
+        pass  # chmod may fail on restricted filesystems
 
     return check_script_path
 


### PR DESCRIPTION
## Summary
- Wrapped 4 `.chmod()` calls in `artifacts.py` and `minimize.py` with try/except OSError for restricted filesystems
- Guarded HTML report write in `campaign.py` with error message instead of crash on disk-full/permission errors
- `learning.py` JSON load was already properly guarded — no change needed

## Test plan
- [x] All 2081 tests pass
- [x] `ruff format` and `ruff check` clean

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)