### PR TITLE
fix: harden native JIT seeding (coverage markers, bounded synth, reject killed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Native JIT seeds now emit a `[fN]` harness marker so coverage is recorded: `parse_log_for_edge_coverage` ignores every uop until a marker sets the current harness id, so without it generated seeds (and all their children) showed 0 edges/UOPs and were judged uninteresting, by @devdanzin.
+- The `synthesize` seed family no longer emits `Mult`/`LShift`, which under feedback (`x *= x`, `x <<= x`) grew ints to multiple GB and made seeds extremely slow; `Add`/`Sub`/bitwise keep values bounded, by @devdanzin.
+- `analyze_run` no longer adds runs killed by SIGKILL/SIGTERM (`-9`/`-15`, i.e. timeout/OOM artifacts) to the corpus — it returns `NoChangeResult` instead of parsing the truncated log and keeping the seed, by @devdanzin.
 - `test_analysis` JSON round-trip test now compares the serialized `crash_type` against `CrashType.C_ASSERTION.value` rather than `str(CrashType.C_ASSERTION)` (`to_dict()` serializes the `(str, Enum)` as its value, so the assertion was comparing the wrong side and failing on Python 3.11+), by @devdanzin.
 - `triage.py` timestamp parsing now produces UTC-aware datetimes instead of naive ones, consistent with the rest of the codebase, by @devdanzin.
 - Added module docstring to `analysis.py` describing crash fingerprinting and classification, by @devdanzin.

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -465,7 +465,7 @@ class CorpusManager:
             f"{BOILERPLATE_END_MARKER}\n"
             f"{core_code}\n"
         )
-        print(f"[*] Generating new seed natively (uop-targeted, seed={seed_int})")
+        print(f"[*] Generating new seed natively (seed={seed_int})")
         try:
             tmp_source.write_text(full_source, encoding="utf-8")
         except OSError as e:

--- a/lafleur/jit_seeds.py
+++ b/lafleur/jit_seeds.py
@@ -513,6 +513,18 @@ def generate_uop_targeted_pattern(uop_names: list[str], rng: random.Random) -> t
     return setup_code, body_code
 
 
