### PR TITLE
fix: remove redundant from __future__ import annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ All notable changes to this project should be documented in this file.
 
 ### Refactored
 
+- Removed redundant `from __future__ import annotations` from 18 files (Python 3.14+ doesn't need it), by @devdanzin.
 - Extracted `_record_timeout_metadata()` and `_record_new_find()` from `_execute_single_mutation` in `orchestrator.py`, reducing the inner mutation loop to its essential logic, by @devdanzin.
 
 ### Enhanced

--- a/lafleur/artifacts.py
+++ b/lafleur/artifacts.py
@@ -6,8 +6,6 @@ This module provides:
 - TelemetryManager: run statistics persistence and time-series logging
 """
 
-from __future__ import annotations
-
 import difflib
 import random
 import re

--- a/lafleur/campaign.py
+++ b/lafleur/campaign.py
@@ -6,8 +6,6 @@ lafleur fuzzing instances, deduplicate findings, and produce fleet-wide
 summaries for campaign analysis.
 """
 
-from __future__ import annotations
-
 import argparse
 import html
 import json

--- a/lafleur/corpus_analysis.py
+++ b/lafleur/corpus_analysis.py
@@ -6,8 +6,6 @@ of the fuzzing corpus, computing statistics about file sizes, execution
 times, lineage depths, and mutation effectiveness.
 """
 
-from __future__ import annotations
-
 import statistics
 from collections import Counter
 from collections.abc import Sequence

--- a/lafleur/driver.py
+++ b/lafleur/driver.py
@@ -15,8 +15,6 @@ Output Protocol:
     [DRIVER:ERROR] <script_path>   - Emitted when a script raises an exception
 """
 
-from __future__ import annotations
-
 import argparse
 import collections.abc
 import ctypes

--- a/lafleur/lineage.py
+++ b/lafleur/lineage.py
@@ -7,8 +7,6 @@ file back to its seed) and descendants (show what a file produced) modes.
 Output formats: Graphviz DOT (default), JSON, or rendered images (PNG/SVG/PDF).
 """
 
-from __future__ import annotations
-
 import argparse
 import hashlib
 import json

--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -8,8 +8,6 @@ This module provides the MutationController class ("The Alchemist") which handle
 - Extracting boilerplate and core code from source files
 """
 
-from __future__ import annotations
-
 import ast
 import copy
 import math

--- a/lafleur/mutators/engine.py
+++ b/lafleur/mutators/engine.py
@@ -7,8 +7,6 @@ the `SlicingMutator`, a meta-mutator designed to efficiently fuzz very large
 functions by operating on small, random slices of their body.
 """
 
-from __future__ import annotations
-
 import ast
 import pickle
 import random

--- a/lafleur/mutators/generic.py
+++ b/lafleur/mutators/generic.py
@@ -7,8 +7,6 @@ perturbing constants, changing container types, and injecting basic control
 flow structures like loops and guards.
 """
 
-from __future__ import annotations
-
 import ast
 import builtins
 import copy

--- a/lafleur/mutators/scenarios_control.py
+++ b/lafleur/mutators/scenarios_control.py
@@ -8,8 +8,6 @@ to break traces, and generating loops with many side-exits to stress the JIT's
 guard emission and bailout mechanisms.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/mutators/scenarios_data.py
+++ b/lafleur/mutators/scenarios_data.py
@@ -8,8 +8,6 @@ lying equality), corrupting built-in namespaces, and creating scenarios that
 misuse collection primitives like iterators and slices.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/mutators/scenarios_runtime.py
+++ b/lafleur/mutators/scenarios_runtime.py
@@ -8,8 +8,6 @@ versioning caches, using frame introspection to corrupt local variables
 from outside their scope, and triggering side effects via object finalizers.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/mutators/scenarios_types.py
+++ b/lafleur/mutators/scenarios_types.py
@@ -8,8 +8,6 @@ call sites to stress inline caches, confusing attribute lookup mechanisms, and
 modifying class hierarchies (MRO) at runtime.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/mutators/utils.py
+++ b/lafleur/mutators/utils.py
@@ -8,8 +8,6 @@ testing, and a library of generator functions for creating "evil" objects
 with stateful or contract-violating behaviors used by various scenarios.
 """
 
-from __future__ import annotations
-
 import ast
 import random
 import sys

--- a/lafleur/registry.py
+++ b/lafleur/registry.py
@@ -5,8 +5,6 @@ This module provides a SQLite-based registry for storing crash fingerprints,
 sightings across fuzzing runs, and links to reported GitHub issues.
 """
 
-from __future__ import annotations
-
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path

--- a/lafleur/triage.py
+++ b/lafleur/triage.py
@@ -5,8 +5,6 @@ This module provides a command-line interface for importing crashes from
 fuzzing campaigns and linking them to GitHub issues.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import subprocess

--- a/lafleur/types.py
+++ b/lafleur/types.py
@@ -12,8 +12,6 @@ untyped dict returned by analyze_run(), enabling isinstance()-based
 dispatch and preventing accidental mutation.
 """
 
-from __future__ import annotations
-
 from collections import Counter
 from dataclasses import dataclass
 from typing import TypedDict

--- a/lafleur/utils.py
+++ b/lafleur/utils.py
@@ -4,8 +4,6 @@ This module contains generic, reusable helper functions and classes for the lafl
 It includes utilities for logging, managing run statistics, and structuring data.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import sys

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,7 +1,5 @@
 """Tests for lafleur.lineage — corpus lineage visualization tool."""
 
-from __future__ import annotations
-
 import json
 import sys
 import unittest


### PR DESCRIPTION
## Summary
- Removed `from __future__ import annotations` from 18 files
- Python 3.14+ doesn't need this import; it's a no-op

## Test plan
- [x] All 2,102 tests pass
- [x] ruff format/check clean

Closes #842

Generated with [Claude Code](https://claude.com/claude-code)