### PR TITLE
refactor: move HarnessCoverage from coverage.py to types.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable changes to this project should be documented in this file.
 - Decomposed `InterestingnessScorer.calculate_score` into `_score_timing`, `_score_jit_vitals`, and `_score_coverage` private methods in `scoring.py`, by @devdanzin.
 - Introduced `ScoringContext` frozen dataclass to bundle 9 parameters of `score_and_decide_interestingness` in `scoring.py`, reducing the method signature from 11 to 3 parameters, by @devdanzin.
 - Fixed API surface inconsistencies: changed `driver.py:main()` from returning `int` to `None` (using `sys.exit()`) matching all other entry points, prefixed internal ctypes structs `PyVMData`/`PyExecutorObject` with underscore, and removed private `_dump_unparse_diagnostics` from `mutators/__init__.py` `__all__`, by @devdanzin.
+- Moved `HarnessCoverage` TypedDict from `coverage.py` to `types.py`, fixing a layer violation where the types module depended on a domain module, by @devdanzin.
 - Replaced fragile `__name__.replace()` strategy name extraction in `mutation_controller.py` with an explicit `strategy_map` dict mapping methods to canonical names, by @devdanzin.
 - Extracted `_prompt_issue_number` and `_prompt_note` shared helpers in `triage.py` to deduplicate interactive input logic between `run_interactive_triage` and `run_review_triage`, with unified EOF handling via `_EOFReceived` sentinel, by @devdanzin.
 - Extracted `_compose_session` helper in `execution.py` to isolate session file composition logic (solo/standard/mixer) from `execute_child`, reducing nesting depth, by @devdanzin.

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -17,9 +17,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-from lafleur.coverage import HarnessCoverage, save_coverage_state, CoverageManager
+from lafleur.coverage import save_coverage_state, CoverageManager
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
-from lafleur.types import CorpusFileMetadata, MutationInfo, NewCoverageResult, RunStats
+from lafleur.types import (
+    CorpusFileMetadata,
+    HarnessCoverage,
+    MutationInfo,
+    NewCoverageResult,
+    RunStats,
+)
 from lafleur.utils import ExecutionResult, FUZZING_ENV
 
 if TYPE_CHECKING:

--- a/lafleur/coverage.py
+++ b/lafleur/coverage.py
@@ -16,8 +16,9 @@ import sys
 from collections import defaultdict, Counter
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Callable, TypedDict
+from typing import Any, Callable
 
+from lafleur.types import HarnessCoverage
 from lafleur.uop_names import UOP_NAMES
 
 migrate_state_to_integers: Callable[[dict[str, Any]], dict[str, Any]] | None
@@ -137,16 +138,6 @@ class CoverageManager:
         self.state["next_id_map"][item_type] += 1
         reverse_map[new_id] = item_string
         return new_id
-
-
-class HarnessCoverage(TypedDict, total=False):
-    """Type for harness coverage data."""
-
-    uops: Counter[int]
-    edges: Counter[int]
-    rare_events: Counter[int]
-    trace_length: int
-    side_exits: int
 
 
 def _create_empty_harness_coverage() -> HarnessCoverage:

--- a/lafleur/types.py
+++ b/lafleur/types.py
@@ -14,10 +14,19 @@ dispatch and preventing accidental mutation.
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 from typing import TypedDict
 
-from lafleur.coverage import HarnessCoverage
+
+class HarnessCoverage(TypedDict, total=False):
+    """Coverage data for a single harness execution."""
+
+    uops: Counter[int]
+    edges: Counter[int]
+    rare_events: Counter[int]
+    trace_length: int
+    side_exits: int
 
 
 class RunStats(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- Moved `HarnessCoverage` TypedDict definition from `coverage.py` to `types.py`
- Updated `coverage.py` to import from `types.py` instead of defining locally
- Updated `corpus_manager.py` to import `HarnessCoverage` from `types.py`

## Test plan
- [x] All 2102 tests pass
- [x] `ruff format` and `ruff check` clean

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)