### PR TITLE
feat: bootstrap corpus natively without requiring --fusil-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ All notable changes to this project should be documented in this file.
 
 ### Enhanced
 
+- Native JIT seeding is now reachable without `--fusil-path`: `run_evolutionary_loop` no longer gates corpus bootstrapping on `fusil_path_is_valid` and no longer halts an empty corpus when no fusil executable is provided — it always bootstraps in-process via `generate_new_seed`. `--fusil-path` is now a deprecated, accepted-but-unused option, by @devdanzin.
 - Updated CLAUDE.md: renamed stale `coverage_parser.py` reference to `coverage.py`, added 6 missing modules (`analysis.py`, `health.py`, `learning.py`, `metadata.py`, `types.py`, `uop_names.py`) to the project structure, by @devdanzin.
 - Guarded `psutil.Process().memory_info()` call in telemetry (`artifacts.py`) with try/except to prevent crashes on edge-case process states, by @devdanzin.
 - Standardized CLI path arguments to `type=Path` in `orchestrator.py`, `jit_tuner.py`, `triage.py`, and `report.py`, removing redundant `Path()` wrapping at call sites, by @devdanzin.

--- a/lafleur/orchestrator.py
+++ b/lafleur/orchestrator.py
@@ -329,44 +329,22 @@ class LafleurOrchestrator:
         needed = self.min_corpus_files - current_corpus_size
 
         if needed > 0:
+            # Seed generation is native (in-process; see lafleur.jit_seeds), so it is
+            # always available -- no external fusil executable is required and there is
+            # no empty-corpus halt.
             print(
-                f"[*] Corpus size ({current_corpus_size}) is less than minimum ({self.min_corpus_files}). Need to generate {needed} more file(s)."
+                f"[*] Corpus size ({current_corpus_size}) is less than minimum "
+                f"({self.min_corpus_files}). Generating {needed} more seed file(s) natively..."
             )
-
-            if not self.corpus_manager.fusil_path_is_valid:
-                print("[!] WARNING: Cannot generate new seed files.", file=sys.stderr)
-                if self.fusil_path:
-                    print(
-                        f"    Reason: Provided --fusil-path '{self.fusil_path}' is not a valid executable file.",
-                        file=sys.stderr,
-                    )
-                else:
-                    print(
-                        "    Reason: The --fusil-path argument was not provided.", file=sys.stderr
-                    )
-
-                if current_corpus_size > 0:
-                    print(
-                        f"[*] Proceeding with the {current_corpus_size} existing file(s). To enforce the minimum, please provide a valid path.",
-                        file=sys.stderr,
-                    )
-                else:
-                    print(
-                        "[!!!] CRITICAL: The corpus is empty and no valid seeder is available. Halting.",
-                        file=sys.stderr,
-                    )
-                    sys.exit(1)  # Unrecoverable state
-            else:
-                # Seeder is available, generate the needed files
-                print("[*] Starting corpus generation phase...")
-                for _ in range(needed):
-                    self.corpus_manager.generate_new_seed(
-                        self.scoring_manager.analyze_run,
-                        self.scoring_manager._build_lineage_profile,
-                    )
-                print(
-                    f"[+] Corpus generation complete. New size: {len(self.coverage_manager.state['per_file_coverage'])}."
+            for _ in range(needed):
+                self.corpus_manager.generate_new_seed(
+                    self.scoring_manager.analyze_run,
+                    self.scoring_manager._build_lineage_profile,
                 )
+            print(
+                f"[+] Corpus generation complete. New size: "
+                f"{len(self.coverage_manager.state['per_file_coverage'])}."
+            )
 
         print("[+] Starting Deep Fuzzer Evolutionary Loop. Press Ctrl+C to stop.")
         try:
@@ -1039,7 +1017,8 @@ def main() -> None:
         "--fusil-path",
         type=Path,
         default=None,
-        help="The absolute path to the classic fusil executable (fusil-python-threaded).",
+        help="Deprecated and unused: seed generation is now native (see lafleur.jit_seeds). "
+        "Accepted for backward compatibility.",
     )
     parser.add_argument(
         "--min-corpus-files",

--- a/tests/orchestrator/test_integration.py
+++ b/tests/orchestrator/test_integration.py
@@ -345,15 +345,12 @@ class TestCorpusBootstrappingIntegration(unittest.TestCase):
         os.chdir(self.original_cwd)
         shutil.rmtree(self.test_dir)
 
-    def test_bootstraps_empty_corpus_with_seeder(self):
-        """Orchestrator bootstraps empty corpus using fusil seeder."""
+    def test_bootstraps_empty_corpus_natively(self):
+        """Orchestrator bootstraps an empty corpus via native seeding (no fusil needed)."""
         # Clear corpus and coverage state
         for f in Path("corpus").glob("*.py"):
             f.unlink()
         self.orchestrator.coverage_manager.state["per_file_coverage"] = {}
-
-        # Mark fusil path as valid
-        self.orchestrator.corpus_manager.fusil_path_is_valid = True
 
         iterations = 0
 
@@ -381,22 +378,23 @@ class TestCorpusBootstrappingIntegration(unittest.TestCase):
             # Verify generate_new_seed was called 5 times (min_corpus_files)
             self.assertEqual(mock_generate.call_count, 5)
 
-    def test_warns_when_corpus_empty_and_no_seeder(self):
-        """Orchestrator warns and exits when corpus empty and no seeder available."""
-        # Ensure corpus is empty
+    def test_bootstrap_does_not_halt_without_fusil(self):
+        """Empty corpus + no fusil path bootstraps natively instead of halting."""
+        # Ensure corpus is empty; the fixture's orchestrator has fusil_path=None.
         for f in Path("corpus").glob("*.py"):
             f.unlink()
+        self.orchestrator.coverage_manager.state["per_file_coverage"] = {}
 
-        with patch("sys.stdout"):
+        with patch.object(
+            self.orchestrator.corpus_manager, "generate_new_seed", return_value=None
+        ) as mock_generate:
             with patch("sys.exit") as mock_exit:
-                # Set select_parent to return None to trigger empty corpus path
-                self.orchestrator.corpus_manager.select_parent = MagicMock(return_value=None)
-                try:
-                    self.orchestrator.run_evolutionary_loop()
-                except SystemExit:
-                    pass
+                # The mocked seeder adds no files, so the loop returns once the corpus
+                # is found empty (select_parent -> None) -- without any sys.exit halt.
+                self.orchestrator.run_evolutionary_loop()
 
-        mock_exit.assert_called_once()
+        self.assertEqual(mock_generate.call_count, 5)
+        mock_exit.assert_not_called()
 
 
 class TestMutationCycleIntegration(unittest.TestCase):

--- a/tests/orchestrator/test_main_loop.py
+++ b/tests/orchestrator/test_main_loop.py
@@ -230,8 +230,8 @@ class TestRunEvolutionaryLoop(unittest.TestCase):
                         self.orchestrator.corpus_manager.generate_new_seed.call_count, 3
                     )
 