+def _harness_marker(label: str) -> str:
+    """A ``[fN]`` marker line so lafleur's coverage parser records the seed's coverage.
+
+    ``parse_log_for_edge_coverage`` ignores every uop until a ``[fN]`` marker
+    (``HARNESS_MARKER_REGEX``) sets the current harness id, so each seed must print
+    one (to stderr, which lafleur merges into the run log) before its hot loop runs.
+    The label is also a human-readable note of what the seed targets. ``sys`` is
+    provided by the prepended boilerplate at run time.
+    """
+    return f'print("[f1] JIT seed: {label}", file=sys.stderr)\n'
+
+
 def generate_uop_seed(
     rng: random.Random,
     *,
@@ -528,6 +540,7 @@ def generate_uop_seed(
     loop_var = f"_loop_{prefix}"
     return (
         f"# JIT seed: targeted uops {uops}\n"
+        f"{_harness_marker('uop')}"
         f"{setup_code}\n\n"
         f"def {harness}():\n"
         f"{indent(body_code, '    ')}\n\n"
@@ -618,6 +631,7 @@ def generate_bug_pattern_seed(
     harness = f"jit_harness_{prefix}"
     return (
         f"# JIT seed: bug pattern {name!r}\n"
+        f"{_harness_marker('bug_pattern ' + name)}"
         f"def {harness}():\n"
         f"    try:\n"
         f"{indent(inner, '        ')}\n"
@@ -637,7 +651,13 @@ def generate_bug_pattern_seed(
 # variables + the loop variable, so runs stay clean (the uop/bug-pattern families
 # already cover type chaos); the JIT value here is structural / data-flow variety.
 
-_SYNTH_BINOPS = (ast.Add, ast.Sub, ast.Mult, ast.BitAnd, ast.BitOr, ast.BitXor, ast.LShift)
+# NOTE: deliberately excludes Mult and LShift. With feedback (e.g. `x *= x` or
+# `x <<= x`, which the grammar can emit since an assignment/aug-assignment target
+# may also be an operand) those grow ints exponentially in the hot loop -> multi-GB
+# memory and very slow runs. Add/Sub/bitwise keep values bounded (<= ~2**300, a few
+# bytes) even under feedback. The uop and bug-pattern families cover mult/shift uops
+# with fixed (non-feedback) operands.
+_SYNTH_BINOPS = (ast.Add, ast.Sub, ast.BitAnd, ast.BitOr, ast.BitXor)
 _SYNTH_CMPOPS = (ast.Lt, ast.Gt, ast.Eq, ast.NotEq, ast.LtE, ast.GtE)
 _SYNTH_CONSTS = (0, 1, 2, 3, 7, 255, -1, 1000)
 _SYNTH_MAX_DEPTH = 3
@@ -781,6 +801,7 @@ def generate_synthesize_seed(
     harness = f"synth_harness_{prefix}"
     return (
         f"# JIT seed: synthesized pattern\n"
+        f"{_harness_marker('synthesize')}"
         f"def {harness}():\n"
         f"{indent(code, '    ')}\n\n"
         f"{harness}()\n"

--- a/lafleur/scoring.py
+++ b/lafleur/scoring.py
@@ -656,6 +656,13 @@ class ScoringManager:
                 fingerprint=self.artifact_manager.last_crash_fingerprint,
             )
 
+        # A run killed by SIGKILL/SIGTERM (timeout / OOM / external kill) is a resource
+        # artifact, not a valid corpus member: its log is truncated and it should never
+        # be added. check_for_crash already declined to treat -9/-15 as a crash; make
+        # sure we also don't add it as new coverage.
+        if exec_result.returncode in (-9, -15):
+            return NoChangeResult(status="NO_CHANGE")
+
         child_coverage = parse_log_for_edge_coverage(exec_result.log_path, self.coverage_manager)
 
         coverage_info = self.find_new_coverage(child_coverage, parent_lineage_profile, parent_id)

--- a/tests/orchestrator/test_scoring.py
+++ b/tests/orchestrator/test_scoring.py
@@ -386,6 +386,46 @@ class TestAnalyzeRunMutationInfo(unittest.TestCase):
         self.assertNotIn("jit_stats", caller_mutation_info)
 
 
+class TestAnalyzeRunKilledRun(unittest.TestCase):
+    """analyze_run rejects runs killed by SIGKILL/SIGTERM (timeout/OOM artifacts)."""
+
+    def setUp(self):
+        self.coverage_manager = MagicMock()
+        self.coverage_manager.state = {"per_file_coverage": {}}
+        self.artifact_manager = MagicMock()
+        self.artifact_manager.check_for_crash.return_value = False
+        self.corpus_manager = MagicMock()
+        self.corpus_manager.known_hashes = set()
+        self.scoring_manager = ScoringManager(
+            coverage_manager=self.coverage_manager,
+            artifact_manager=self.artifact_manager,
+            corpus_manager=self.corpus_manager,
+            get_core_code_func=lambda code: code,
+            run_stats={"divergences_found": 0},
+        )
+
+    @patch("lafleur.scoring.parse_log_for_edge_coverage")
+    def test_killed_run_is_not_added(self, mock_parse_coverage):
+        for rc in (-9, -15):  # SIGKILL, SIGTERM
+            with self.subTest(returncode=rc):
+                exec_result = MagicMock()
+                exec_result.is_divergence = False
+                exec_result.log_path.read_text.return_value = "truncated log"
+                exec_result.returncode = rc
+                result = self.scoring_manager.analyze_run(
+                    exec_result=exec_result,
+                    parent_lineage_profile={},
+                    parent_id=None,
+                    mutation_info={},
+                    mutation_seed=0,
+                    parent_file_size=0,
+                    parent_lineage_edge_count=0,
+                )
+                self.assertEqual(result.status, "NO_CHANGE")
+        # Rejected before any coverage parsing of the truncated log.
+        mock_parse_coverage.assert_not_called()
+
+
 class TestPrepareNewCoverageResult(unittest.TestCase):
     """Test the extracted _prepare_new_coverage_result method."""
 

--- a/tests/test_jit_seeds.py
+++ b/tests/test_jit_seeds.py
@@ -202,6 +202,14 @@ class TestSynthesizeSeeds(unittest.TestCase):
         b = generate_synthesize_seed(random.Random(99))
         self.assertEqual(a, b)
 
+    def test_no_unbounded_arithmetic(self):
+        # Mult/LShift with feedback (x*=x, x<<=x) blow ints up to GBs in the hot loop;
+        # the grammar must never emit them.
+        for s in range(60):
+            tree = ast.parse(generate_synthesize_seed(random.Random(s)))
+            for node in ast.walk(tree):
+                self.assertNotIsInstance(node, (ast.Mult, ast.LShift))
+
 
 class TestFamilyDispatch(unittest.TestCase):
     """generate_jit_seed dispatches across families and always yields valid Python."""
@@ -223,6 +231,14 @@ class TestFamilyDispatch(unittest.TestCase):
             for s in range(8):
                 with self.subTest(family=family, seed=s):
                     ast.parse(generate_jit_seed(random.Random(s), family=family))
+
+    def test_all_families_emit_harness_marker(self):
+        # Without a [fN] marker, lafleur's coverage parser records 0 uops/edges
+        # (parse_log_for_edge_coverage skips everything until current_harness_id is set).
+        for family in ("uop", "bug_pattern", "synthesize"):
+            for s in range(10):
+                with self.subTest(family=family, seed=s):
+                    self.assertIn("[f1]", generate_jit_seed(random.Random(s), family=family))
 
     def test_default_dispatch_covers_all_families(self):
         seen = set()


### PR DESCRIPTION
## Summary
Three regressions from the new multi-family native seeding, found in a smoke run:

1. **0 edges/UOPs for every seed** (children all "uninteresting"). Native seeds emitted no `[fN]` harness marker, and `parse_log_for_edge_coverage` skips every uop until a marker sets `current_harness_id` (`coverage.py:205`). Each seed now prints a `[f1] JIT seed: <label>` marker before its hot loop. (The old fusil seeds printed `[f1] STRATEGY: …`; the native port dropped it.) Confirmed: a marker turns a 0-coverage run into 43 uops / 72 edges.
2. **GB-memory / very slow seeds.** The `synthesize` grammar could emit feedback growth (`x *= x`, `x <<= x`) in the hot loop → exponential int blowup. Dropped `Mult`/`LShift`; `Add`/`Sub`/bitwise keep values bounded (≤ ~2³⁰⁰). uop/bug-pattern families use fixed operands and were unaffected.
3. **Killed seeds kept in the corpus.** `analyze_run` now returns `NoChangeResult` for returncode `-9`/`-15` (SIGKILL/SIGTERM timeout/OOM artifacts) instead of parsing the truncated log and adding it. Covers seeds and mutation children.

Also fixes the stale `(uop-targeted, …)` log line (the family is random now).

## Test plan
- [x] `ruff format` + `ruff check` — clean
- [x] New tests: per-family `[fN]` marker presence, no `Mult`/`LShift` in synth output, `analyze_run` rejecting `-9`/`-15`
- [x] E2E: each family now yields coverage (uop 43u/72e, bug_pattern 23u/58e, synthesize 31u/85e) on the debug+patched build
- [x] Full suite — **2132 passed, 0 failed**

## Note on time-tracking
lafleur already measures `execution_time_ms` and the scheduler penalizes slow files; the perceived "no time tracking" was these pathological seeds (fix #2) plus killed seeds being kept (fix #3). The hard `execution_timeout` still bounds per-run time.

Closes #865

Generated with [Claude Code](https://claude.com/claude-code)