### PR TITLE
feat: native JIT seed generation (drop fusil subprocess for seeding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project should be documented in this file.
 
 ### Added
 
+- Native JIT seed generation (`lafleur/jit_seeds.py`): `CorpusManager.generate_new_seed` now synthesizes uop-targeted hot-loop seeds in-process — porting fusil's `UOP_RECIPES` table plus a trimmed simple-value generator, and reusing lafleur's own evil-object generators (`mutators.utils.gen_*`) — instead of shelling out to the classic fusil executable. This removes the fragile external dependency for seeding, fixes the silent degradation to plain values (fusil's `lafleur.mutator` import had bit-rotted), and produces richer seeds, by @devdanzin.
 - Targeted testing CLI options: `--mutators` to filter the mutator pool and `--strategy` to force a specific mutation strategy, by @devdanzin.
 - Diagnostic introspection CLI options: `--keep-children` to retain all generated scripts, `--dry-run` for mutation-only mode, and `--list-mutators` to discover available mutators, by @devdanzin.
 - Diagnostic bounded-run CLI options: `--max-sessions`, `--max-mutations-per-session`, `--seed`, and `--workdir` for reproducible smoke tests and CI verification, by @devdanzin.

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from lafleur.coverage import CoverageManager, save_coverage_state
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
+from lafleur.jit_seeds import generate_jit_seed
+from lafleur.mutation_controller import BOILERPLATE_END_MARKER, BOILERPLATE_START_MARKER
 from lafleur.types import (
     CorpusFileMetadata,
     HarnessCoverage,
@@ -431,51 +433,43 @@ class CorpusManager:
     def generate_new_seed(
         self, orchestrator_analyze_run_func: Callable, orchestrator_build_lineage_func: Callable
     ) -> None:
-        """Run a single generative session to create a new seed file."""
+        """Run a single generative session to create a new seed file.
+
+        The seed is generated natively (see :mod:`lafleur.jit_seeds`) rather than by
+        shelling out to the classic fusil executable. Only the JIT "core" is
+        synthesized here; it is wrapped with lafleur's boilerplate (which supplies the
+        ``sys`` import and the ``fuzzer_rng`` the evil objects reference), bracketed by
+        the standard ``FUSIL_BOILERPLATE`` markers so downstream analysis can strip it
+        back to the core. The generation RNG seed is drawn from the (optionally seeded)
+        global RNG and recorded as ``mutation_seed`` so the seed is reproducible.
+        """
         tmp_source = TMP_DIR / "gen_run.py"
         tmp_log = TMP_DIR / "gen_run.log"
 
-        python_executable = sys.executable
-        # Use fusil to generate a new file
-        command = [
-            python_executable,
-            self.fusil_path,
-            "--jit-fuzz",
-            "--jit-target-uop=ALL",
-            f"--source-output-path={tmp_source}",
-            "--classes-number=0",
-            "--functions-number=1",
-            "--methods-number=0",
-            "--objects-number=0",
-            "--sessions=1",
-            f"--python={self.target_python}",
-            "--no-jit-external-references",
-            "--no-threads",
-            "--no-async",
-            "--jit-loop-iterations=300",
-            "--no-numpy",
-            "--modules=encodings.ascii",
-            "--only-generate",
-            # "--keep-sessions",
-        ]
-        print(f"[*] Generating new seed with command: {' '.join(command)}")
+        seed_int = random.randrange(2**31)
         try:
-            result = subprocess.run(command, capture_output=True, env=FUZZING_ENV, timeout=120)
-            if result.returncode != 0:
-                print(
-                    f"[!] Seed generation failed (exit {result.returncode})",
-                    file=sys.stderr,
-                )
-                return
-        except subprocess.TimeoutExpired:
-            print("[!] Seed generation timed out after 120s", file=sys.stderr)
-            return
-        except OSError as e:
-            print(f"[!] Seed generation failed: {e}", file=sys.stderr)
+            core_code = generate_jit_seed(random.Random(seed_int), loop_iterations=300)
+        except Exception as e:  # generation is pure-Python; never let it abort the run
+            print(f"[!] Native seed generation failed: {e}", file=sys.stderr)
             return
 
-        if not tmp_source.exists():
-            print("[!] Seed generation produced no output file", file=sys.stderr)
+        boilerplate = self.get_boilerplate().rstrip()
+        if not boilerplate:
+            # Minimal self-contained boilerplate for a cold start (empty corpus): the
+            # native core only needs `sys` and `fuzzer_rng`.
+            boilerplate = f"{BOILERPLATE_START_MARKER}\nimport sys"
+        full_source = (
+            f"{boilerplate}\n"
+            f"import random\n"
+            f"fuzzer_rng = random.Random({seed_int})\n"
+            f"{BOILERPLATE_END_MARKER}\n"
+            f"{core_code}\n"
+        )
+        print(f"[*] Generating new seed natively (uop-targeted, seed={seed_int})")
+        try:
+            tmp_source.write_text(full_source, encoding="utf-8")
+        except OSError as e:
+            print(f"[!] Could not write generated seed: {e}", file=sys.stderr)
             return
 
         # Execute it to get a log (also using the configurable timeout)
@@ -508,7 +502,7 @@ class CorpusManager:
             parent_lineage_profile={},
             parent_id=None,
             mutation_info={"strategy": "generative_seed"},
-            mutation_seed=0,
+            mutation_seed=seed_int,
             parent_file_size=0,
             parent_lineage_edge_count=0,
         )

--- a/lafleur/jit_seeds.py
+++ b/lafleur/jit_seeds.py
@@ -1,0 +1,551 @@
+"""
+Native JIT seed generation for lafleur (DRAFT — MVP of the fusil seed-gen port).
+
+Background
+----------
+Until now lafleur produced new corpus seeds by shelling out to the *classic fusil*
+executable (`CorpusManager.generate_new_seed` → `fusil-python-threaded --jit-fuzz
+--jit-target-uop=ALL ...`). An analysis of what that subprocess actually does
+(see fusil `doc/jit-seed-generation.md`) showed lafleur exercises only ONE slice of
+fusil's 4,483-LOC JIT subsystem: the **uop-targeted** path —
+
+    pick 3–7 Tier-2 micro-ops → fill each from a recipe template → declare the
+    typed operands → wrap in a JIT-warming hot loop.
+
+This module re-implements that slice natively, so lafleur no longer needs the fusil
+subprocess for seeds. It is intentionally small:
+
+* ``UOP_RECIPES`` — the 38-entry recipe table (ported verbatim from fusil's
+  ``ast_pattern_generator.py``; pure data).
+* simple value generators (``int``/``float``/``str``/``bytes``/collections) — a
+  trimmed copy of fusil's ``ArgumentGenerator`` simple half (the only part not
+  already in lafleur).
+* the **object / "evil" generators are reused from lafleur itself**
+  (``lafleur.mutators.utils.gen_*``) — fusil already imported these back from
+  lafleur, so there is nothing to port for that half.
+
+Output contract
+---------------
+``generate_jit_seed()`` returns the **core** seed (setup + ``uop_harness`` + hot
+loop) — i.e. the ``core_code`` lafleur stores in the corpus. It is NOT standalone:
+it assumes lafleur's boilerplate is prepended at execution time, which provides
+``import sys`` and the ``fuzzer_rng`` RNG that the evil objects reference. This
+matches how fusil-generated seeds already work today.
+
+NOT in scope for this MVP (later "better seeds" work): fusil's ``BUG_PATTERNS``
+(variational mode) and the from-scratch ``generate_pattern`` synthesize grammar.
+"""
+
+from __future__ import annotations
+
+import random
+from textwrap import dedent, indent
+from typing import Callable
+
+# The object/"evil" generators already live in lafleur. Map each object "kind" to
+# the lafleur generator that realizes it; the object_with_* variants all use the
+# generic simple object (it has .x, .get_value, and __getitem__). When this module
+# is used outside a full lafleur runtime (e.g. unit tests), degrade to simple values
+# so the generator still produces parseable output.
+try:
+    from lafleur.mutators.utils import (
+        gen_simple_object,
+        gen_stateful_bool_object,
+        gen_stateful_getattr_object,
+        gen_stateful_getitem_object,
+        gen_stateful_index_object,
+        gen_stateful_iter_object,
+        gen_stateful_len_object,
+        gen_unstable_hash_object,
+    )
+
+    _OBJECT_GENERATORS: dict[str, Callable[[str], str]] = {
+        "object": gen_simple_object,
+        "object_with_attr": gen_simple_object,
+        "object_with_getitem": gen_simple_object,
+        "object_with_method": gen_simple_object,
+        "stateful_getattr_object": gen_stateful_getattr_object,
+        "stateful_getitem_object": gen_stateful_getitem_object,
+        "stateful_index_object": gen_stateful_index_object,
+        "stateful_bool_object": gen_stateful_bool_object,
+        "stateful_iter_object": gen_stateful_iter_object,
+        "stateful_len_object": gen_stateful_len_object,
+        "unstable_hash_object": gen_unstable_hash_object,
+    }
+    HAS_OBJECTS = True
+except ImportError:  # pragma: no cover - exercised only without lafleur installed
+    _OBJECT_GENERATORS = {}
+    HAS_OBJECTS = False
+
+
+# ==============================================================================
+# UOP recipe table (ported verbatim from fusil ast_pattern_generator.UOP_RECIPES)
+# ==============================================================================
+# Each entry: a `pattern` (a str.format template) and `placeholders` mapping each
+# template field to a tuple of acceptable operand "kinds". "new_variable" means a
+# fresh result name (an assignment/loop target); every other kind is realized by a
+# value or object generator.
+UOP_RECIPES: dict[str, dict] = {
+    # --- Attribute and Subscript Operations ---
+    "_STORE_ATTR": {
+        "pattern": "{target_obj}.x = {value}",
+        "placeholders": {
+            "target_obj": ("object", "object_with_attr", "stateful_getattr_object"),
+            "value": ("any",),
+        },
+    },
+    "_LOAD_ATTR_METHOD_WITH_VALUES": {
+        "pattern": "{result_var} = {target_obj}.get_value()",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "target_obj": ("object_with_method", "stateful_getattr_object"),
+        },
+    },
+    "_BINARY_SUBSCR_LIST_INT": {
+        "pattern": "{result_var} = {target_list}[{index}]",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "target_list": ("list", "object_with_getitem", "stateful_getitem_object"),
+            "index": ("small_int", "stateful_index_object"),
+        },
+    },
+    "_BINARY_OP_SUBSCR_GETITEM": {
+        "pattern": "{result_var} = {target_obj}[{key}]",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "target_obj": ("object_with_getitem", "stateful_getitem_object"),
+            "key": ("any", "stateful_index_object"),
+        },
+    },
+    "_DELETE_ATTR": {
+        "pattern": "del {target_obj}.x",
+        "placeholders": {"target_obj": ("object_with_attr",), "value": ("int",)},
+    },
+    # --- Binary Operations ---
+    "_BINARY_OP_ADD_INT": {
+        "pattern": "{result_var} = {operand_a} + {operand_b}",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "operand_a": ("int",),
+            "operand_b": ("int",),
+        },
+    },
+    "_BINARY_OP_ADD_FLOAT": {
+        "pattern": "{result_var} = {operand_a} + {operand_b}",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "operand_a": ("float",),
+            "operand_b": ("float",),
+        },
+    },
+    "_BINARY_OP_MULTIPLY_TUPLE_INT": {
+        "pattern": "{result_var} = {operand_a} * {operand_b}",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "operand_a": ("tuple",),
+            "operand_b": ("small_int", "stateful_index_object"),
+        },
+    },
+    # --- Collection and Iteration ---
+    "_BUILD_LIST": {
+        "pattern": "{result_var} = [" + "{val_a}, {val_b}, {val_c}," * 50 + "]",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "val_a": ("any",),
+            "val_b": ("any",),
+            "val_c": ("any",),
+        },
+    },
+    "_CONTAINS_OP_DICT": {
+        "pattern": "{result_var} = {key} in {target_dict}",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "key": ("any", "unstable_hash_object"),
+            "target_dict": ("dict",),
+        },
+    },
+    # --- Compare and Boolean Operations ---
+    "_COMPARE_OP_INT": {
+        "pattern": "{result_var} = {operand_a} > {operand_b}",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "operand_a": ("int",),
+            "operand_b": ("int", "stateful_index_object"),
+        },
+    },
+    "_TO_BOOL_INT": {
+        "pattern": "if {target_int}: pass",
+        "placeholders": {"target_int": ("int", "stateful_index_object", "stateful_len_object")},
+    },
+    "_LOAD_ATTR": {
+        "pattern": "{target_obj}.x",
+        "placeholders": {"target_obj": ("object_with_attr", "stateful_getattr_object")},
+    },
+    "_BINARY_SUBSCR_TUPLE_INT": {
+        "pattern": "{target_tuple}[{index}]",
+        "placeholders": {
+            "target_tuple": ("tuple",),
+            "index": ("small_int", "stateful_index_object"),
+        },
+    },
+    "_BINARY_OP_SUB_INT": {"pattern": "{a} - {b}", "placeholders": {"a": ("int",), "b": ("int",)}},
+    "_BINARY_OP_MUL_INT": {
+        "pattern": "{a} * {b}",
+        "placeholders": {"a": ("int",), "b": ("int", "stateful_index_object")},
+    },
+    "_BINARY_OP_SUB_FLOAT": {
+        "pattern": "{a} - {b}",
+        "placeholders": {"a": ("float",), "b": ("float",)},
+    },
+    "_BINARY_OP_MUL_FLOAT": {
+        "pattern": "{a} * {b}",
+        "placeholders": {"a": ("float",), "b": ("float",)},
+    },
+    "_BINARY_OP_AND_INT": {
+        "pattern": "{a} & {b}",
+        "placeholders": {
+            "a": ("int", "stateful_index_object"),
+            "b": ("int", "stateful_index_object"),
+        },
+    },
+    "_BINARY_OP_OR_INT": {
+        "pattern": "{a} | {b}",
+        "placeholders": {
+            "a": ("int", "stateful_index_object"),
+            "b": ("int", "stateful_index_object"),
+        },
+    },
+    "_BINARY_OP_XOR_INT": {
+        "pattern": "{a} ^ {b}",
+        "placeholders": {"a": ("int",), "b": ("int", "stateful_index_object")},
+    },
+    "_COMPARE_OP_EQ_INT": {
+        "pattern": "{a} == {b}",
+        "placeholders": {"a": ("int",), "b": ("int", "stateful_index_object")},
+    },
+    "_COMPARE_OP_LT_INT": {"pattern": "{a} < {b}", "placeholders": {"a": ("int",), "b": ("int",)}},
+    "_COMPARE_OP_GT_INT": {"pattern": "{a} > {b}", "placeholders": {"a": ("int",), "b": ("int",)}},
+    "_COMPARE_OP_EQ_STR": {"pattern": "{a} == {b}", "placeholders": {"a": ("str",), "b": ("str",)}},
+    "_COMPARE_OP_LT_STR": {"pattern": "{a} < {b}", "placeholders": {"a": ("str",), "b": ("str",)}},
+    "_COMPARE_OP_GT_STR": {"pattern": "{a} > {b}", "placeholders": {"a": ("str",), "b": ("str",)}},
+    "_UNARY_NOT": {
+        "pattern": "not {value}",
+        "placeholders": {"value": ("any", "stateful_index_object")},
+    },
+    "_TO_BOOL": {
+        "pattern": "if {obj}: pass",
+        "placeholders": {
+            "obj": (
+                "object",
+                "stateful_bool_object",
+                "stateful_len_object",
+                "stateful_index_object",
+            )
+        },
+    },
+    "_BUILD_TUPLE": {
+        "pattern": "(" + "{a}, {b}," * 50 + ")",
+        "placeholders": {"a": ("any",), "b": ("any",)},
+    },
+    "_BUILD_SET": {
+        "pattern": "{{ {a}, {b} }}",
+        "placeholders": {
+            "a": ("any", "unstable_hash_object"),
+            "b": ("any", "unstable_hash_object"),
+        },
+    },
+    "_BUILD_MAP": {
+        "pattern": "{{ {key}: {value} }}",
+        "placeholders": {"key": ("str", "int", "unstable_hash_object"), "value": ("any",)},
+    },
+    "_UNPACK_SEQUENCE_TUPLE": {
+        "pattern": "x, *y = {iterable}",
+        "placeholders": {"iterable": ("tuple", "stateful_iter_object")},
+    },
+    "_UNPACK_SEQUENCE_LIST": {
+        "pattern": "x, *y = {iterable}",
+        "placeholders": {"iterable": ("list", "stateful_iter_object")},
+    },
+    "_FOR_ITER_LIST": {
+        "pattern": "for {result_var} in {iterable}: pass",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "iterable": ("list", "stateful_iter_object"),
+        },
+    },
+    "_FOR_ITER_TUPLE": {
+        "pattern": "for {result_var} in {iterable}: pass",
+        "placeholders": {
+            "result_var": ("new_variable",),
+            "iterable": ("tuple", "stateful_iter_object"),
+        },
+    },
+    "_CALL_LIST_APPEND": {
+        "pattern": "{target_list}.append({value})",
+        "placeholders": {"target_list": ("list",), "value": ("any",)},
+    },
+    # NOTE: `_YIELD_VALUE` ("yield {value}") is intentionally excluded from the
+    # default selectable set: it turns the harness into a generator that the hot
+    # loop never actually runs (so it never warms the JIT). Kept in the table for
+    # parity; handle it specially before re-enabling.
+    "_YIELD_VALUE": {"pattern": "yield {value}", "placeholders": {"value": ("any",)}},
+}
+
+#: uops safe to drop into a plain hot-loop harness (see _YIELD_VALUE note above).
+SELECTABLE_UOPS: tuple[str, ...] = tuple(k for k in UOP_RECIPES if k != "_YIELD_VALUE")
+
+# Concrete kinds that "any" can expand to.
+_ANY_SIMPLE = ("int", "float", "str", "list", "tuple", "dict", "bool", "none")
+_ANY_KINDS = _ANY_SIMPLE + tuple(_OBJECT_GENERATORS)
+
+
+# ==============================================================================
+# Simple value generators (trimmed copy of fusil ArgumentGenerator's simple half)
+# ==============================================================================
+# Each returns a Python *literal/expression string*. Using repr() guarantees a
+# valid literal without manual escaping.
+
+_INTERESTING_INTS = (
+    0,
+    1,
+    -1,
+    2,
+    8,
+    255,
+    256,
+    1024,
+    -(2**31),
+    2**31 - 1,
+    2**31,
+    -(2**63),
+    2**63 - 1,
+    2**63,
+    10**18,
+)
+_TRICKY_STRS = ("", "a", "abc", "\x00", "\U0010ffff", "𝒜", "A" * 64)
+
+
+def _gen_int(rng: random.Random) -> str:
+    if rng.random() < 0.5:
+        return repr(rng.choice(_INTERESTING_INTS))
+    return repr(rng.randint(-(2**70), 2**70))
+
+
+def _gen_small_int(rng: random.Random) -> str:
+    return repr(rng.randint(-19, 19))
+
+
+def _gen_float(rng: random.Random) -> str:
+    special = ("float('inf')", "float('-inf')", "float('nan')", "0.0", "-0.0", "1e308")
+    if rng.random() < 0.3:
+        return rng.choice(special)
+    return repr(round(rng.uniform(-1e6, 1e6), 4))
+
+
+def _gen_str(rng: random.Random) -> str:
+    if rng.random() < 0.4:
+        return repr(rng.choice(_TRICKY_STRS))
+    n = rng.randint(0, 12)
+    return repr("".join(chr(rng.randint(32, 126)) for _ in range(n)))
+
+
+def _gen_bytes(rng: random.Random) -> str:
+    n = rng.randint(0, 12)
+    return repr(bytes(rng.randint(0, 255) for _ in range(n)))
+
+
+def _gen_bool(rng: random.Random) -> str:
+    return rng.choice(("True", "False"))
+
+
+def _gen_none(_rng: random.Random) -> str:
+    return "None"
+
+
+def _gen_scalar(rng: random.Random) -> str:
+    """A hashable scalar literal, for collection elements / dict keys."""
+    return rng.choice(
+        (_gen_int, _gen_small_int, _gen_float, _gen_str, _gen_bytes, _gen_bool, _gen_none)
+    )(rng)
+
+
+def _gen_list(rng: random.Random) -> str:
+    return "[" + ", ".join(_gen_scalar(rng) for _ in range(rng.randint(0, 6))) + "]"
+
+
+def _gen_tuple(rng: random.Random) -> str:
+    items = [_gen_scalar(rng) for _ in range(rng.randint(0, 6))]
+    if len(items) == 1:
+        return f"({items[0]},)"
+    return "(" + ", ".join(items) + ")"
+
+
+def _gen_set(rng: random.Random) -> str:
+    n = rng.randint(0, 6)
+    if not n:
+        return "set()"
+    return "{" + ", ".join(_gen_scalar(rng) for _ in range(n)) + "}"
+
+
+def _gen_dict(rng: random.Random) -> str:
+    n = rng.randint(0, 6)
+    return "{" + ", ".join(f"{_gen_scalar(rng)}: {_gen_scalar(rng)}" for _ in range(n)) + "}"
+
+
+_SIMPLE_GENERATORS: dict[str, Callable[[random.Random], str]] = {
+    "int": _gen_int,
+    "small_int": _gen_small_int,
+    "float": _gen_float,
+    "str": _gen_str,
+    "bytes": _gen_bytes,
+    "bool": _gen_bool,
+    "none": _gen_none,
+    "list": _gen_list,
+    "tuple": _gen_tuple,
+    "set": _gen_set,
+    "dict": _gen_dict,
+}
+
+
+# ==============================================================================
+# Pattern assembly
+# ==============================================================================
+
+
+class _VarPool:
+    """Tracks declared operand variables so uops in a chain can reuse them."""
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+        self._counter = 0
+        self.by_kind: dict[str, list[str]] = {}
+        self.setup_lines: list[str] = []
+
+    def _fresh_name(self, base: str) -> str:
+        self._counter += 1
+        return f"{base}_v{self._counter}"
+
+    def fresh_result(self) -> str:
+        """A new assignment/loop target (the 'new_variable' kind)."""
+        return self._fresh_name("res")
+
+    def _declare(self, kind: str) -> str:
+        """Create a variable of a concrete kind, emitting its setup, and return it."""
+        name = self._fresh_name(kind)
+        if kind in _SIMPLE_GENERATORS:
+            self.setup_lines.append(f"{name} = {_SIMPLE_GENERATORS[kind](self.rng)}")
+        elif kind in _OBJECT_GENERATORS:
+            self.setup_lines.append(dedent(_OBJECT_GENERATORS[kind](name)).strip())
+        else:  # object kind requested but lafleur unavailable -> degrade to a scalar
+            self.setup_lines.append(f"{name} = {_gen_scalar(self.rng)}")
+        self.by_kind.setdefault(kind, []).append(name)
+        return name
+
+    def get(self, kinds: tuple[str, ...]) -> str:
+        """Pick (reuse ~70% of the time) or create a variable of an acceptable kind."""
+        existing = [name for k in kinds for name in self.by_kind.get(k, [])]
+        if existing and self.rng.random() > 0.3:
+            return self.rng.choice(existing)
+        kind = self.rng.choice([k for k in kinds if k != "new_variable"])
+        if kind == "any":
+            kind = self.rng.choice(_ANY_KINDS)
+        return self._declare(kind)
+
+
+def _render_recipe(uop: str, recipe: dict, pool: _VarPool) -> str:
+    """Build the substitution map and render one recipe's statement text."""
+    subs: dict[str, str] = {}
+    for pname, kinds in recipe["placeholders"].items():
+        if "new_variable" in kinds:
+            subs[pname] = pool.fresh_result()
+        else:
+            subs[pname] = pool.get(kinds)
+
+    if uop == "_DELETE_ATTR":
+        # Robust del/set pair so the attribute exists to be deleted (fusil parity).
+        target = subs["target_obj"]
+        value = pool.get(("int",))
+        return dedent(
+            f"""
+            try:
+                del {target}.x
+            except AttributeError:
+                pass
+            {target}.x = {value}
+            """
+        ).strip()
+
+    return recipe["pattern"].format(**subs)
+
+
+def generate_uop_targeted_pattern(uop_names: list[str], rng: random.Random) -> tuple[str, str]:
+    """
+    Build a setup block + harness body that stresses the given uops.
+
+    Returns ``(setup_code, body_code)`` where ``setup_code`` declares the operands
+    and ``body_code`` is the sequence of (repeated) uop statements destined for the
+    harness function body.
+    """
+    pool = _VarPool(rng)
+    body_blocks: list[str] = []
+    for uop in uop_names:
+        recipe = UOP_RECIPES.get(uop)
+        if not recipe:
+            body_blocks.append(f"# ERROR: no recipe for {uop}")
+            continue
+        rendered = _render_recipe(uop, recipe, pool)
+        # Repeat each op a few times so it gets hot / specialized.
+        for _ in range(rng.randint(3, 5)):
+            body_blocks.append(rendered)
+
+    setup_code = "\n".join(pool.setup_lines)
+    body_code = "\n".join(body_blocks) if body_blocks else "pass"
+    return setup_code, body_code
+
+
+def generate_jit_seed(
+    rng: random.Random | None = None,
+    *,
+    num_uops: tuple[int, int] = (3, 7),
+    loop_iterations: int = 300,
+    prefix: str = "f1",
+) -> str:
+    """
+    Generate one JIT seed (the corpus ``core_code``).
+
+    The result assumes lafleur's boilerplate is prepended at run time (it provides
+    ``import sys`` and ``fuzzer_rng``). Deterministic for a given ``rng`` seed.
+    """
+    rng = rng or random.Random()
+    uops = rng.choices(SELECTABLE_UOPS, k=rng.randint(*num_uops))
+    setup_code, body_code = generate_uop_targeted_pattern(uops, rng)
+
+    harness = f"uop_harness_{prefix}"
+    loop_var = f"_loop_{prefix}"
+    return (
+        f"# JIT seed: targeted uops {uops}\n"
+        f"{setup_code}\n\n"
+        f"def {harness}():\n"
+        f"{indent(body_code, '    ')}\n\n"
+        f"for {loop_var} in range({loop_iterations}):\n"
+        f"    try:\n"
+        f"        {harness}()\n"
+        f"    except Exception:\n"
+        f"        break\n"
+    )
+
+
+def main() -> None:
+    """CLI demo: print one seed (optionally seeded for reproducibility)."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a JIT corpus seed.")
+    parser.add_argument("--seed", type=int, default=None, help="RNG seed for reproducibility")
+    parser.add_argument("--loop-iterations", type=int, default=300)
+    args = parser.parse_args()
+    rng = random.Random(args.seed)
+    print(generate_jit_seed(rng, loop_iterations=args.loop_iterations))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_jit_seeds.py
+++ b/tests/test_jit_seeds.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for lafleur/jit_seeds.py (native JIT seed generation).
+"""
+
+import ast
+import random
+import unittest
+
+from lafleur import jit_seeds
+from lafleur.jit_seeds import (
+    HAS_OBJECTS,
+    SELECTABLE_UOPS,
+    UOP_RECIPES,
+    generate_jit_seed,
+    generate_uop_targeted_pattern,
+)
+
+# Every operand "kind" a recipe placeholder is allowed to reference.
+_OBJECT_KINDS = {
+    "object",
+    "object_with_attr",
+    "object_with_getitem",
+    "object_with_method",
+    "stateful_getattr_object",
+    "stateful_getitem_object",
+    "stateful_index_object",
+    "stateful_bool_object",
+    "stateful_iter_object",
+    "stateful_len_object",
+    "unstable_hash_object",
+}
+_KNOWN_KINDS = set(jit_seeds._SIMPLE_GENERATORS) | _OBJECT_KINDS | {"new_variable", "any"}
+
+
+class TestRecipeTableIntegrity(unittest.TestCase):
+    """The UOP_RECIPES table is well-formed and self-consistent."""
+
+    def test_table_is_populated(self):
+        self.assertGreaterEqual(len(UOP_RECIPES), 38)
+
+    def test_every_recipe_has_pattern_and_placeholders(self):
+        for name, recipe in UOP_RECIPES.items():
+            with self.subTest(uop=name):
+                self.assertIn("pattern", recipe)
+                self.assertIn("placeholders", recipe)
+                self.assertIsInstance(recipe["pattern"], str)
+                self.assertIsInstance(recipe["placeholders"], dict)
+
+    def test_selectable_excludes_yield_value(self):
+        # _YIELD_VALUE would turn the harness into a never-run generator (see module).
+        self.assertNotIn("_YIELD_VALUE", SELECTABLE_UOPS)
+        self.assertEqual(set(SELECTABLE_UOPS), set(UOP_RECIPES) - {"_YIELD_VALUE"})
+
+    def test_recipes_only_reference_known_kinds(self):
+        for name, recipe in UOP_RECIPES.items():
+            for placeholder, kinds in recipe["placeholders"].items():
+                for kind in kinds:
+                    with self.subTest(uop=name, placeholder=placeholder, kind=kind):
+                        self.assertIn(kind, _KNOWN_KINDS)
+
+
+class TestSeedGeneration(unittest.TestCase):
+    """Generated seeds are valid, deterministic Python with the expected shape."""
+
+    def test_generated_seeds_parse(self):
+        for s in range(25):
+            with self.subTest(seed=s):
+                code = generate_jit_seed(random.Random(s))
+                ast.parse(code)  # raises SyntaxError if invalid
+
+    def test_assembled_seed_with_boilerplate_parses(self):
+        # Mirror what CorpusManager.generate_new_seed assembles around the core.
+        for s in range(10):
+            core = generate_jit_seed(random.Random(s))
+            full = f"import sys\nimport random\nfuzzer_rng = random.Random({s})\n{core}\n"
+            with self.subTest(seed=s):
+                ast.parse(full)
+
+    def test_deterministic_for_same_rng_seed(self):
+        a = generate_jit_seed(random.Random(1234))
+        b = generate_jit_seed(random.Random(1234))
+        self.assertEqual(a, b)
+
+    def test_distinct_for_different_rng_seeds(self):
+        a = generate_jit_seed(random.Random(1))
+        b = generate_jit_seed(random.Random(2))
+        self.assertNotEqual(a, b)
+
+    def test_contains_harness_and_hot_loop(self):
+        code = generate_jit_seed(random.Random(7), loop_iterations=300, prefix="f1")
+        self.assertIn("def uop_harness_f1():", code)
+        self.assertIn("range(300)", code)
+
+    def test_loop_iterations_respected(self):
+        code = generate_jit_seed(random.Random(0), loop_iterations=123)
+        self.assertIn("range(123)", code)
+
+    def test_num_uops_bounds(self):
+        # The header line records the selected uops; count them.
+        code = generate_jit_seed(random.Random(3), num_uops=(2, 2))
+        header = code.splitlines()[0]
+        self.assertTrue(header.startswith("# JIT seed: targeted uops "))
+
+
+class TestObjectGeneratorWiring(unittest.TestCase):
+    """Object placeholders are realized by lafleur's own evil-object generators."""
+
+    @unittest.skipUnless(HAS_OBJECTS, "lafleur.mutators.utils not importable")
+    def test_object_kinds_all_have_generators(self):
+        for kind in _OBJECT_KINDS:
+            with self.subTest(kind=kind):
+                self.assertIn(kind, jit_seeds._OBJECT_GENERATORS)
+
+    @unittest.skipUnless(HAS_OBJECTS, "lafleur.mutators.utils not importable")
+    def test_object_recipe_emits_a_class(self):
+        # _LOAD_ATTR's operand is always an object kind, so its setup defines a class.
+        setup, _body = generate_uop_targeted_pattern(["_LOAD_ATTR"], random.Random(0))
+        self.assertIn("class ", setup)
+
+    def test_degrades_without_objects(self):
+        # The unknown-recipe path and "any"/object fallback must still yield valid code.
+        setup, body = generate_uop_targeted_pattern(["_BINARY_OP_ADD_INT"], random.Random(0))
+        ast.parse(f"{setup}\n{body}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `lafleur/jit_seeds.py`: native, in-process generation of uop-targeted hot-loop JIT seeds — ports fusil's `UOP_RECIPES` (38 recipes) + a trimmed simple-value generator, and reuses lafleur's own evil-object generators (`mutators.utils.gen_*`).
- Wire it into `CorpusManager.generate_new_seed` so seeding no longer shells out to the classic fusil executable. This fixes the silent degradation to plain values (fusil's `lafleur.mutator` import had bit-rotted to a renamed module) and produces richer, deterministic seeds.
- Add `tests/test_jit_seeds.py` and a CHANGELOG entry.

Background analysis: fusil `doc/jit-seed-generation.md` (devdanzin/fusil#138).

## Test plan
- [x] `ruff format --check` + `ruff check` on changed files — clean
- [x] `tests/test_jit_seeds.py` + `tests/test_corpus_manager.py` — 70 passed (incl. the existing `generate_new_seed` timing test, unmodified)
- [x] `tests/orchestrator/` — 505 passed (they mock `generate_new_seed`; behavior unchanged)
- [x] Full suite — 2115 passed, 1 failed; the single failure (`test_analysis.py::TestCrashFingerprinter::test_to_dict_json_roundtrip`, a `CrashType` enum `str()` mismatch) is **pre-existing and unrelated** — it fails identically with this branch's changes stashed.

## Notes / follow-ups (out of scope here)
- The orchestrator still gates seeding on `fusil_path_is_valid`; a follow-up should relax that so native seeding is reachable without `--fusil-path` (and update `test_warns_when_corpus_empty_and_no_seeder` / `test_bootstraps_empty_corpus_with_seeder`).
- "Better seeds" follow-ups: port fusil's curated `BUG_PATTERNS` and a hot-loop-wrapped synthesize grammar as additional seed families.
- `_YIELD_VALUE` is excluded from the default uop pool (it would make the harness a never-run generator).

Closes #855

Generated with [Claude Code](https://claude.com/claude-code)