### PR TITLE
fix: remove unnecessary shebangs from source and test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to this project should be documented in this file.
 ### Refactored
 
 - Removed redundant `from __future__ import annotations` from 18 files (Python 3.14+ doesn't need it), by @devdanzin.
+- Removed unnecessary shebangs from 23 package and test files, by @devdanzin.
 - Extracted `_record_timeout_metadata()` and `_record_new_find()` from `_execute_single_mutation` in `orchestrator.py`, reducing the inner mutation loop to its essential logic, by @devdanzin.
 
 ### Enhanced

--- a/lafleur/bump_version.py
+++ b/lafleur/bump_version.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import re
 from pathlib import Path
 import sys

--- a/lafleur/coverage.py
+++ b/lafleur/coverage.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 This module provides utilities for parsing CPython JIT trace logs.
 

--- a/lafleur/jit_tuner.py
+++ b/lafleur/jit_tuner.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 A utility script to apply aggressive JIT settings to the CPython source code.
 

--- a/lafleur/minimize.py
+++ b/lafleur/minimize.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Advanced Session Minimizer for Lafleur crash bundles.
 

--- a/lafleur/state_tool.py
+++ b/lafleur/state_tool.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 A standalone command-line utility for inspecting and migrating lafleur's
 binary state file (`coverage_state.pkl`).

--- a/tests/mutators/test_engine.py
+++ b/tests/mutators/test_engine.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for mutation engine components.
 

--- a/tests/mutators/test_generic.py
+++ b/tests/mutators/test_generic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for generic mutators.
 

--- a/tests/mutators/test_scenarios_control.py
+++ b/tests/mutators/test_scenarios_control.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for control flow mutators.
 

--- a/tests/mutators/test_scenarios_data.py
+++ b/tests/mutators/test_scenarios_data.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for data structure mutators.
 
@@ -309,9 +308,11 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         with patch("random.random", side_effect=[0.1, 0.1]):  # trigger, use enhanced
             with patch(
                 "random.choice",
-                side_effect=lambda x: "direct_dict_modification"
-                if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
-                else x[0],
+                side_effect=lambda x: (
+                    "direct_dict_modification"
+                    if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
+                    else x[0]
+                ),
             ):
                 with patch("random.randint", return_value=5000):
                     mutator = BuiltinNamespaceCorruptor()
@@ -341,9 +342,11 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         with patch("random.random", side_effect=[0.1, 0.1]):  # trigger, use enhanced
             with patch(
                 "random.choice",
-                side_effect=lambda x: "builtins_type_toggle"
-                if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
-                else x[0],
+                side_effect=lambda x: (
+                    "builtins_type_toggle"
+                    if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
+                    else x[0]
+                ),
             ):
                 with patch("random.randint", return_value=6000):
                     mutator = BuiltinNamespaceCorruptor()
@@ -372,9 +375,11 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         with patch("random.random", side_effect=[0.1, 0.1]):  # trigger, use enhanced
             with patch(
                 "random.choice",
-                side_effect=lambda x: "highfreq_builtin_corruption"
-                if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
-                else x[0],
+                side_effect=lambda x: (
+                    "highfreq_builtin_corruption"
+                    if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
+                    else x[0]
+                ),
             ):
                 with patch("random.randint", return_value=7000):
                     mutator = BuiltinNamespaceCorruptor()
@@ -405,9 +410,11 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
         with patch("random.random", side_effect=[0.1, 0.1]):
             with patch(
                 "random.choice",
-                side_effect=lambda x: "highfreq_builtin_corruption"
-                if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
-                else x[0],
+                side_effect=lambda x: (
+                    "highfreq_builtin_corruption"
+                    if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
+                    else x[0]
+                ),
             ):
                 with patch("random.randint", return_value=8000):
                     mutator = BuiltinNamespaceCorruptor()
@@ -434,9 +441,9 @@ class TestBuiltinNamespaceCorruptor(unittest.TestCase):
             with patch("random.random", side_effect=[0.1, 0.1]):
                 with patch(
                     "random.choice",
-                    side_effect=lambda x, at=attack_type: at
-                    if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS
-                    else x[0],
+                    side_effect=lambda x, at=attack_type: (
+                        at if x == BuiltinNamespaceCorruptor.ENHANCED_ATTACKS else x[0]
+                    ),
                 ):
                     with patch("random.randint", return_value=9000):
                         mutator = BuiltinNamespaceCorruptor()
@@ -1458,9 +1465,9 @@ class TestBloomFilterSaturator(unittest.TestCase):
         with patch("random.random", side_effect=[0.1, 0.1, 0.1]):
             with patch(
                 "random.choice",
-                side_effect=lambda x: "saturation_probe"
-                if x == BloomFilterSaturator.ENHANCED_ATTACKS
-                else x[0],
+                side_effect=lambda x: (
+                    "saturation_probe" if x == BloomFilterSaturator.ENHANCED_ATTACKS else x[0]
+                ),
             ):
                 with patch("random.randint", return_value=5000):
                     mutator = BloomFilterSaturator()
@@ -1490,9 +1497,9 @@ class TestBloomFilterSaturator(unittest.TestCase):
         with patch("random.random", side_effect=[0.1, 0.1, 0.1]):
             with patch(
                 "random.choice",
-                side_effect=lambda x: "strategic_global_mod"
-                if x == BloomFilterSaturator.ENHANCED_ATTACKS
-                else x[0],
+                side_effect=lambda x: (
+                    "strategic_global_mod" if x == BloomFilterSaturator.ENHANCED_ATTACKS else x[0]
+                ),
             ):
                 with patch("random.randint", return_value=6000):
                     mutator = BloomFilterSaturator()
@@ -1522,9 +1529,9 @@ class TestBloomFilterSaturator(unittest.TestCase):
         with patch("random.random", side_effect=[0.1, 0.1, 0.1]):
             with patch(
                 "random.choice",
-                side_effect=lambda x: "multi_phase_attack"
-                if x == BloomFilterSaturator.ENHANCED_ATTACKS
-                else x[0],
+                side_effect=lambda x: (
+                    "multi_phase_attack" if x == BloomFilterSaturator.ENHANCED_ATTACKS else x[0]
+                ),
             ):
                 with patch("random.randint", return_value=7000):
                     mutator = BloomFilterSaturator()
@@ -1557,9 +1564,9 @@ class TestBloomFilterSaturator(unittest.TestCase):
             with patch("random.random", side_effect=[0.1, 0.1, 0.1]):
                 with patch(
                     "random.choice",
-                    side_effect=lambda x, at=attack_type: at
-                    if x == BloomFilterSaturator.ENHANCED_ATTACKS
-                    else x[0],
+                    side_effect=lambda x, at=attack_type: (
+                        at if x == BloomFilterSaturator.ENHANCED_ATTACKS else x[0]
+                    ),
                 ):
                     with patch("random.randint", return_value=9000):
                         mutator = BloomFilterSaturator()

--- a/tests/mutators/test_scenarios_runtime.py
+++ b/tests/mutators/test_scenarios_runtime.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for runtime manipulation mutators.
 

--- a/tests/mutators/test_scenarios_types.py
+++ b/tests/mutators/test_scenarios_types.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for type system mutators.
 

--- a/tests/mutators/test_utils.py
+++ b/tests/mutators/test_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for utility transformers.
 

--- a/tests/orchestrator/test_coverage.py
+++ b/tests/orchestrator/test_coverage.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for coverage analysis methods.
 

--- a/tests/orchestrator/test_crash_detection.py
+++ b/tests/orchestrator/test_crash_detection.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for crash detection and artifact saving in lafleur.
 

--- a/tests/orchestrator/test_diagnostic_mode.py
+++ b/tests/orchestrator/test_diagnostic_mode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 End-to-end integration tests for diagnostic mode.
 

--- a/tests/orchestrator/test_execution.py
+++ b/tests/orchestrator/test_execution.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for execution methods.
 

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for main evolutionary loop in lafleur/orchestrator.py.
 

--- a/tests/orchestrator/test_mutation_strategies.py
+++ b/tests/orchestrator/test_mutation_strategies.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for mutation strategy methods in lafleur/mutation_controller.py.
 
@@ -31,8 +30,8 @@ class TestApplyMutationStrategy(unittest.TestCase):
         # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
-        self.controller.score_tracker.record_attempt.side_effect = (
-            lambda name: self.controller.score_tracker.attempts.__setitem__(
+        self.controller.score_tracker.record_attempt.side_effect = lambda name: (
+            self.controller.score_tracker.attempts.__setitem__(
                 name, self.controller.score_tracker.attempts[name] + 1
             )
         )
@@ -304,8 +303,8 @@ class TestRunHavocStage(unittest.TestCase):
         # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
-        self.controller.score_tracker.record_attempt.side_effect = (
-            lambda name: self.controller.score_tracker.attempts.__setitem__(
+        self.controller.score_tracker.record_attempt.side_effect = lambda name: (
+            self.controller.score_tracker.attempts.__setitem__(
                 name, self.controller.score_tracker.attempts[name] + 1
             )
         )
@@ -516,8 +515,8 @@ class TestRunSniperStage(unittest.TestCase):
         # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
-        self.controller.score_tracker.record_attempt.side_effect = (
-            lambda name: self.controller.score_tracker.attempts.__setitem__(
+        self.controller.score_tracker.record_attempt.side_effect = lambda name: (
+            self.controller.score_tracker.attempts.__setitem__(
                 name, self.controller.score_tracker.attempts[name] + 1
             )
         )
@@ -585,8 +584,8 @@ class TestRunHelperSniperStage(unittest.TestCase):
         # Mock score_tracker with record_attempt wired to real attempts dict
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
-        self.controller.score_tracker.record_attempt.side_effect = (
-            lambda name: self.controller.score_tracker.attempts.__setitem__(
+        self.controller.score_tracker.record_attempt.side_effect = lambda name: (
+            self.controller.score_tracker.attempts.__setitem__(
                 name, self.controller.score_tracker.attempts[name] + 1
             )
         )
@@ -900,8 +899,8 @@ class TestHygienePass(unittest.TestCase):
         self.controller.ast_mutator.transformers = [MagicMock, MagicMock]
         self.controller.score_tracker = MagicMock()
         self.controller.score_tracker.attempts = defaultdict(int)
-        self.controller.score_tracker.record_attempt.side_effect = (
-            lambda name: self.controller.score_tracker.attempts.__setitem__(
+        self.controller.score_tracker.record_attempt.side_effect = lambda name: (
+            self.controller.score_tracker.attempts.__setitem__(
                 name, self.controller.score_tracker.attempts[name] + 1
             )
         )

--- a/tests/orchestrator/test_scoring.py
+++ b/tests/orchestrator/test_scoring.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for scoring components in lafleur/scoring.py.
 

--- a/tests/test_corpus_manager.py
+++ b/tests/test_corpus_manager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Unit tests for lafleur/corpus_manager.py
 """
@@ -1157,10 +1156,13 @@ class TestGenerateNewSeed(unittest.TestCase):
         mock_analyze = Mock(return_value={"status": "NO_NEW_COVERAGE"})
         mock_lineage = Mock()
 
-        with patch("builtins.open", mock_open()), patch(
-            "lafleur.corpus_manager.TMP_DIR"
-        ) as mock_tmp:
-            mock_tmp.__truediv__ = Mock(side_effect=lambda name: Mock(exists=Mock(return_value=True)))
+        with (
+            patch("builtins.open", mock_open()),
+            patch("lafleur.corpus_manager.TMP_DIR") as mock_tmp,
+        ):
+            mock_tmp.__truediv__ = Mock(
+                side_effect=lambda name: Mock(exists=Mock(return_value=True))
+            )
             self.corpus_manager.generate_new_seed(mock_analyze, mock_lineage)
 
         # Verify analyze was called with execution_time_ms=250 (not zero)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Unit tests for lafleur/coverage.py
 """

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Tests for the session fuzzing driver.
 

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Unit tests for lafleur/learning.py
 """


### PR DESCRIPTION
## Summary
- Removed `#!/usr/bin/env python3` from 23 files (5 package modules, 18 test files)
- These are package modules/tests, not standalone scripts

## Test plan
- [x] All 2,102 tests pass
- [x] ruff format/check clean

Closes #843

Generated with [Claude Code](https://claude.com/claude-code)