-    def test_warns_when_fusil_path_invalid(self):
-        """Test that warning is printed when fusil path is invalid."""
+    def test_bootstraps_natively_when_fusil_path_invalid(self):
+        """An invalid/absent --fusil-path no longer blocks seeding: bootstrap is native."""
         self.orchestrator.coverage_manager.state = {"per_file_coverage": {}}
         self.orchestrator.corpus_manager.fusil_path_is_valid = False
         self.orchestrator.fusil_path = "/invalid/path/to/fusil"
@@ -241,13 +241,16 @@ class TestRunEvolutionaryLoop(unittest.TestCase):
             with patch("sys.exit") as mock_exit:
                 self.orchestrator.run_evolutionary_loop()
 
-                stderr_output = mock_stderr.getvalue()
-                self.assertIn("WARNING: Cannot generate new seed files", stderr_output)
-                self.assertIn("/invalid/path/to/fusil", stderr_output)
-                mock_exit.assert_called_once_with(1)
+        # Native bootstrap runs regardless of the fusil path; no warning, no halt.
+        self.assertEqual(
+            self.orchestrator.corpus_manager.generate_new_seed.call_count,
+            self.orchestrator.min_corpus_files,
+        )
+        mock_exit.assert_not_called()
+        self.assertNotIn("Cannot generate new seed files", mock_stderr.getvalue())
 
-    def test_exits_when_corpus_empty_and_no_seeder(self):
-        """Test that sys.exit is called when corpus is empty with no seeder."""
+    def test_no_halt_when_corpus_empty_and_no_fusil(self):
+        """An empty corpus with no fusil path bootstraps natively instead of halting."""
         self.orchestrator.coverage_manager.state = {"per_file_coverage": {}}
         self.orchestrator.corpus_manager.fusil_path_is_valid = False
         self.orchestrator.corpus_manager.select_parent = MagicMock(return_value=None)
@@ -256,9 +259,12 @@ class TestRunEvolutionaryLoop(unittest.TestCase):
             with patch("sys.exit") as mock_exit:
                 self.orchestrator.run_evolutionary_loop()
 
-                stderr_output = mock_stderr.getvalue()
-                self.assertIn("CRITICAL: The corpus is empty", stderr_output)
-                mock_exit.assert_called_once_with(1)
+        mock_exit.assert_not_called()
+        self.assertNotIn("CRITICAL: The corpus is empty", mock_stderr.getvalue())
+        self.assertEqual(
+            self.orchestrator.corpus_manager.generate_new_seed.call_count,
+            self.orchestrator.min_corpus_files,
+        )
 
     # def test_proceeds_with_existing_files_when_seeder_unavailable(self):
     #     """Test that loop proceeds when corpus has files but below minimum."""


### PR DESCRIPTION
## Summary
- `run_evolutionary_loop` no longer gates corpus bootstrapping on `corpus_manager.fusil_path_is_valid`, and no longer halts (`sys.exit(1)`) on an empty corpus when no fusil executable is provided. Since `generate_new_seed` is now native (#856), seeding is always available — the orchestrator always bootstraps to the configured minimum.
- `--fusil-path` becomes a deprecated, accepted-but-unused option.
- Updates the tests that pinned the old warn/halt behavior to assert native bootstrapping with no halt.

Completes the fusil-independence of seeding (follow-up to #856 / #855).

## Test plan
- [x] `ruff format` + `ruff check` on changed files — clean
- [x] `tests/orchestrator/` — 165 passed
- [x] Full suite — 2115 passed, 1 failed; the single failure (`test_analysis.py::TestCrashFingerprinter::test_to_dict_json_roundtrip`, a `CrashType` enum `str()` mismatch) is **pre-existing and unrelated** (it fails identically on `main`).

## Notes
- `--fusil-path` is kept (no-op) rather than removed, to avoid breaking existing invocations.
- `CorpusManager.fusil_path_is_valid` is retained (still reflects path validity; `test_invalid_fusil_path`/`test_empty_fusil_path` unchanged) — it's just no longer used for gating.

Closes #857

Generated with [Claude Code](https://claude.com/claude-code)