### PR TITLE
fix: give mutated children a boilerplate that imports sys (#867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to this project should be documented in this file.
 
 ### Fixed
 
+- Mutated children are now assembled with a valid boilerplate that imports `sys` (plus `gc`/`collect`), so they no longer crash on the `[fN]` marker (`print(..., file=sys.stderr)`) before the harness runs. Corpus files are stored core-only, so `_extract_and_cache_boilerplate` cached an empty boilerplate and every child raised `NameError: name 'sys' is not defined` on its first line — producing 0 attributed coverage and a 0.0 score for *every* mutated child. `get_boilerplate()` now falls back to a shared `DEFAULT_BOILERPLATE`, and children also emit the `# FUSIL_BOILERPLATE_END` marker so an interesting child's core extracts cleanly, by @devdanzin.
 - Native JIT seeds now emit a `[fN]` harness marker so coverage is recorded: `parse_log_for_edge_coverage` ignores every uop until a marker sets the current harness id, so without it generated seeds (and all their children) showed 0 edges/UOPs and were judged uninteresting, by @devdanzin.
 - The `synthesize` seed family no longer emits `Mult`/`LShift`, which under feedback (`x *= x`, `x <<= x`) grew ints to multiple GB and made seeds extremely slow; `Add`/`Sub`/bitwise keep values bounded, by @devdanzin.
 - `analyze_run` no longer adds runs killed by SIGKILL/SIGTERM (`-9`/`-15`, i.e. timeout/OOM artifacts) to the corpus — it returns `NoChangeResult` instead of parsing the truncated log and keeping the seed, by @devdanzin.

--- a/lafleur/corpus_manager.py
+++ b/lafleur/corpus_manager.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from lafleur.coverage import CoverageManager, save_coverage_state
 from lafleur.health import FILE_SIZE_WARNING_THRESHOLD
 from lafleur.jit_seeds import generate_jit_seed
-from lafleur.mutation_controller import BOILERPLATE_END_MARKER, BOILERPLATE_START_MARKER
+from lafleur.mutation_controller import BOILERPLATE_END_MARKER, DEFAULT_BOILERPLATE
 from lafleur.types import (
     CorpusFileMetadata,
     HarnessCoverage,
@@ -455,9 +455,10 @@ class CorpusManager:
 
         boilerplate = self.get_boilerplate().rstrip()
         if not boilerplate:
-            # Minimal self-contained boilerplate for a cold start (empty corpus): the
-            # native core only needs `sys` and `fuzzer_rng`.
-            boilerplate = f"{BOILERPLATE_START_MARKER}\nimport sys"
+            # Self-contained boilerplate for a cold start (empty corpus). The native core
+            # needs `sys` (the [fN] marker + evil objects), `gc`, and `collect` (some bug
+            # patterns call `collect()`); `fuzzer_rng` is added just below. See #867.
+            boilerplate = DEFAULT_BOILERPLATE
         full_source = (
             f"{boilerplate}\n"
             f"import random\n"

--- a/lafleur/mutation_controller.py
+++ b/lafleur/mutation_controller.py
@@ -43,6 +43,15 @@ RANDOM = random.Random()
 BOILERPLATE_START_MARKER = "# FUSIL_BOILERPLATE_START"
 BOILERPLATE_END_MARKER = "# FUSIL_BOILERPLATE_END"
 
+# Boilerplate used when a parent file carries no FUSIL_BOILERPLATE markers — which is
+# the normal case, because corpus files are stored core-only (add_new_file strips the
+# boilerplate). The native seed cores reference ``sys`` (the [fN] coverage marker prints
+# to ``sys.stderr`` and the evil objects use ``sys``), ``gc``, and ``collect`` (some bug
+# patterns call ``collect()``). Without these imports the core raises ``NameError`` on its
+# very first line — before the harness/hot loop run — which silently zeroes the child's JIT
+# coverage and makes every mutated child score 0.0 (see issue #867).
+DEFAULT_BOILERPLATE = f"{BOILERPLATE_START_MARKER}\nimport sys\nimport gc\nfrom gc import collect"
+
 MutationStrategy = Callable[..., tuple[ast.AST, MutationInfo]]
 
 
@@ -90,8 +99,14 @@ class MutationController:
         self.health_monitor: HealthMonitor | None = None
 
     def get_boilerplate(self) -> str:
-        """Return the cached boilerplate code."""
-        return self.boilerplate_code or ""
+        """Return the cached boilerplate code, or a safe default.
+
+        Falls back to :data:`DEFAULT_BOILERPLATE` when nothing has been cached (or the
+        cached value is empty), so assembled scripts always import ``sys``/``gc``/
+        ``collect``. Without this, children built from core-only corpus parents lack
+        ``import sys`` and crash on the ``[fN]`` marker before warming the JIT (#867).
+        """
+        return self.boilerplate_code or DEFAULT_BOILERPLATE
 
     def _extract_and_cache_boilerplate(self, source_code: str) -> None:
         """Parse a source file to find, extract, and cache the boilerplate code."""
@@ -102,12 +117,14 @@ class MutationController:
             self.boilerplate_code = source_code[start_index:end_index]
             print("[+] Boilerplate code extracted and cached.")
         except ValueError:
+            # Corpus files are stored core-only, so this is the normal path. Fall back to
+            # a valid boilerplate (imports sys/gc/collect) rather than an empty string —
+            # otherwise children crash on the [fN] marker before the harness runs (#867).
             print(
-                "[!] Warning: Could not find boilerplate markers in the initial seed file.",
+                "[!] No boilerplate markers found (core-only file); using default boilerplate.",
                 file=sys.stderr,
             )
-            # Fallback to using an empty boilerplate
-            self.boilerplate_code = ""
+            self.boilerplate_code = DEFAULT_BOILERPLATE
 
     def _get_core_code(self, source_code: str) -> str:
         """Strip the boilerplate from a source file to get the dynamic core."""
@@ -516,7 +533,15 @@ class MutationController:
 
             boilerplate = self.get_boilerplate()
             mutated_core_code = ast.unparse(child_core_tree)
-            return f"{boilerplate}\n{gc_tuning_code}{rng_setup_code}\n{mutated_core_code}"
+            # Close the boilerplate region with the END marker (mirroring how seeds are
+            # assembled) so that an interesting child's core extracts cleanly via
+            # _get_core_code instead of carrying the boilerplate + RNG setup into the corpus.
+            return (
+                f"{boilerplate}\n"
+                f"{gc_tuning_code}{rng_setup_code}\n"
+                f"{BOILERPLATE_END_MARKER}\n"
+                f"{mutated_core_code}"
+            )
         except RecursionError:
             print(
                 "  [!] Warning: Skipping mutation due to RecursionError during ast.unparse.",

--- a/tests/orchestrator/test_mutation_strategies.py
+++ b/tests/orchestrator/test_mutation_strategies.py
@@ -12,7 +12,11 @@ from collections import defaultdict
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
-from lafleur.mutation_controller import MutationController
+from lafleur.mutation_controller import (
+    BOILERPLATE_END_MARKER,
+    DEFAULT_BOILERPLATE,
+    MutationController,
+)
 from lafleur.types import DivergenceResult
 
 
@@ -1124,6 +1128,89 @@ class TestForcedStrategy(unittest.TestCase):
             self.controller.apply_mutation_strategy(self.dummy_tree, seed=42)
 
         mock_rng.choices.assert_called_once()
+
+
+class TestBoilerplateHandling(unittest.TestCase):
+    """Boilerplate fallback so children always import sys/gc/collect (issue #867)."""
+
+    def _bare_controller(self) -> MutationController:
+        controller = MutationController.__new__(MutationController)
+        controller.boilerplate_code = None
+        controller.differential_testing = False
+        controller.health_monitor = None
+        return controller
+
+    def test_default_boilerplate_imports_required_names(self):
+        # The native seed cores reference all three; missing any aborts the core
+        # before the harness runs, zeroing coverage.
+        self.assertIn("import sys", DEFAULT_BOILERPLATE)
+        self.assertIn("import gc", DEFAULT_BOILERPLATE)
+        self.assertIn("from gc import collect", DEFAULT_BOILERPLATE)
+
+    def test_get_boilerplate_falls_back_when_unset_or_empty(self):
+        controller = self._bare_controller()
+        # None -> default
+        self.assertIn("import sys", controller.get_boilerplate())
+        # "" -> default (the regression: empty boilerplate omitted import sys)
+        controller.boilerplate_code = ""
+        self.assertIn("import sys", controller.get_boilerplate())
+        # A real cached boilerplate is returned verbatim.
+        controller.boilerplate_code = "# FUSIL_BOILERPLATE_START\nimport sys\nimport os"
+        self.assertEqual(
+            controller.get_boilerplate(), "# FUSIL_BOILERPLATE_START\nimport sys\nimport os"
+        )
+
+    def test_extract_from_core_only_file_caches_valid_default(self):
+        # Corpus files are core-only (no markers) -> must fall back to a boilerplate
+        # that imports sys, not "".
+        controller = self._bare_controller()
+        with patch("sys.stderr", new=io.StringIO()):
+            controller._extract_and_cache_boilerplate("x = 1\nprint('hi')\n")
+        self.assertIn("import sys", controller.boilerplate_code)
+        self.assertIn("from gc import collect", controller.boilerplate_code)
+
+    def test_child_assembled_from_core_only_parent_imports_sys(self):
+        # End-to-end regression guard: a child built from a core-only parent must be
+        # runnable — i.e. import sys before the [fN] marker — and round-trip cleanly.
+        controller = self._bare_controller()
+        # Simulate a core-only corpus parent: extraction fails -> default cached.
+        with patch("sys.stderr", new=io.StringIO()):
+            controller._extract_and_cache_boilerplate("# core only, no markers\n")
+
+        core_src = dedent(
+            """
+            print('[f1] JIT seed: uop', file=sys.stderr)
+            x = 1
+
+            def uop_harness_f1():
+                x == x
+
+            for _loop_f1 in range(300):
+                try:
+                    uop_harness_f1()
+                except Exception:
+                    break
+            """
+        )
+        parent_core_tree = ast.parse(core_src)
+        mutated_harness = next(n for n in parent_core_tree.body if isinstance(n, ast.FunctionDef))
+
+        with patch("lafleur.mutation_controller.RANDOM") as mock_rng:
+            mock_rng.random.return_value = 1.0  # skip GC-pressure injection
+            child = controller.prepare_child_script(parent_core_tree, mutated_harness, 42)
+
+        self.assertIsNotNone(child)
+        assert child is not None
+        # Must import sys before the marker, and parse as valid Python.
+        self.assertIn("import sys", child)
+        self.assertLess(child.index("import sys"), child.index("[f1]"))
+        ast.parse(child)
+        # The END marker lets the core be re-extracted cleanly (no boilerplate in corpus).
+        self.assertIn(BOILERPLATE_END_MARKER, child)
+        core = controller._get_core_code(child)
+        self.assertIn("[f1]", core)
+        self.assertIn("def uop_harness_f1", core)
+        self.assertNotIn("import sys", core)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Mutated children were assembled with an **empty boilerplate** (corpus files are core-only, so `_extract_and_cache_boilerplate` cached `""`), leaving out `import sys`. The first core statement — the `[fN]` marker `print(..., file=sys.stderr)` — raised `NameError: name 'sys' is not defined` before the harness/hot loop ran, so **every mutated child got 0 coverage and scored 0.0**. Seeds were unaffected (they had their own fallback).
- Introduce a shared `DEFAULT_BOILERPLATE` (imports `sys`, `gc`, `collect` — all referenced by the native seed cores); `get_boilerplate()` and `_extract_and_cache_boilerplate()` fall back to it, and `generate_new_seed()` uses it (its old fallback omitted `collect`).
- Children now also emit the `# FUSIL_BOILERPLATE_END` marker so an interesting child's core extracts cleanly instead of carrying boilerplate into the corpus.

## Test plan
- [x] New `TestBoilerplateHandling` covers the fallback, the core-only extraction path, and an end-to-end child assembly (imports sys before the marker, parses, round-trips its core).
- [x] `ruff format` + `ruff check` clean on changed files.
- [x] Full suite: `2136 passed, 462 subtests passed`.
- [x] Bounded JIT run (12 sessions) now finds **16 interesting children** and **229 NEW RELATIVE** coverage discoveries (both were **0** before the fix).

Closes #867

Generated with [Claude Code](https://claude.com/claude-code)