### PR TITLE
test: fix test_analysis roundtrip assertion (compare enum value, not str)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- `test_analysis` JSON round-trip test now compares the serialized `crash_type` against `CrashType.C_ASSERTION.value` rather than `str(CrashType.C_ASSERTION)` (`to_dict()` serializes the `(str, Enum)` as its value, so the assertion was comparing the wrong side and failing on Python 3.11+), by @devdanzin.
 - `triage.py` timestamp parsing now produces UTC-aware datetimes instead of naive ones, consistent with the rest of the codebase, by @devdanzin.
 - Added module docstring to `analysis.py` describing crash fingerprinting and classification, by @devdanzin.
 - Added missing `REPORTED` and `FIXED` choices to `lafleur-triage list --status`, matching the full set of valid triage statuses, by @devdanzin.

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -241,7 +241,8 @@ SUMMARY: AddressSanitizer: stack-buffer-overflow
         serialized = json.dumps(d)
         loaded = json.loads(serialized)
         self.assertEqual(loaded["type"], "ASSERT")
-        self.assertEqual(loaded["crash_type"], str(CrashType.C_ASSERTION))
+        # to_dict() (asdict + json) serializes the (str, Enum) as its value, not str(enum).
+        self.assertEqual(loaded["crash_type"], CrashType.C_ASSERTION.value)
         self.assertEqual(loaded["returncode"], -6)
         self.assertEqual(loaded["signal_name"], "SIGABRT")
         self.assertEqual(loaded["fingerprint"], "ASSERT:file.c:10:cond")


### PR DESCRIPTION
## Summary
`test_to_dict_json_roundtrip` compared the serialized `crash_type` against `str(CrashType.C_ASSERTION)` (`"CrashType.C_ASSERTION"` on Python 3.11+), but `to_dict()` (`asdict` + `json.dumps`) serializes the `(str, Enum)` as its **value** (`"C_ASSERTION"`). Fixed to compare against `CrashType.C_ASSERTION.value`. Test-only, no behavior change.

## Test plan
- [x] `ruff format` + `ruff check` — clean
- [x] `test_to_dict_json_roundtrip` — passes
- [x] Full suite — **2129 passed, 0 failed** (on the rebuilt `--with-pydebug` + threshold-patched JIT build; the 21 JIT-trace failures were a release-build artifact, now resolved)

Closes #863

Generated with [Claude Code](https://claude.com/claude-code)